### PR TITLE
feat(wo): Work Orders MCP server (RFC-0042) + OS Assistant RFC-0043

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,10 @@ web_modules/
 .env.*
 !.env.example
 
+# MCP local config may hold a DATABASE_URL with credentials — keep it local.
+.mcp.json
+!.mcp.json.example
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,13 @@
+{
+  "//": "RFC-0042 Work Orders MCP. Copy to .mcp.json (gitignored) and fill DATABASE_URL + GCDR_TENANT_ID. NEVER commit real credentials. Prefer a READ-ONLY role / read replica.",
+  "mcpServers": {
+    "gcdr-wo": {
+      "command": "npx",
+      "args": ["tsx", "src/mcp/server.ts"],
+      "env": {
+        "DATABASE_URL": "postgresql://<readonly_user>:<password>@<host>:5432/<db>",
+        "GCDR_TENANT_ID": "<tenant-uuid>"
+      }
+    }
+  }
+}

--- a/docs/RFC-0042-Work-Orders-MCP-Server.md
+++ b/docs/RFC-0042-Work-Orders-MCP-Server.md
@@ -160,15 +160,70 @@ the `summary` to help the LLM retry.
 
 ## 8. Rollout
 
-1. **Phase 1:** `context.ts` (tenant/customer scope + read-only repos) + the
-   `customers`/`work_orders` tools + stdio server + `.mcp.json`. Validate with a
-   local LLM client.
-2. **Phase 2:** `devices`, `maintenance`, `analytics` tools (reuse the
-   Desempenho aggregations so MCP numbers equal the UI).
-3. **Phase 3:** packaging/ops — read-replica wiring, a thin auth wrapper so a
-   `gcdr_cust_*` key auto-scopes the customer, and docs for consumers.
+1. **Phase 1 — DONE.** `context.ts` (tenant scope + read-only repos), the
+   `customers` + `work_orders` tools (`list_customers`, `find_customer`,
+   `list_work_orders`, `get_work_order`, `get_transitions`), stdio server and
+   `.mcp.json`.
+2. **Phase 2 — DONE.** `devices`, `maintenance` and `analytics` tools
+   (`get_devices`, `get_device_details`, `get_maintenance`, `get_progress`,
+   `get_average_time`, `get_technician_performance`, `get_activity_log`,
+   `get_daily_summary`). Analytics query the WO tables directly and reuse the
+   Desempenho gap-based time model so numbers equal the UI.
+3. **Phase 3 — production hardening (not new tools).** Three things, only needed
+   to expose this in production / to third parties:
+   1. **DB-level read-only.** Run the server with a SELECT-only Postgres role
+      (and/or a read replica). The tools are already read-only in code; this is
+      the safety net at the database level.
+   2. **Auto-scope by API key.** Today a server is pinned to a *tenant* and sees
+      *all* its customers. Phase 3 resolves an optional `gcdr_cust_*` key to its
+      customer and restricts every tool to it — so a customer can be given an
+      MCP without seeing other customers' OS. (This is the only code part:
+      resolve the key → `allowedCustomerIds` in `context.ts` and filter in the
+      tools.)
+   3. **Ops/docs.** Running the server inside the network that reaches the prod
+      Postgres (the prod host is internal), `.mcp.json` config and a consumer
+      guide for the tools.
 
-## 9. Out of scope
+   For **local/internal** use with a trusted single tenant, Phase 3 is **not**
+   required — Phases 1–2 are fully functional.
+
+## 9. Migrations, seeds & environment
+
+- **No migrations and no seeds are required by the MCP itself** — it only
+  *reads* existing tables (`work_orders*`, `work_orders_events`,
+  `work_orders_devices`, `work_orders_lifecycle_rules`, `customers`, `users`,
+  `devices`). The RFC-0041 migrations (`0040`, `0041`) and the demo seeds
+  (`27`/`28`/`29`) are independent; they just provide data to query.
+- **Environment** (set in `.mcp.json` → `env`, never committed):
+  - `DATABASE_URL` — points at the GCDR database. **Prod: use a read-only role
+    / read replica**, on a host the server can reach (the prod DB host is
+    internal, so run the MCP from inside that network).
+  - `GCDR_TENANT_ID` — pins the tenant (required).
+  - `GCDR_MCP_API_KEY` *(Phase 3)* — optional customer-scoping key.
+- No changes to the API's own `.env` are needed; the MCP is a separate process.
+
+## 10. How to test
+
+Run a JSON-RPC handshake over stdio and call a tool (no LLM client needed):
+
+```bash
+# from gcdr.git, with the local DB up (docker container gcdr-db-local on :5544)
+{
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}'
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+  printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_progress","arguments":{}}}'
+  sleep 5
+} | DATABASE_URL="postgresql://postgres:postgres@localhost:5544/db_gcdr" \
+    GCDR_TENANT_ID="11111111-1111-1111-1111-111111111111" \
+    npx tsx src/mcp/server.ts
+```
+
+A real MCP client (Claude Desktop / Claude Code) just needs the `.mcp.json`
+above; it spawns `npx tsx src/mcp/server.ts` and lists the 13 tools.
+Prerequisite: `npm install` (pulls `@modelcontextprotocol/sdk`).
+
+## 11. Out of scope
 
 - **Write tools** (creating WOs / appending events) — this server is read-only.
   A future RFC could add a guarded, audited write surface.

--- a/docs/RFC-0043-OS-Assistant-UI-Integration.md
+++ b/docs/RFC-0043-OS-Assistant-UI-Integration.md
@@ -1,0 +1,122 @@
+# RFC-0043 — OS Assistant (bringing the WO MCP into the GCDR UI)
+
+- **Status:** Draft
+- **Date:** 2026-06-15
+- **Domain:** Work Orders (`wo` / OS)
+- **Depends on:** [RFC-0042 — Work Orders MCP Server](./RFC-0042-Work-Orders-MCP-Server.md), [RFC-0041 — Rules Engine](./RFC-0041-Work-Order-Rules-Engine.md)
+
+## 1. Summary
+
+Expose the Work Orders MCP capabilities **inside the GCDR web UI** as a natural-
+language **assistant ("Copiloto OS")**. This RFC records the integration options,
+their trade-offs, the recommended path, and the decisions to make.
+
+## 2. The constraint
+
+The MCP server (RFC-0042) speaks **stdio** and is meant for an **LLM host**
+(Claude Desktop, Claude Code, …). Two consequences:
+
+- The **browser cannot talk to it directly** (no stdio in the browser).
+- The MCP alone answers nothing — **an LLM** is what calls the tools and turns
+  results into language.
+
+So "integrating into the UI" means adding an **assistant surface** (a chat) whose
+backend runs an LLM wired to the WO tools. The MCP itself stays as the
+desktop/agent entry point.
+
+## 3. Options
+
+### Option A — Assistant chat in the UI + backend endpoint (recommended)
+
+```
+[Chat panel in the GCDR UI]
+        │  POST /wo/assistant   (JWT/tenant from the request)
+        ▼
+[GCDR backend] → LLM (Claude) + the WO tools → natural-language answer (stream)
+```
+
+- The backend runs the LLM with the **same tool functions** the MCP exposes
+  (`get_progress`, `find_customer`, `list_work_orders`, …) and returns the
+  answer to the UI.
+- Tenant/customer scope comes from the **logged-in user's JWT** (not env), so the
+  assistant respects the caller's permissions automatically.
+- Requires extracting the tools into a **transport-agnostic** service (see §4) so
+  stdio-MCP and the HTTP assistant share one implementation.
+- **Pros:** real new value (NL over OS), reuses existing auth, one tool codebase.
+- **Cons:** needs an LLM credential on the server + cost controls; streaming.
+
+### Option B — MCP over HTTP/SSE + a web MCP client
+
+- The MCP SDK supports an HTTP/SSE transport; expose the MCP over HTTP and have a
+  web client connect.
+- **Pros:** lets external MCP clients (not just desktop) connect; standards-based.
+- **Cons:** still needs an LLM to be conversational; more moving parts; the
+  browser-side MCP client is heavier. Better suited to *external integrators*
+  than to an in-app assistant.
+
+### Option C — REST "insights" widgets (no chat)
+
+- Reuse the tool functions as plain REST endpoints (e.g. `GET /wo/insights/progress`)
+  and render cards/summaries in the UI.
+- **Pros:** simplest; no LLM.
+- **Cons:** this largely duplicates what the **Desempenho** tab already shows; the
+  unique value of the MCP (natural language) is lost. Only worth it for specific
+  embedded summaries.
+
+## 4. Shared tool layer (enabler for A & B)
+
+Extract the WO query logic into a transport-agnostic module, e.g.
+`src/services/work-orders/insights/` (pure functions returning
+`{ data, summary }`), consumed by:
+
+- the **stdio MCP** (`src/mcp/tools/*` become thin wrappers), and
+- the **HTTP assistant** endpoint (Option A), and
+- optionally the **REST insights** endpoints (Option C).
+
+One implementation, three surfaces — no logic drift, numbers always match the UI.
+
+## 5. Architecture for Option A
+
+- **Frontend:** a chat panel. Placement (decision in §7): a **tab "Assistente"**
+  inside `/os`, or a **global "Copiloto"** entry in the GCDR sidebar.
+- **Backend:** `POST /api/v1/wo/assistant` — body `{ message, conversationId? }`,
+  streams the LLM answer (SSE). The handler:
+  1. builds tenant/customer scope from `req.context` (the user's JWT);
+  2. runs the LLM with the WO tools bound (read-only);
+  3. streams tokens + a final structured `summary`.
+- **LLM:** Claude via the Anthropic API; server-held key; per-tenant rate/cost caps.
+
+## 6. Security
+
+- **Read-only** — the assistant exposes only the read tools; no WO writes.
+- **Scope from the caller** — tenant (and customer, for customer-scoped users)
+  derived from the JWT, never from a tool argument; the assistant can't read
+  outside the user's scope.
+- **No secrets** in answers; **cost/rate limits** per tenant; prompt-injection
+  hardening (tools are typed/validated, not free SQL).
+
+## 7. Decisions to make
+
+1. **Menu placement:** "Assistente" tab in `/os` (focused on OS) **vs** a global
+   "Copiloto" in the GCDR sidebar (spans the whole product, OS first).
+2. **LLM provider/credential & budget:** Anthropic key on the server; per-tenant
+   spend caps; which model.
+3. **Streaming UX:** SSE token streaming vs single response.
+4. **History:** ephemeral per session vs persisted conversations.
+
+## 8. Recommendation
+
+- **Now (no UI work):** the MCP already serves internal staff via Claude
+  Desktop/Code — ship the `.mcp.json` and use it immediately.
+- **In-app:** go with **Option A**, starting by extracting the shared
+  `wo-insights` layer (§4), then a `POST /wo/assistant` endpoint, then a chat
+  panel in an **"Assistente"** tab under `/os`. Promote to a global "Copiloto"
+  later if it proves out.
+- Keep **Option B** for *external* MCP integrators; use **Option C** only for
+  specific embedded summaries.
+
+## 9. Out of scope
+
+- Write actions from the assistant (creating WOs / appending events) — read-only
+  for now; a future RFC could add guarded, confirmed, audited writes.
+- A full multi-domain copilot (this RFC is OS-first).

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-sdk/client-s3": "^3.1037.0",
         "@aws-sdk/lib-dynamodb": "^3.400.0",
         "@aws-sdk/s3-request-presigner": "^3.1037.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "bcryptjs": "^3.0.3",
         "compression": "^1.7.4",
         "cors": "^2.8.5",
@@ -3809,6 +3810,18 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -4368,6 +4381,363 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
@@ -8502,7 +8872,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8602,7 +8971,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -10616,6 +10984,27 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10712,6 +11101,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10791,7 +11198,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -10849,7 +11255,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11879,6 +12284,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -11979,7 +12393,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12134,10 +12547,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -12711,7 +13123,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
@@ -13642,6 +14053,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -14733,7 +15150,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -15145,7 +15561,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15308,6 +15723,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -15964,7 +16388,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16114,6 +16537,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/run-async": {
@@ -16890,7 +17345,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -16903,7 +17357,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18845,7 +19298,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -19059,7 +19511,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -19285,6 +19736,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/client-s3": "^3.1037.0",
     "@aws-sdk/lib-dynamodb": "^3.400.0",
     "@aws-sdk/s3-request-presigner": "^3.1037.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "bcryptjs": "^3.0.3",
     "compression": "^1.7.4",
     "cors": "^2.8.5",

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -1,0 +1,41 @@
+// RFC-0042 — shared context for the Work Orders MCP server.
+// A server instance is pinned to one tenant (GCDR_TENANT_ID) and reads through
+// the existing WO services/repositories. Read-only: no tool performs writes.
+
+import { workOrderService } from '../services/work-orders/WorkOrderService';
+import { workOrdersCustomerSettingsService } from '../services/work-orders/WorkOrdersCustomerSettingsService';
+import { CustomerRepository } from '../repositories/CustomerRepository';
+import { db, schema } from '../infrastructure/database/drizzle/db';
+
+export interface ToolResponse<T = unknown> {
+  success: boolean;
+  message: string;
+  data: T;
+  summary: string;
+}
+
+export interface McpContext {
+  tenantId: string;
+  workOrders: typeof workOrderService;
+  settings: typeof workOrdersCustomerSettingsService;
+  customers: CustomerRepository;
+  db: typeof db;
+  schema: typeof schema;
+}
+
+export function loadContext(): McpContext {
+  const tenantId = process.env.GCDR_TENANT_ID;
+  if (!tenantId) {
+    throw new Error(
+      'GCDR_TENANT_ID is required to run the Work Orders MCP server (RFC-0042).',
+    );
+  }
+  return {
+    tenantId,
+    workOrders: workOrderService,
+    settings: workOrdersCustomerSettingsService,
+    customers: new CustomerRepository(),
+    db,
+    schema,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env npx tsx
+/**
+ * RFC-0042 — Work Orders MCP server (read-only).
+ *
+ * Lets chatbots/LLMs query the GCDR Work Orders (OS) domain in natural language.
+ * Pinned to one tenant via GCDR_TENANT_ID; reads through the WO services/repos.
+ *
+ * Usage:   npx tsx src/mcp/server.ts
+ * Env:     DATABASE_URL, GCDR_TENANT_ID (required)
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { loadContext, ToolResponse } from './context';
+import {
+  listCustomersSchema,
+  findCustomerSchema,
+  listCustomers,
+  findCustomer,
+} from './tools/customers';
+import {
+  listWorkOrdersSchema,
+  getWorkOrderSchema,
+  getTransitionsSchema,
+  listWorkOrders,
+  getWorkOrder,
+  getTransitions,
+} from './tools/workOrders';
+
+const ctx = loadContext();
+
+const server = new Server(
+  { name: 'gcdr-wo', version: '1.0.0' },
+  { capabilities: { tools: {} } },
+);
+
+const obj = (properties: Record<string, unknown>, required: string[] = []) => ({
+  type: 'object' as const,
+  properties,
+  required,
+});
+
+const TOOLS = [
+  {
+    name: 'list_customers',
+    description:
+      'List OS-enabled customers with their work-order counts by status. The GCDR equivalent of the old "list malls".',
+    inputSchema: obj({}),
+  },
+  {
+    name: 'find_customer',
+    description: 'Resolve a customer by fuzzy name or code (typo-tolerant).',
+    inputSchema: obj({ name: { type: 'string', description: 'Customer name or code' } }, ['name']),
+  },
+  {
+    name: 'list_work_orders',
+    description: 'List a customer work orders, optionally filtered by status and type.',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        status: { type: 'string' },
+        type: { type: 'string' },
+        limit: { type: 'number' },
+      },
+      ['customer'],
+    ),
+  },
+  {
+    name: 'get_work_order',
+    description: 'Full work order by code: type, status, device scope and recent timeline.',
+    inputSchema: obj({ code: { type: 'string', description: 'Work order code, e.g. OS-ABC1D2' } }, [
+      'code',
+    ]),
+  },
+  {
+    name: 'get_transitions',
+    description:
+      'Rules-engine evaluation (RFC-0041): which events can/cannot be appended next and why.',
+    inputSchema: obj({ code: { type: 'string', description: 'Work order code' } }, ['code']),
+  },
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  try {
+    let result: ToolResponse;
+    switch (name) {
+      case 'list_customers':
+        listCustomersSchema.parse(args ?? {});
+        result = await listCustomers(ctx);
+        break;
+      case 'find_customer':
+        result = await findCustomer(ctx, findCustomerSchema.parse(args));
+        break;
+      case 'list_work_orders':
+        result = await listWorkOrders(ctx, listWorkOrdersSchema.parse(args));
+        break;
+      case 'get_work_order':
+        result = await getWorkOrder(ctx, getWorkOrderSchema.parse(args));
+        break;
+      case 'get_transitions':
+        result = await getTransitions(ctx, getTransitionsSchema.parse(args));
+        break;
+      default:
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: false,
+                message: `Unknown tool: ${name}`,
+                data: null,
+                summary: `Tool "${name}" is not available.`,
+              }),
+            },
+          ],
+        };
+    }
+    return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            success: false,
+            message: err instanceof Error ? err.message : String(err),
+            data: null,
+            summary: 'The tool call failed.',
+          }),
+        },
+      ],
+    };
+  }
+});
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // stdout is the MCP channel — log to stderr.
+  console.error(`[gcdr-wo] MCP server ready (tenant ${ctx.tenantId})`);
+}
+
+main().catch((err) => {
+  console.error('[gcdr-wo] fatal:', err);
+  process.exit(1);
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -30,6 +30,25 @@ import {
   getWorkOrder,
   getTransitions,
 } from './tools/workOrders';
+import {
+  getDevicesSchema,
+  getDeviceDetailsSchema,
+  getDevices,
+  getDeviceDetails,
+} from './tools/devices';
+import { getMaintenanceSchema, getMaintenance } from './tools/maintenance';
+import {
+  getProgressSchema,
+  getAverageTimeSchema,
+  getTechnicianPerformanceSchema,
+  getActivityLogSchema,
+  getDailySummarySchema,
+  getProgress,
+  getAverageTime,
+  getTechnicianPerformance,
+  getActivityLog,
+  getDailySummary,
+} from './tools/analytics';
 
 const ctx = loadContext();
 
@@ -82,6 +101,58 @@ const TOOLS = [
       'Rules-engine evaluation (RFC-0041): which events can/cannot be appended next and why.',
     inputSchema: obj({ code: { type: 'string', description: 'Work order code' } }, ['code']),
   },
+  {
+    name: 'get_devices',
+    description: 'Devices in a customer work-order scope, filterable by install state.',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        filter: { type: 'string', enum: ['all', 'installed', 'pending'] },
+      },
+      ['customer'],
+    ),
+  },
+  {
+    name: 'get_device_details',
+    description: 'A device (fuzzy by name/serial/code) with its event history.',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        device: { type: 'string', description: 'Device name, serial or code (fuzzy)' },
+      },
+      ['customer', 'device'],
+    ),
+  },
+  {
+    name: 'get_maintenance',
+    description: 'Maintenance (MANUTENCAO) work orders, optionally by customer/status.',
+    inputSchema: obj({ customer: { type: 'string' }, status: { type: 'string' } }),
+  },
+  {
+    name: 'get_progress',
+    description: 'Installation progress % for a customer or tenant-wide.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+  },
+  {
+    name: 'get_average_time',
+    description: 'Average installation time (gap model) for a customer or tenant-wide.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+  },
+  {
+    name: 'get_technician_performance',
+    description: 'Technician ranking by installs with total/average time.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+  },
+  {
+    name: 'get_activity_log',
+    description: 'Recent work-order events (timeline feed).',
+    inputSchema: obj({ customer: { type: 'string' }, limit: { type: 'number' } }),
+  },
+  {
+    name: 'get_daily_summary',
+    description: "Today's installs and the open work-order backlog.",
+    inputSchema: obj({ customer: { type: 'string' } }),
+  },
 ];
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
@@ -106,6 +177,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case 'get_transitions':
         result = await getTransitions(ctx, getTransitionsSchema.parse(args));
+        break;
+      case 'get_devices':
+        result = await getDevices(ctx, getDevicesSchema.parse(args));
+        break;
+      case 'get_device_details':
+        result = await getDeviceDetails(ctx, getDeviceDetailsSchema.parse(args));
+        break;
+      case 'get_maintenance':
+        result = await getMaintenance(ctx, getMaintenanceSchema.parse(args ?? {}));
+        break;
+      case 'get_progress':
+        result = await getProgress(ctx, getProgressSchema.parse(args ?? {}));
+        break;
+      case 'get_average_time':
+        result = await getAverageTime(ctx, getAverageTimeSchema.parse(args ?? {}));
+        break;
+      case 'get_technician_performance':
+        result = await getTechnicianPerformance(ctx, getTechnicianPerformanceSchema.parse(args ?? {}));
+        break;
+      case 'get_activity_log':
+        result = await getActivityLog(ctx, getActivityLogSchema.parse(args ?? {}));
+        break;
+      case 'get_daily_summary':
+        result = await getDailySummary(ctx, getDailySummarySchema.parse(args ?? {}));
         break;
       default:
         return {

--- a/src/mcp/tools/analytics.ts
+++ b/src/mcp/tools/analytics.ts
@@ -1,0 +1,291 @@
+// RFC-0042 — analytics tools (progress, time, technicians, activity, daily).
+import { z } from 'zod';
+import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+import { McpContext, ToolResponse } from '../context';
+import { resolveCustomer } from './customers';
+
+const INSTALL = 'PRODUTO_INSTALADO';
+const TERMINAL = ['FINALIZADA', 'CANCELADA'];
+const GAP_CAP_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_FIRST_MS = 20 * 60 * 1000;
+
+/** Resolve the optional `customer` arg to an id (or null = whole tenant). */
+async function scopeCustomerId(ctx: McpContext, customer?: string): Promise<string | null | false> {
+  if (!customer) return null;
+  const c = await resolveCustomer(ctx, customer);
+  return c ? c.id : false; // false = not found
+}
+
+interface InstallRec {
+  deviceId: string;
+  techKey: string;
+  techName: string;
+  ts: number;
+}
+
+async function installEvents(ctx: McpContext, customerId: string | null): Promise<InstallRec[]> {
+  const { workOrders, workOrdersEvents } = ctx.schema;
+  const conds = [
+    eq(workOrders.tenantId, ctx.tenantId),
+    eq(workOrdersEvents.eventType, INSTALL),
+    isNotNull(workOrdersEvents.deviceId),
+  ];
+  if (customerId) conds.push(eq(workOrders.customerId, customerId));
+  const rows = await ctx.db
+    .select({
+      deviceId: workOrdersEvents.deviceId,
+      actorUserId: workOrdersEvents.actorUserId,
+      actor: workOrdersEvents.actor,
+      createdAt: workOrdersEvents.createdAt,
+    })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(and(...conds));
+  return rows.map((r) => {
+    const actor = (r.actor ?? {}) as { id?: string; name?: string; email?: string };
+    return {
+      deviceId: r.deviceId as string,
+      techKey: r.actorUserId || actor.id || actor.email || actor.name || 'unknown',
+      techName: actor.name || actor.email || r.actorUserId || 'Sistema',
+      ts: new Date(r.createdAt as unknown as string).getTime(),
+    };
+  });
+}
+
+/** Per-technician gap-based time (mirrors the Desempenho tab). */
+function perTechnician(recs: InstallRec[]) {
+  const byTech = new Map<string, InstallRec[]>();
+  for (const r of recs) {
+    const a = byTech.get(r.techKey);
+    if (a) a.push(r);
+    else byTech.set(r.techKey, [r]);
+  }
+  const rows = [];
+  let grandTotal = 0;
+  for (const [key, list] of byTech) {
+    list.sort((a, b) => a.ts - b.ts);
+    const gaps: number[] = [];
+    for (let i = 1; i < list.length; i++) {
+      const g = list[i].ts - list[i - 1].ts;
+      if (g > 0 && g <= GAP_CAP_MS) gaps.push(g);
+    }
+    const median = gaps.length
+      ? gaps.slice().sort((a, b) => a - b)[Math.floor(gaps.length / 2)]
+      : DEFAULT_FIRST_MS;
+    let total = 0;
+    const devices = new Set<string>();
+    for (let i = 0; i < list.length; i++) {
+      const g = i === 0 ? median : list[i].ts - list[i - 1].ts;
+      total += g > 0 && g <= GAP_CAP_MS ? g : median;
+      devices.add(list[i].deviceId);
+    }
+    grandTotal += total;
+    rows.push({ techKey: key, name: list[0].techName, installed: devices.size, totalMs: total });
+  }
+  rows.sort((a, b) => b.installed - a.installed);
+  const installed = new Set(recs.map((r) => r.deviceId)).size;
+  return { rows, grandTotal, installed };
+}
+
+function fmtH(ms: number): string {
+  if (!ms || ms <= 0) return '0min';
+  const m = Math.round(ms / 60000);
+  const h = Math.floor(m / 60);
+  return h ? `${h}h ${String(m % 60).padStart(2, '0')}min` : `${m}min`;
+}
+
+async function scopeError(query: string): Promise<ToolResponse> {
+  return {
+    success: false,
+    message: `No customer matches "${query}"`,
+    data: null,
+    summary: `No customer matched "${query}".`,
+  };
+}
+
+// ── get_progress ──────────────────────────────────────────────────────────────
+export const getProgressSchema = z.object({
+  customer: z.string().optional().describe('Customer name/code; omit for tenant-wide'),
+});
+
+export async function getProgress(
+  ctx: McpContext,
+  p: z.infer<typeof getProgressSchema>,
+): Promise<ToolResponse> {
+  const cid = await scopeCustomerId(ctx, p.customer);
+  if (cid === false) return scopeError(p.customer!);
+  const { workOrders, workOrdersDevices, workOrdersEvents } = ctx.schema;
+
+  const woCustomer = cid ? [eq(workOrders.customerId, cid)] : [];
+
+  const [{ total }] = await ctx.db
+    .select({ total: sql<number>`count(distinct ${workOrdersDevices.deviceId})::int` })
+    .from(workOrdersDevices)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersDevices.workOrderId))
+    .where(and(eq(workOrders.tenantId, ctx.tenantId), ...woCustomer));
+
+  const [{ installed }] = await ctx.db
+    .select({ installed: sql<number>`count(distinct ${workOrdersEvents.deviceId})::int` })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(
+      and(
+        eq(workOrders.tenantId, ctx.tenantId),
+        eq(workOrdersEvents.eventType, INSTALL),
+        isNotNull(workOrdersEvents.deviceId),
+        ...woCustomer,
+      ),
+    );
+
+  const progress = total > 0 ? Math.round((installed / total) * 100) : 0;
+  const scope = p.customer ? `for "${p.customer}"` : 'tenant-wide';
+  return {
+    success: true,
+    message: `Progress ${scope}`,
+    data: { total, installed, pending: Math.max(0, total - installed), progress },
+    summary: `Installation progress ${scope}: ${progress}% (${installed}/${total} devices installed).`,
+  };
+}
+
+// ── get_average_time ──────────────────────────────────────────────────────────
+export const getAverageTimeSchema = z.object({ customer: z.string().optional() });
+
+export async function getAverageTime(
+  ctx: McpContext,
+  p: z.infer<typeof getAverageTimeSchema>,
+): Promise<ToolResponse> {
+  const cid = await scopeCustomerId(ctx, p.customer);
+  if (cid === false) return scopeError(p.customer!);
+  const { grandTotal, installed } = perTechnician(await installEvents(ctx, cid));
+  const avgMs = installed ? grandTotal / installed : 0;
+  const scope = p.customer ? `for "${p.customer}"` : 'tenant-wide';
+  return {
+    success: true,
+    message: `Average installation time ${scope}`,
+    data: { installed, totalMs: grandTotal, avgMs },
+    summary: `Average installation time ${scope}: ${fmtH(avgMs)} per device (${fmtH(
+      grandTotal,
+    )} over ${installed} installs).`,
+  };
+}
+
+// ── get_technician_performance ───────────────────────────────────────────────
+export const getTechnicianPerformanceSchema = z.object({ customer: z.string().optional() });
+
+export async function getTechnicianPerformance(
+  ctx: McpContext,
+  p: z.infer<typeof getTechnicianPerformanceSchema>,
+): Promise<ToolResponse> {
+  const cid = await scopeCustomerId(ctx, p.customer);
+  if (cid === false) return scopeError(p.customer!);
+  const { rows } = perTechnician(await installEvents(ctx, cid));
+  const ranking = rows.map((r) => ({
+    technician: r.name,
+    installed: r.installed,
+    totalTime: fmtH(r.totalMs),
+    avgTime: fmtH(r.installed ? r.totalMs / r.installed : 0),
+  }));
+  const top = ranking[0];
+  return {
+    success: true,
+    message: `Technician ranking (${ranking.length})`,
+    data: { technicians: ranking },
+    summary: top
+      ? `Top technician: ${top.technician} with ${top.installed} installs (avg ${top.avgTime}).`
+      : 'No installations recorded yet.',
+  };
+}
+
+// ── get_activity_log ──────────────────────────────────────────────────────────
+export const getActivityLogSchema = z.object({
+  customer: z.string().optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+export async function getActivityLog(
+  ctx: McpContext,
+  p: z.infer<typeof getActivityLogSchema>,
+): Promise<ToolResponse> {
+  const cid = await scopeCustomerId(ctx, p.customer);
+  if (cid === false) return scopeError(p.customer!);
+  const { workOrders, workOrdersEvents } = ctx.schema;
+  const conds = [eq(workOrders.tenantId, ctx.tenantId)];
+  if (cid) conds.push(eq(workOrders.customerId, cid));
+
+  const rows = await ctx.db
+    .select({
+      code: workOrders.code,
+      eventType: workOrdersEvents.eventType,
+      actor: workOrdersEvents.actor,
+      createdAt: workOrdersEvents.createdAt,
+    })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(and(...conds))
+    .orderBy(desc(workOrdersEvents.createdAt))
+    .limit(p.limit ?? 20);
+
+  const items = rows.map((r) => {
+    const a = (r.actor ?? {}) as { name?: string; email?: string };
+    return {
+      workOrder: r.code,
+      eventType: r.eventType,
+      by: a.name || a.email || null,
+      at: r.createdAt,
+    };
+  });
+  return {
+    success: true,
+    message: `${items.length} recent event(s)`,
+    data: { activity: items },
+    summary: `Most recent activity: ${items
+      .slice(0, 3)
+      .map((i) => `${i.eventType} on ${i.workOrder}`)
+      .join('; ') || 'none'}.`,
+  };
+}
+
+// ── get_daily_summary ─────────────────────────────────────────────────────────
+export const getDailySummarySchema = z.object({ customer: z.string().optional() });
+
+export async function getDailySummary(
+  ctx: McpContext,
+  p: z.infer<typeof getDailySummarySchema>,
+): Promise<ToolResponse> {
+  const cid = await scopeCustomerId(ctx, p.customer);
+  if (cid === false) return scopeError(p.customer!);
+  const { workOrders, workOrdersEvents } = ctx.schema;
+  const woCustomer = cid ? [eq(workOrders.customerId, cid)] : [];
+
+  const [{ installsToday }] = await ctx.db
+    .select({ installsToday: sql<number>`count(distinct ${workOrdersEvents.deviceId})::int` })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(
+      and(
+        eq(workOrders.tenantId, ctx.tenantId),
+        eq(workOrdersEvents.eventType, INSTALL),
+        sql`${workOrdersEvents.createdAt} >= date_trunc('day', now())`,
+        ...woCustomer,
+      ),
+    );
+
+  const [{ open }] = await ctx.db
+    .select({ open: sql<number>`count(*)::int` })
+    .from(workOrders)
+    .where(
+      and(
+        eq(workOrders.tenantId, ctx.tenantId),
+        sql`${workOrders.status} <> all(${TERMINAL})`,
+        ...woCustomer,
+      ),
+    );
+
+  const scope = p.customer ? `for "${p.customer}"` : 'tenant-wide';
+  return {
+    success: true,
+    message: `Daily summary ${scope}`,
+    data: { installsToday, openWorkOrders: open },
+    summary: `Today ${scope}: ${installsToday} device(s) installed, ${open} work order(s) still open.`,
+  };
+}

--- a/src/mcp/tools/customers.ts
+++ b/src/mcp/tools/customers.ts
@@ -1,0 +1,82 @@
+// RFC-0042 — customer tools (the GCDR replacement for qr-checker's "malls").
+import { z } from 'zod';
+import { McpContext, ToolResponse } from '../context';
+import { fuzzyMatch } from '../utils/fuzzyMatch';
+
+export interface CustomerRef {
+  id: string;
+  name: string;
+  code: string;
+}
+
+/** OS-enabled customers for the tenant, with display name/code resolved. */
+export async function customerRoster(ctx: McpContext): Promise<CustomerRef[]> {
+  const settings = await ctx.settings.listEnabled(ctx.tenantId);
+  const refs: CustomerRef[] = [];
+  for (const s of settings) {
+    const c = await ctx.customers.getById(ctx.tenantId, s.customerId);
+    refs.push({ id: s.customerId, name: c?.name ?? s.customerId, code: c?.code ?? '' });
+  }
+  return refs;
+}
+
+export async function resolveCustomer(
+  ctx: McpContext,
+  query: string,
+): Promise<CustomerRef | null> {
+  const roster = await customerRoster(ctx);
+  return fuzzyMatch(query, roster, [(r) => r.code, (r) => r.name, (r) => r.id]);
+}
+
+// ── list_customers ──────────────────────────────────────────────────────────
+export const listCustomersSchema = z.object({});
+
+export async function listCustomers(ctx: McpContext): Promise<ToolResponse> {
+  const roster = await customerRoster(ctx);
+  const rows = [];
+  for (const r of roster) {
+    const res = await ctx.workOrders.list(ctx.tenantId, { customerId: r.id, limit: 100 });
+    const byStatus: Record<string, number> = {};
+    for (const wo of res.items) byStatus[wo.status] = (byStatus[wo.status] ?? 0) + 1;
+    rows.push({
+      ...r,
+      workOrders: res.pagination.total ?? res.items.length,
+      byStatus,
+    });
+  }
+  const totalWo = rows.reduce((a, r) => a + r.workOrders, 0);
+  return {
+    success: true,
+    message: `Found ${rows.length} OS-enabled customer(s)`,
+    data: { customers: rows },
+    summary: `There are ${rows.length} OS-enabled customers with ${totalWo} work orders in total.`,
+  };
+}
+
+// ── find_customer ───────────────────────────────────────────────────────────
+export const findCustomerSchema = z.object({
+  name: z.string().describe('Customer name or code to resolve (fuzzy match)'),
+});
+
+export async function findCustomer(
+  ctx: McpContext,
+  params: z.infer<typeof findCustomerSchema>,
+): Promise<ToolResponse> {
+  const roster = await customerRoster(ctx);
+  const match = fuzzyMatch(params.name, roster, [(r) => r.code, (r) => r.name, (r) => r.id]);
+  if (!match) {
+    const names = roster.map((r) => r.name).join(', ');
+    return {
+      success: false,
+      message: `No customer matches "${params.name}"`,
+      data: { available: roster },
+      summary: `No customer matched "${params.name}". Available customers: ${names || '(none)'}.`,
+    };
+  }
+  return {
+    success: true,
+    message: `Matched ${match.name}`,
+    data: { customer: match },
+    summary: `Matched customer "${match.name}" (code ${match.code || '—'}).`,
+  };
+}

--- a/src/mcp/tools/devices.ts
+++ b/src/mcp/tools/devices.ts
@@ -1,0 +1,153 @@
+// RFC-0042 — device tools (scope + details), customer-scoped.
+import { z } from 'zod';
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { McpContext, ToolResponse } from '../context';
+import { resolveCustomer } from './customers';
+import { fuzzyMatch } from '../utils/fuzzyMatch';
+
+const INSTALL = 'PRODUTO_INSTALADO';
+
+interface ScopeDevice {
+  id: string;
+  name: string;
+  code: string | null;
+  serialNumber: string | null;
+}
+
+async function scopeDevices(ctx: McpContext, customerId: string): Promise<ScopeDevice[]> {
+  const { workOrders, workOrdersDevices, devices } = ctx.schema;
+  const rows = await ctx.db
+    .selectDistinct({
+      id: devices.id,
+      name: devices.displayName,
+      code: devices.code,
+      serialNumber: devices.serialNumber,
+    })
+    .from(workOrdersDevices)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersDevices.workOrderId))
+    .innerJoin(devices, eq(devices.id, workOrdersDevices.deviceId))
+    .where(and(eq(workOrders.tenantId, ctx.tenantId), eq(workOrders.customerId, customerId)));
+  return rows as ScopeDevice[];
+}
+
+async function installedDeviceIds(ctx: McpContext, customerId: string): Promise<Set<string>> {
+  const { workOrders, workOrdersEvents } = ctx.schema;
+  const rows = await ctx.db
+    .selectDistinct({ deviceId: workOrdersEvents.deviceId })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(
+      and(
+        eq(workOrders.tenantId, ctx.tenantId),
+        eq(workOrders.customerId, customerId),
+        eq(workOrdersEvents.eventType, INSTALL),
+        isNotNull(workOrdersEvents.deviceId),
+      ),
+    );
+  return new Set(rows.map((r) => r.deviceId as string));
+}
+
+function customerNotFound(query: string): ToolResponse {
+  return {
+    success: false,
+    message: `No customer matches "${query}"`,
+    data: null,
+    summary: `No customer matched "${query}".`,
+  };
+}
+
+// ── get_devices ───────────────────────────────────────────────────────────────
+export const getDevicesSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  filter: z.enum(['all', 'installed', 'pending']).optional().default('all'),
+});
+
+export async function getDevices(
+  ctx: McpContext,
+  p: z.infer<typeof getDevicesSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+
+  const [all, installed] = await Promise.all([
+    scopeDevices(ctx, c.id),
+    installedDeviceIds(ctx, c.id),
+  ]);
+  const enriched = all.map((d) => ({ ...d, installed: installed.has(d.id) }));
+  const filtered =
+    p.filter === 'installed'
+      ? enriched.filter((d) => d.installed)
+      : p.filter === 'pending'
+        ? enriched.filter((d) => !d.installed)
+        : enriched;
+
+  return {
+    success: true,
+    message: `${filtered.length} device(s) (${p.filter}) for ${c.name}`,
+    data: { customer: c, devices: filtered },
+    summary: `${c.name}: ${all.length} devices in scope, ${installed.size} installed, ${
+      all.length - installed.size
+    } pending.`,
+  };
+}
+
+// ── get_device_details ────────────────────────────────────────────────────────
+export const getDeviceDetailsSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  device: z.string().describe('Device name, serial or code (fuzzy)'),
+});
+
+export async function getDeviceDetails(
+  ctx: McpContext,
+  p: z.infer<typeof getDeviceDetailsSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+
+  const all = await scopeDevices(ctx, c.id);
+  const match = fuzzyMatch(p.device, all, [
+    (d) => d.serialNumber,
+    (d) => d.code,
+    (d) => d.name,
+    (d) => d.id,
+  ]);
+  if (!match) {
+    return {
+      success: false,
+      message: `No device matches "${p.device}" for ${c.name}`,
+      data: { available: all.slice(0, 20).map((d) => d.name) },
+      summary: `No device matched "${p.device}" in ${c.name}'s scope.`,
+    };
+  }
+
+  const { workOrders, workOrdersEvents } = ctx.schema;
+  const events = await ctx.db
+    .select({
+      code: workOrders.code,
+      eventType: workOrdersEvents.eventType,
+      actor: workOrdersEvents.actor,
+      createdAt: workOrdersEvents.createdAt,
+    })
+    .from(workOrdersEvents)
+    .innerJoin(workOrders, eq(workOrders.id, workOrdersEvents.workOrderId))
+    .where(
+      and(eq(workOrders.tenantId, ctx.tenantId), eq(workOrdersEvents.deviceId, match.id)),
+    )
+    .orderBy(desc(workOrdersEvents.createdAt))
+    .limit(20);
+
+  const history = events.map((e) => {
+    const a = (e.actor ?? {}) as { name?: string; email?: string };
+    return { workOrder: e.code, eventType: e.eventType, by: a.name || a.email || null, at: e.createdAt };
+  });
+  const installed = history.some((h) => h.eventType === INSTALL);
+
+  return {
+    success: true,
+    message: `Device ${match.name}`,
+    data: { device: match, installed, history },
+    summary: `${match.name} (serial ${match.serialNumber ?? '—'}) is ${
+      installed ? 'installed' : 'pending'
+    }; ${history.length} event(s) on record.`,
+  };
+}

--- a/src/mcp/tools/maintenance.ts
+++ b/src/mcp/tools/maintenance.ts
@@ -1,0 +1,63 @@
+// RFC-0042 — maintenance tool (MANUTENCAO work orders).
+import { z } from 'zod';
+import { McpContext, ToolResponse } from '../context';
+import { resolveCustomer } from './customers';
+
+const STATUS = [
+  'PLANEJADA',
+  'EM_ANDAMENTO',
+  'INTERROMPIDA',
+  'AGUARDANDO',
+  'REAGENDADA',
+  'FINALIZADA',
+  'CANCELADA',
+] as const;
+const OPEN = new Set(['PLANEJADA', 'EM_ANDAMENTO', 'INTERROMPIDA', 'AGUARDANDO', 'REAGENDADA']);
+
+export const getMaintenanceSchema = z.object({
+  customer: z.string().optional().describe('Customer name/code; omit for tenant-wide'),
+  status: z.enum(STATUS).optional(),
+});
+
+export async function getMaintenance(
+  ctx: McpContext,
+  p: z.infer<typeof getMaintenanceSchema>,
+): Promise<ToolResponse> {
+  let customerId: string | undefined;
+  let customerName: string | undefined;
+  if (p.customer) {
+    const c = await resolveCustomer(ctx, p.customer);
+    if (!c) {
+      return {
+        success: false,
+        message: `No customer matches "${p.customer}"`,
+        data: null,
+        summary: `No customer matched "${p.customer}".`,
+      };
+    }
+    customerId = c.id;
+    customerName = c.name;
+  }
+
+  const res = await ctx.workOrders.list(ctx.tenantId, {
+    customerId,
+    type: 'MANUTENCAO',
+    status: p.status,
+    limit: 100,
+    sort: 'createdAt_desc',
+  });
+  const items = res.items.map((wo) => ({
+    code: wo.code,
+    status: wo.status,
+    scheduledAt: wo.scheduledAt,
+    assignedTo: wo.assignedTo,
+  }));
+  const open = items.filter((i) => OPEN.has(i.status)).length;
+  const scope = customerName ? `for ${customerName}` : 'tenant-wide';
+  return {
+    success: true,
+    message: `${items.length} maintenance work order(s) ${scope}`,
+    data: { maintenance: items },
+    summary: `${items.length} maintenance work order(s) ${scope}, ${open} still open.`,
+  };
+}

--- a/src/mcp/tools/workOrders.ts
+++ b/src/mcp/tools/workOrders.ts
@@ -1,0 +1,145 @@
+// RFC-0042 — work-order tools.
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { McpContext, ToolResponse } from '../context';
+import { resolveCustomer } from './customers';
+
+const STATUS = [
+  'PLANEJADA',
+  'EM_ANDAMENTO',
+  'INTERROMPIDA',
+  'AGUARDANDO',
+  'REAGENDADA',
+  'FINALIZADA',
+  'CANCELADA',
+] as const;
+const TYPE = ['INSTALACAO', 'MANUTENCAO', 'VISITA_TECNICA'] as const;
+
+function customerNotFound(query: string): ToolResponse {
+  return {
+    success: false,
+    message: `No customer matches "${query}"`,
+    data: null,
+    summary: `No customer matched "${query}". Use find_customer to resolve it.`,
+  };
+}
+
+async function resolveWoIdByCode(ctx: McpContext, code: string): Promise<string | null> {
+  const rows = await ctx.db
+    .select({ id: ctx.schema.workOrders.id })
+    .from(ctx.schema.workOrders)
+    .where(
+      and(
+        eq(ctx.schema.workOrders.tenantId, ctx.tenantId),
+        eq(ctx.schema.workOrders.code, code),
+      ),
+    )
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+// ── list_work_orders ──────────────────────────────────────────────────────────
+export const listWorkOrdersSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  status: z.enum(STATUS).optional(),
+  type: z.enum(TYPE).optional(),
+  limit: z.number().int().min(1).max(100).optional(),
+});
+
+export async function listWorkOrders(
+  ctx: McpContext,
+  p: z.infer<typeof listWorkOrdersSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+
+  const res = await ctx.workOrders.list(ctx.tenantId, {
+    customerId: c.id,
+    status: p.status,
+    type: p.type,
+    limit: p.limit ?? 50,
+    sort: 'createdAt_desc',
+  });
+  const items = res.items.map((wo) => ({
+    code: wo.code,
+    type: wo.type,
+    status: wo.status,
+    scheduledAt: wo.scheduledAt,
+    assignedTo: wo.assignedTo,
+  }));
+  return {
+    success: true,
+    message: `${items.length} work order(s) for ${c.name}`,
+    data: { customer: c, workOrders: items },
+    summary: `${c.name} has ${res.pagination.total ?? items.length} work order(s) matching the filter.`,
+  };
+}
+
+// ── get_work_order ────────────────────────────────────────────────────────────
+export const getWorkOrderSchema = z.object({
+  code: z.string().describe('Work order code, e.g. OS-ABC1D2'),
+});
+
+export async function getWorkOrder(
+  ctx: McpContext,
+  p: z.infer<typeof getWorkOrderSchema>,
+): Promise<ToolResponse> {
+  const id = await resolveWoIdByCode(ctx, p.code);
+  if (!id) {
+    return {
+      success: false,
+      message: `No work order "${p.code}"`,
+      data: null,
+      summary: `Work order "${p.code}" was not found.`,
+    };
+  }
+  const wo = await ctx.workOrders.detail(ctx.tenantId, id);
+  const events = [...wo.events]
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .slice(0, 10)
+    .map((e) => ({ eventType: e.eventType, at: e.createdAt, by: e.actor?.name ?? e.actor?.email ?? null }));
+  return {
+    success: true,
+    message: `Work order ${wo.code}`,
+    data: {
+      code: wo.code,
+      type: wo.type,
+      status: wo.status,
+      scheduledAt: wo.scheduledAt,
+      devices: wo.devices.length,
+      events,
+    },
+    summary: `${wo.code} (${wo.type}) is ${wo.status} with ${wo.devices.length} device(s) in scope.`,
+  };
+}
+
+// ── get_transitions ───────────────────────────────────────────────────────────
+export const getTransitionsSchema = z.object({
+  code: z.string().describe('Work order code to evaluate next allowed events'),
+});
+
+export async function getTransitions(
+  ctx: McpContext,
+  p: z.infer<typeof getTransitionsSchema>,
+): Promise<ToolResponse> {
+  const id = await resolveWoIdByCode(ctx, p.code);
+  if (!id) {
+    return {
+      success: false,
+      message: `No work order "${p.code}"`,
+      data: null,
+      summary: `Work order "${p.code}" was not found.`,
+    };
+  }
+  const r = await ctx.workOrders.getTransitions(ctx.tenantId, id);
+  const allowed = r.transitions.filter((t) => t.allowed).map((t) => t.code);
+  const blocked = r.transitions
+    .filter((t) => !t.allowed)
+    .map((t) => ({ code: t.code, reason: t.reasonCode, missing: t.missing }));
+  return {
+    success: true,
+    message: `Transitions for ${p.code}`,
+    data: { status: r.status, allowed, blocked },
+    summary: `${p.code} is ${r.status}. Allowed next: ${allowed.join(', ') || 'none'}.`,
+  };
+}

--- a/src/mcp/utils/fuzzyMatch.ts
+++ b/src/mcp/utils/fuzzyMatch.ts
@@ -1,0 +1,62 @@
+// RFC-0042 — typo-tolerant matching for customer name/code (ported from
+// qrcode-check.git src/mcp/utils/fuzzy-match.ts, adapted to multiple keys).
+
+export function normalize(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+function bigrams(s: string): Map<string, number> {
+  const m = new Map<string, number>();
+  for (let i = 0; i < s.length - 1; i++) {
+    const g = s.slice(i, i + 2);
+    m.set(g, (m.get(g) ?? 0) + 1);
+  }
+  return m;
+}
+
+/** Sørensen–Dice coefficient over character bigrams (0..1). */
+function dice(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length < 2 || b.length < 2) return 0;
+  const A = bigrams(a);
+  const B = bigrams(b);
+  let inter = 0;
+  for (const [g, n] of A) inter += Math.min(n, B.get(g) ?? 0);
+  return (2 * inter) / (a.length - 1 + (b.length - 1));
+}
+
+/**
+ * Resolve `query` against `items`. Precedence: exact key → key includes query →
+ * best Dice score ≥ threshold across all keys. Returns null when nothing fits.
+ */
+export function fuzzyMatch<T>(
+  query: string,
+  items: T[],
+  keys: Array<(item: T) => string | null | undefined>,
+  threshold = 0.5,
+): T | null {
+  const q = normalize(query);
+  if (!q) return null;
+
+  const keyVals = (item: T) => keys.map((k) => normalize(k(item) ?? '')).filter(Boolean);
+
+  // 1) exact
+  for (const item of items) {
+    if (keyVals(item).some((v) => v === q)) return item;
+  }
+  // 2) substring (either direction)
+  for (const item of items) {
+    if (keyVals(item).some((v) => v.includes(q) || q.includes(v))) return item;
+  }
+  // 3) fuzzy
+  let best: { item: T; score: number } | null = null;
+  for (const item of items) {
+    const score = Math.max(0, ...keyVals(item).map((v) => dice(q, v)));
+    if (score >= threshold && (!best || score > best.score)) best = { item, score };
+  }
+  return best?.item ?? null;
+}


### PR DESCRIPTION
## What

Implements **RFC-0042 — Work Orders MCP server** (read-only) and adds **RFC-0043 — OS Assistant** (UI integration options, design only).

### MCP server (`src/mcp/`)
- stdio, read-only, pinned to one tenant via `GCDR_TENANT_ID`; reads through the existing WO services/repositories.
- The fixed malls concept becomes **customers**.
- **13 tools:** `list_customers`, `find_customer`, `list_work_orders`, `get_work_order`, `get_transitions` (rules engine RFC-0041), `get_devices`, `get_device_details`, `get_maintenance`, `get_progress`, `get_average_time`, `get_technician_performance`, `get_activity_log`, `get_daily_summary`.
- Analytics query the WO tables directly via Drizzle and reuse the Desempenho gap-based time model, so numbers match the UI.
- `.mcp.json` is gitignored (`.mcp.json.example` committed) — no DB credentials in the repo.

### Docs
- RFC-0042 (MCP) + RFC-0043 (OS Assistant: chat-in-UI vs MCP-over-HTTP vs REST widgets; recommends a shared `wo-insights` layer + `/wo/assistant`).

## Notes
- **No migrations / no seeds** required by the MCP (reads existing tables). Adds `@modelcontextprotocol/sdk` to deps (`npm install` needed).
- Validated end-to-end via MCP Inspector against the local DB (progress 90% (283/316); technician ranking correct).
- Phase 3 (prod hardening: read-only DB role, API-key auto-scope) is documented, not implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)