### PR TITLE
feat(assistant): GCDR Copiloto (RFC-0043 Option A) - backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,3 +136,12 @@ S3_UPLOAD_MAX_BYTES=10485760
 # If unset, server-side captcha verification is bypassed (dev only — set it in
 # prod to actually enforce bot protection on /public/wiki/integrations/submit).
 TURNSTILE_SECRET_KEY=
+
+# =============================================================================
+# GCDR Copiloto (RFC-0043) - read-only LLM assistant over the Work Order tools
+# =============================================================================
+# Anthropic API key used by POST /assistant. If unset, the assistant endpoint
+# returns 503 and the UI shows the "unavailable" state (the rest of the app is
+# unaffected). Model is overridable; defaults to claude-sonnet-4-6.
+ANTHROPIC_API_KEY=
+ASSISTANT_MODEL=claude-sonnet-4-6

--- a/docs/RFC-0043-OS-Assistant-UI-Integration.md
+++ b/docs/RFC-0043-OS-Assistant-UI-Integration.md
@@ -125,23 +125,43 @@ Option A is implemented as a POC, but as a **general GCDR Copiloto** (not OS-onl
   here.
 - `src/services/assistant/AssistantService.ts` — Anthropic tool-use loop, scoped
   to the caller's tenant via `makeContext(tenantId)`; read-only.
-- `src/controllers/assistant.controller.ts` — `POST /assistant` (ask) and
-  `GET /assistant/status` (is it configured), behind `authMiddleware`.
+- `src/controllers/assistant.controller.ts` — `POST /assistant` (ask),
+  `GET /assistant/status`, and persisted-history CRUD under
+  `/assistant/conversations` (see below), behind `authMiddleware`.
+- Tools wired: Work Orders (13, RFC-0042), Technicians (`find_technician`,
+  `list_technician_work_orders`) and Alarm Rules (`list_alarm_rules`,
+  `get_alarm_rule`, `get_rule_devices`, `compare_alarm_rules`). The registry is
+  domain-agnostic; more domains plug in here.
+- **Prompt caching**: the tools + system prefix is identical on every call, so it
+  carries `cache_control: ephemeral` (5-min TTL). The tool-use loop re-sends it
+  up to MAX_STEPS times per ask and quick follow-ups reuse it; cache reads cost
+  0.1x. Breakpoints sit only on static content.
 - Env: `ANTHROPIC_API_KEY` (required to enable) and optional `ASSISTANT_MODEL`
   (defaults `claude-sonnet-4-6`). If the key is absent the endpoint returns 503
   and the UI degrades gracefully.
 
+**Persisted conversation history (shareable)**
+- Table `assistant_conversations` (migration 0042): per-user chat history stored
+  as JSONB turns, `shared` boolean. Private to the owner unless shared, when
+  other users in the same tenant can read it (owner-only edit/delete).
+- `src/services/assistant/conversationStore.ts` + endpoints:
+  `GET /assistant/conversations?scope=mine|shared|all`, `GET/POST/PATCH/DELETE
+  /assistant/conversations[/:id]`. The transient `ask` stays stateless; saving
+  is opt-in from the UI.
+
 **Frontend (`gcdr-frontend.git`)**
 - A **global floating "Copiloto"** widget (`components/assistant/CopilotWidget.tsx`)
-  mounted in `Layout`, available on every authenticated page — so it's a
-  product-wide assistant, OS being the first domain it can answer about.
+  in `Layout`, with maximize/restore, available on every authenticated page.
+  Can be hidden/re-shown (localStorage pref).
+- A dedicated **"Assistente"** menu + page (`/assistant`) with tabs **Chat**,
+  **Histórico** (mine / shared-by-others, open/save/share/delete) and **Guia**
+  (capabilities + example prompts per domain + assistant status + launcher
+  toggle). Shared chat logic in `hooks/useCopilotChat.ts`.
 - `services/api/assistantService.ts`, `i18n` namespace `assistant` (pt-BR/en).
 
-POC limitations (vs sections 5/8): no token streaming (single response),
-ephemeral history (not persisted), and the tool set is still WO-first. Next:
-extract a shared `wo-insights` layer if/when REST widgets (Option C) are also
-wanted, add streaming, and register tools from other domains (customers,
-devices, assets).
+Remaining (vs sections 5/8): no token streaming yet (single response); a shared
+`wo-insights` layer would be extracted only if/when REST widgets (Option C) are
+also wanted; more tool domains (assets, centrals) can be registered.
 
 ## 10. Out of scope
 

--- a/docs/RFC-0043-OS-Assistant-UI-Integration.md
+++ b/docs/RFC-0043-OS-Assistant-UI-Integration.md
@@ -115,8 +115,37 @@ One implementation, three surfaces — no logic drift, numbers always match the 
 - Keep **Option B** for *external* MCP integrators; use **Option C** only for
   specific embedded summaries.
 
-## 9. Out of scope
+## 9. POC status (branch `feat/gcdr-assistant`)
+
+Option A is implemented as a POC, but as a **general GCDR Copiloto** (not OS-only):
+
+**Backend (`gcdr.git`)**
+- `src/services/assistant/registry.ts` — a domain-agnostic tool registry,
+  currently seeded with the 13 Work Orders tools (RFC-0042). New domains plug in
+  here.
+- `src/services/assistant/AssistantService.ts` — Anthropic tool-use loop, scoped
+  to the caller's tenant via `makeContext(tenantId)`; read-only.
+- `src/controllers/assistant.controller.ts` — `POST /assistant` (ask) and
+  `GET /assistant/status` (is it configured), behind `authMiddleware`.
+- Env: `ANTHROPIC_API_KEY` (required to enable) and optional `ASSISTANT_MODEL`
+  (defaults `claude-sonnet-4-6`). If the key is absent the endpoint returns 503
+  and the UI degrades gracefully.
+
+**Frontend (`gcdr-frontend.git`)**
+- A **global floating "Copiloto"** widget (`components/assistant/CopilotWidget.tsx`)
+  mounted in `Layout`, available on every authenticated page — so it's a
+  product-wide assistant, OS being the first domain it can answer about.
+- `services/api/assistantService.ts`, `i18n` namespace `assistant` (pt-BR/en).
+
+POC limitations (vs sections 5/8): no token streaming (single response),
+ephemeral history (not persisted), and the tool set is still WO-first. Next:
+extract a shared `wo-insights` layer if/when REST widgets (Option C) are also
+wanted, add streaming, and register tools from other domains (customers,
+devices, assets).
+
+## 10. Out of scope
 
 - Write actions from the assistant (creating WOs / appending events) — read-only
   for now; a future RFC could add guarded, confirmed, audited writes.
-- A full multi-domain copilot (this RFC is OS-first).
+- A full multi-domain copilot — the POC is a general shell but only WO tools are
+  wired so far.

--- a/drizzle/migrations/0042_assistant_conversations.sql
+++ b/drizzle/migrations/0042_assistant_conversations.sql
@@ -1,0 +1,28 @@
+-- Migration 0042: assistant_conversations (RFC-0043)
+--
+-- Per-user, persisted GCDR Copiloto chat history. Each row is one conversation
+-- (a list of turns stored as JSONB). A conversation is private to its owner
+-- unless "shared" = true, in which case other users in the same tenant can read
+-- it (read-only; only the owner can edit/delete). The transient "ask" endpoint
+-- stays stateless; this table is opt-in persistence the UI writes to.
+--
+-- No BEGIN/COMMIT: the custom runner wraps each file in its own transaction.
+
+CREATE TABLE IF NOT EXISTS "assistant_conversations" (
+  "id"         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id"  uuid NOT NULL,
+  "user_id"    uuid NOT NULL,
+  "title"      varchar(200) NOT NULL DEFAULT 'Conversa',
+  "messages"   jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "shared"     boolean NOT NULL DEFAULT false,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+-- Own conversations, newest first.
+CREATE INDEX IF NOT EXISTS "assistant_conversations_owner_idx"
+  ON "assistant_conversations" ("tenant_id", "user_id", "updated_at" DESC);
+
+-- Tenant feed of shared conversations.
+CREATE INDEX IF NOT EXISTS "assistant_conversations_shared_idx"
+  ON "assistant_conversations" ("tenant_id", "shared", "updated_at" DESC);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gcdr-api",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.104.1",
         "@aws-sdk/client-dynamodb": "^3.400.0",
         "@aws-sdk/client-eventbridge": "^3.400.0",
         "@aws-sdk/client-s3": "^3.1037.0",
@@ -62,6 +63,27 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.104.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2738,6 +2760,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -6158,6 +6189,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -11251,6 +11288,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -14045,6 +14088,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -17632,6 +17688,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -18241,6 +18307,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "db:ops": "tsx scripts/db/seed-runner.ts exec"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.104.1",
     "@aws-sdk/client-dynamodb": "^3.400.0",
     "@aws-sdk/client-eventbridge": "^3.400.0",
     "@aws-sdk/client-s3": "^3.1037.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -81,6 +81,7 @@ import {
   woCustomersController,
   woLifecycleController,
   woEventTypesHandler,
+  assistantController,
   // RFC-0036: Device/Work-Order Annotations (polymorphic)
   annotationsController,
 } from './controllers';
@@ -350,6 +351,9 @@ apiV1Router.get('/wo/event-types', authMiddleware, woEventTypesHandler);
 apiV1Router.use('/wo/lifecycle-rules', authMiddleware, woLifecycleController);
 apiV1Router.use('/wo/work-orders', authMiddleware, workOrdersController);
 apiV1Router.use('/wo/customers', woCustomersController);
+
+// RFC-0043: GCDR Copiloto (read-only LLM assistant over the WO tools).
+apiV1Router.use('/assistant', authMiddleware, assistantController);
 
 // Mount API v1 router
 app.use('/api/v1', apiV1Router);

--- a/src/controllers/assistant.controller.ts
+++ b/src/controllers/assistant.controller.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { runAssistant, isAssistantConfigured } from '../services/assistant/AssistantService';
+import { sendSuccess } from '../middleware';
+
+const router = Router();
+
+// =============================================================================
+// /assistant — RFC-0043 GCDR Copiloto (read-only LLM over the WO tools).
+// Tenant scope comes from the caller's JWT (req.context), never the body.
+// =============================================================================
+
+const AskSchema = z.object({
+  message: z.string().min(1).max(4000),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string().min(1).max(8000),
+      }),
+    )
+    .max(20)
+    .optional(),
+});
+
+/** GET /assistant/status — whether the assistant is configured (for the UI). */
+router.get('/status', (req: Request, res: Response) => {
+  sendSuccess(res, { enabled: isAssistantConfigured() }, 200, req.context.requestId);
+});
+
+/** POST /assistant — ask the copilot a question; returns the answer + tools used. */
+router.post('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { message, history } = AskSchema.parse(req.body);
+    const result = await runAssistant(tenantId, message, history ?? []);
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/src/controllers/assistant.controller.ts
+++ b/src/controllers/assistant.controller.ts
@@ -1,9 +1,33 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { runAssistant, isAssistantConfigured } from '../services/assistant/AssistantService';
-import { sendSuccess } from '../middleware';
+import {
+  listConversations,
+  getConversation,
+  createConversation,
+  updateConversation,
+  deleteConversation,
+  type ConversationScope,
+} from '../services/assistant/conversationStore';
+import { sendSuccess, sendCreated } from '../middleware';
 
 const router = Router();
+
+const TurnSchema = z.object({
+  role: z.enum(['user', 'assistant']),
+  content: z.string().min(1).max(8000),
+  tools: z.array(z.string()).optional(),
+});
+const ConversationBody = z.object({
+  title: z.string().max(200).optional(),
+  messages: z.array(TurnSchema).max(200),
+  shared: z.boolean().optional(),
+});
+const ConversationPatch = z.object({
+  title: z.string().max(200).optional(),
+  messages: z.array(TurnSchema).max(200).optional(),
+  shared: z.boolean().optional(),
+});
 
 // =============================================================================
 // /assistant — RFC-0043 GCDR Copiloto (read-only LLM over the WO tools).
@@ -35,6 +59,68 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
     const { message, history } = AskSchema.parse(req.body);
     const result = await runAssistant(tenantId, message, history ?? []);
     sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ── Persisted, optionally-shared conversation history (RFC-0043) ───────────────
+
+/** GET /assistant/conversations?scope=mine|shared|all — list conversations. */
+router.get('/conversations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const scope = (['mine', 'shared', 'all'] as const).includes(req.query.scope as ConversationScope)
+      ? (req.query.scope as ConversationScope)
+      : 'all';
+    const items = await listConversations(tenantId, userId, scope);
+    sendSuccess(res, { items }, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** GET /assistant/conversations/:id — one conversation (owner or shared). */
+router.get('/conversations/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const convo = await getConversation(tenantId, userId, req.params.id);
+    sendSuccess(res, convo, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** POST /assistant/conversations — save a new conversation. */
+router.post('/conversations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const body = ConversationBody.parse(req.body);
+    const convo = await createConversation(tenantId, userId, body);
+    sendCreated(res, convo, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** PATCH /assistant/conversations/:id — update messages/title/shared (owner). */
+router.patch('/conversations/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const patch = ConversationPatch.parse(req.body);
+    const convo = await updateConversation(tenantId, userId, req.params.id, patch);
+    sendSuccess(res, convo, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** DELETE /assistant/conversations/:id — delete (owner). */
+router.delete('/conversations/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    await deleteConversation(tenantId, userId, req.params.id);
+    sendSuccess(res, { deleted: true }, 200, requestId);
   } catch (err) {
     next(err);
   }

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -70,3 +70,6 @@ export { default as userContactsController } from './user-contacts.controller';
 
 // RFC-0033: Customer Integration Sync State
 export { default as customerIntegrationsController } from './customer-integrations.controller';
+
+// RFC-0043: GCDR Copiloto (assistant)
+export { default as assistantController } from './assistant.controller';

--- a/src/infrastructure/database/drizzle/schema.ts
+++ b/src/infrastructure/database/drizzle/schema.ts
@@ -1954,3 +1954,21 @@ export const annotationAttachments = pgTable('annotation_attachments', {
   responseIdx:   index('annotation_attachments_response_idx').on(table.responseId).where(sql`response_id IS NOT NULL`),
   fileIdx:       index('annotation_attachments_file_idx').on(table.fileAssetId),
 }));
+
+// -----------------------------------------------------------------------------
+// assistant_conversations (RFC-0043) — persisted GCDR Copiloto chat history.
+// Private to the owner unless `shared` = true (then readable by the tenant).
+// -----------------------------------------------------------------------------
+export const assistantConversations = pgTable('assistant_conversations', {
+  id:        uuid('id').primaryKey().defaultRandom(),
+  tenantId:  uuid('tenant_id').notNull(),
+  userId:    uuid('user_id').notNull(),
+  title:     varchar('title', { length: 200 }).notNull().default('Conversa'),
+  messages:  jsonb('messages').notNull().default(sql`'[]'::jsonb`),
+  shared:    boolean('shared').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  ownerIdx:  index('assistant_conversations_owner_idx').on(table.tenantId, table.userId, table.updatedAt),
+  sharedIdx: index('assistant_conversations_shared_idx').on(table.tenantId, table.shared, table.updatedAt),
+}));

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -23,13 +23,8 @@ export interface McpContext {
   schema: typeof schema;
 }
 
-export function loadContext(): McpContext {
-  const tenantId = process.env.GCDR_TENANT_ID;
-  if (!tenantId) {
-    throw new Error(
-      'GCDR_TENANT_ID is required to run the Work Orders MCP server (RFC-0042).',
-    );
-  }
+/** Build a context for a given tenant (used by the HTTP assistant, RFC-0043). */
+export function makeContext(tenantId: string): McpContext {
   return {
     tenantId,
     workOrders: workOrderService,
@@ -38,4 +33,15 @@ export function loadContext(): McpContext {
     db,
     schema,
   };
+}
+
+/** Env-pinned context for the stdio MCP server (RFC-0042). */
+export function loadContext(): McpContext {
+  const tenantId = process.env.GCDR_TENANT_ID;
+  if (!tenantId) {
+    throw new Error(
+      'GCDR_TENANT_ID is required to run the Work Orders MCP server (RFC-0042).',
+    );
+  }
+  return makeContext(tenantId);
 }

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -4,6 +4,7 @@
 
 import { workOrderService } from '../services/work-orders/WorkOrderService';
 import { workOrdersCustomerSettingsService } from '../services/work-orders/WorkOrdersCustomerSettingsService';
+import { ruleService } from '../services/RuleService';
 import { CustomerRepository } from '../repositories/CustomerRepository';
 import { db, schema } from '../infrastructure/database/drizzle/db';
 
@@ -18,6 +19,7 @@ export interface McpContext {
   tenantId: string;
   workOrders: typeof workOrderService;
   settings: typeof workOrdersCustomerSettingsService;
+  rules: typeof ruleService;
   customers: CustomerRepository;
   db: typeof db;
   schema: typeof schema;
@@ -29,6 +31,7 @@ export function makeContext(tenantId: string): McpContext {
     tenantId,
     workOrders: workOrderService,
     settings: workOrdersCustomerSettingsService,
+    rules: ruleService,
     customers: new CustomerRepository(),
     db,
     schema,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -44,6 +44,16 @@ import {
   listTechnicianWorkOrders,
 } from './tools/technicians';
 import {
+  listAlarmRulesSchema,
+  getAlarmRuleSchema,
+  getRuleDevicesSchema,
+  compareAlarmRulesSchema,
+  listAlarmRules,
+  getAlarmRule,
+  getRuleDevices,
+  compareAlarmRules,
+} from './tools/rules';
+import {
   getProgressSchema,
   getAverageTimeSchema,
   getTechnicianPerformanceSchema,
@@ -152,6 +162,56 @@ const TOOLS = [
     inputSchema: obj({ customer: { type: 'string' }, status: { type: 'string' } }),
   },
   {
+    name: 'list_alarm_rules',
+    description: 'List a customer alarm rules (name, type, priority, enabled, scope, device count).',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        type: {
+          type: 'string',
+          enum: ['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE'],
+        },
+        enabled: { type: 'boolean' },
+      },
+      ['customer'],
+    ),
+  },
+  {
+    name: 'get_alarm_rule',
+    description:
+      'A customer alarm rule in detail: Condition, Behavior (guards/escalation/channels), Schedule and Scope (with devices).',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        rule: { type: 'string', description: 'Rule name (fuzzy)' },
+      },
+      ['customer', 'rule'],
+    ),
+  },
+  {
+    name: 'get_rule_devices',
+    description: 'The devices a given alarm rule applies to (scope).',
+    inputSchema: obj(
+      {
+        customer: { type: 'string', description: 'Customer name or code (fuzzy)' },
+        rule: { type: 'string', description: 'Rule name (fuzzy)' },
+      },
+      ['customer', 'rule'],
+    ),
+  },
+  {
+    name: 'compare_alarm_rules',
+    description:
+      'Compare the alarm rule sets of two customers: same-named rules and whether their Condition, Behavior, Schedule and Scope match, plus rules unique to each.',
+    inputSchema: obj(
+      {
+        customerA: { type: 'string', description: 'First customer name or code (fuzzy)' },
+        customerB: { type: 'string', description: 'Second customer name or code (fuzzy)' },
+      },
+      ['customerA', 'customerB'],
+    ),
+  },
+  {
     name: 'get_progress',
     description: 'Installation progress % for a customer or tenant-wide.',
     inputSchema: obj({ customer: { type: 'string' } }),
@@ -215,6 +275,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case 'get_maintenance':
         result = await getMaintenance(ctx, getMaintenanceSchema.parse(args ?? {}));
+        break;
+      case 'list_alarm_rules':
+        result = await listAlarmRules(ctx, listAlarmRulesSchema.parse(args));
+        break;
+      case 'get_alarm_rule':
+        result = await getAlarmRule(ctx, getAlarmRuleSchema.parse(args));
+        break;
+      case 'get_rule_devices':
+        result = await getRuleDevices(ctx, getRuleDevicesSchema.parse(args));
+        break;
+      case 'compare_alarm_rules':
+        result = await compareAlarmRules(ctx, compareAlarmRulesSchema.parse(args));
         break;
       case 'get_progress':
         result = await getProgress(ctx, getProgressSchema.parse(args ?? {}));

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -38,6 +38,12 @@ import {
 } from './tools/devices';
 import { getMaintenanceSchema, getMaintenance } from './tools/maintenance';
 import {
+  findTechnicianSchema,
+  listTechnicianWorkOrdersSchema,
+  findTechnician,
+  listTechnicianWorkOrders,
+} from './tools/technicians';
+import {
   getProgressSchema,
   getAverageTimeSchema,
   getTechnicianPerformanceSchema,
@@ -86,6 +92,23 @@ const TOOLS = [
         limit: { type: 'number' },
       },
       ['customer'],
+    ),
+  },
+  {
+    name: 'find_technician',
+    description: 'Resolve a technician (the responsible person of work orders) by fuzzy name or email.',
+    inputSchema: obj({ name: { type: 'string', description: 'Technician name or email' } }, ['name']),
+  },
+  {
+    name: 'list_technician_work_orders',
+    description:
+      'List the work orders a technician is responsible for (assignedTo), optionally by status. Answers "which OS belong to <person>".',
+    inputSchema: obj(
+      {
+        technician: { type: 'string', description: 'Technician name or email (fuzzy)' },
+        status: { type: 'string' },
+      },
+      ['technician'],
     ),
   },
   {
@@ -171,6 +194,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         break;
       case 'list_work_orders':
         result = await listWorkOrders(ctx, listWorkOrdersSchema.parse(args));
+        break;
+      case 'find_technician':
+        result = await findTechnician(ctx, findTechnicianSchema.parse(args));
+        break;
+      case 'list_technician_work_orders':
+        result = await listTechnicianWorkOrders(ctx, listTechnicianWorkOrdersSchema.parse(args));
         break;
       case 'get_work_order':
         result = await getWorkOrder(ctx, getWorkOrderSchema.parse(args));

--- a/src/mcp/tools/rules.ts
+++ b/src/mcp/tools/rules.ts
@@ -1,0 +1,326 @@
+// RFC-0042/0043 — alarm-rules tools. List a customer's alarm rules, inspect a
+// rule (Condition / Behavior / Schedule / Scope) with its devices, and compare
+// rule sets between two customers. Read-only.
+import { z } from 'zod';
+import { McpContext, ToolResponse } from '../context';
+import { resolveCustomer, CustomerRef } from './customers';
+import { fuzzyMatch, normalize } from '../utils/fuzzyMatch';
+import { DeviceRepository } from '../../repositories/DeviceRepository';
+import { Rule } from '../../domain/entities/Rule';
+
+const RULE_TYPE = ['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE'] as const;
+
+function customerNotFound(query: string): ToolResponse {
+  return {
+    success: false,
+    message: `No customer matches "${query}"`,
+    data: null,
+    summary: `No customer matched "${query}". Use find_customer to resolve it.`,
+  };
+}
+
+/** Device UUIDs a rule scopes (single entityId and/or the entityIds array). */
+function ruleDeviceIds(rule: Rule): string[] {
+  const ids = new Set<string>();
+  if (rule.scope?.entityId) ids.add(rule.scope.entityId);
+  if (rule.scope?.entityIds) for (const id of rule.scope.entityIds) ids.add(id);
+  return [...ids];
+}
+
+// ── facet extractors (the 4 comparison dimensions) ────────────────────────────
+function conditionFacet(rule: Rule): Record<string, unknown> {
+  if (rule.type === 'ALARM_THRESHOLD' && rule.alarmConfig) {
+    const a = rule.alarmConfig;
+    return {
+      metric: a.metric,
+      operator: a.operator,
+      value: a.value,
+      valueHigh: a.valueHigh ?? null,
+      unit: a.unit ?? null,
+      duration: a.duration ?? null,
+      aggregation: a.aggregation ?? null,
+      aggregationWindow: a.aggregationWindow ?? null,
+    };
+  }
+  if (rule.type === 'SLA' && rule.slaConfig) {
+    const s = rule.slaConfig;
+    return { metric: s.metric, target: s.target, unit: s.unit, period: s.period, method: s.calculationMethod };
+  }
+  return {};
+}
+
+function guardFlag(g?: { enabled: boolean }): boolean {
+  return Boolean(g?.enabled);
+}
+
+function behaviorFacet(rule: Rule): Record<string, unknown> {
+  const a = rule.alarmConfig;
+  return {
+    priority: rule.priority,
+    guards: {
+      dedup: guardFlag(a?.dedup),
+      cooldown: guardFlag(a?.cooldown),
+      hysteresisGuard: guardFlag(a?.hysteresisGuard),
+      digest: guardFlag(a?.digest),
+    },
+    escalationLevels: rule.escalationConfig?.levels?.length ?? 0,
+    channels: (rule.notificationChannels ?? [])
+      .filter((c) => c.enabled)
+      .map((c) => c.type)
+      .sort(),
+  };
+}
+
+function scheduleFacet(rule: Rule): Record<string, unknown> {
+  if (rule.type === 'MAINTENANCE_WINDOW' && rule.maintenanceConfig) {
+    const m = rule.maintenanceConfig;
+    return {
+      recurrence: m.recurrence ?? null,
+      recurrenceDays: (m.recurrenceDays ?? []).slice().sort((x, y) => x - y),
+      timezone: m.timezone,
+    };
+  }
+  const a = rule.alarmConfig;
+  return {
+    startAt: a?.startAt ?? null,
+    endAt: a?.endAt ?? null,
+    daysOfWeek: (a?.daysOfWeek ?? []).slice().sort((x, y) => x - y),
+  };
+}
+
+function scopeFacet(rule: Rule): Record<string, unknown> {
+  return {
+    type: rule.scope?.type ?? null,
+    deviceCount: ruleDeviceIds(rule).length,
+    profiles: (rule.scopeProfiles ?? []).slice().sort(),
+  };
+}
+
+/** Stable JSON for value equality (sorted keys). */
+function canon(value: unknown): string {
+  return JSON.stringify(value, (_k, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.keys(v as Record<string, unknown>)
+          .sort()
+          .reduce((acc, k) => {
+            acc[k] = (v as Record<string, unknown>)[k];
+            return acc;
+          }, {} as Record<string, unknown>)
+      : v,
+  );
+}
+
+function ruleBrief(rule: Rule) {
+  return {
+    name: rule.name,
+    type: rule.type,
+    priority: rule.priority,
+    enabled: rule.enabled,
+    scopeType: rule.scope?.type ?? null,
+    deviceCount: ruleDeviceIds(rule).length,
+  };
+}
+
+async function resolveRule(ctx: McpContext, customerId: string, query: string): Promise<Rule | null> {
+  const rules = await ctx.rules.getByCustomerId(ctx.tenantId, customerId);
+  return fuzzyMatch(query, rules, [(r) => r.name, (r) => r.id]);
+}
+
+// ── list_alarm_rules ──────────────────────────────────────────────────────────
+export const listAlarmRulesSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  type: z.enum(RULE_TYPE).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export async function listAlarmRules(
+  ctx: McpContext,
+  p: z.infer<typeof listAlarmRulesSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+
+  let rules = await ctx.rules.getByCustomerId(ctx.tenantId, c.id);
+  if (p.type) rules = rules.filter((r) => r.type === p.type);
+  if (p.enabled !== undefined) rules = rules.filter((r) => r.enabled === p.enabled);
+
+  const items = rules.map(ruleBrief);
+  const enabled = items.filter((r) => r.enabled).length;
+  return {
+    success: true,
+    message: `${items.length} alarm rule(s) for ${c.name}`,
+    data: { customer: c, rules: items },
+    summary: `${c.name} has ${items.length} alarm rule(s) (${enabled} enabled).`,
+  };
+}
+
+// ── get_alarm_rule ────────────────────────────────────────────────────────────
+export const getAlarmRuleSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  rule: z.string().describe('Rule name (fuzzy)'),
+});
+
+export async function getAlarmRule(
+  ctx: McpContext,
+  p: z.infer<typeof getAlarmRuleSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+  const rule = await resolveRule(ctx, c.id, p.rule);
+  if (!rule) {
+    const rules = await ctx.rules.getByCustomerId(ctx.tenantId, c.id);
+    return {
+      success: false,
+      message: `No rule matches "${p.rule}" for ${c.name}`,
+      data: { available: rules.slice(0, 20).map((r) => r.name) },
+      summary: `No rule matched "${p.rule}" for ${c.name}.`,
+    };
+  }
+
+  const ids = ruleDeviceIds(rule);
+  let devices: { id: string; name: string; serialNumber: string | null }[] = [];
+  if (ids.length) {
+    const repo = new DeviceRepository();
+    const recs = await repo.listByIds(ctx.tenantId, ids);
+    devices = recs.map((d) => ({
+      id: d.id,
+      name: d.displayName || d.name,
+      serialNumber: d.serialNumber ?? null,
+    }));
+  }
+
+  return {
+    success: true,
+    message: `Rule ${rule.name}`,
+    data: {
+      customer: c,
+      name: rule.name,
+      type: rule.type,
+      enabled: rule.enabled,
+      condition: conditionFacet(rule),
+      behavior: behaviorFacet(rule),
+      schedule: scheduleFacet(rule),
+      scope: { ...scopeFacet(rule), devices },
+    },
+    summary: `${rule.name} (${rule.type}, ${rule.enabled ? 'enabled' : 'disabled'}) scopes ${
+      devices.length
+    } device(s) on ${c.name}.`,
+  };
+}
+
+// ── get_rule_devices ──────────────────────────────────────────────────────────
+export const getRuleDevicesSchema = z.object({
+  customer: z.string().describe('Customer name or code (fuzzy)'),
+  rule: z.string().describe('Rule name (fuzzy)'),
+});
+
+export async function getRuleDevices(
+  ctx: McpContext,
+  p: z.infer<typeof getRuleDevicesSchema>,
+): Promise<ToolResponse> {
+  const c = await resolveCustomer(ctx, p.customer);
+  if (!c) return customerNotFound(p.customer);
+  const rule = await resolveRule(ctx, c.id, p.rule);
+  if (!rule) {
+    return {
+      success: false,
+      message: `No rule matches "${p.rule}" for ${c.name}`,
+      data: null,
+      summary: `No rule matched "${p.rule}" for ${c.name}.`,
+    };
+  }
+
+  const ids = ruleDeviceIds(rule);
+  const repo = new DeviceRepository();
+  const recs = ids.length ? await repo.listByIds(ctx.tenantId, ids) : [];
+  const devices = recs.map((d) => ({
+    name: d.displayName || d.name,
+    serialNumber: d.serialNumber ?? null,
+    code: d.code ?? null,
+  }));
+
+  return {
+    success: true,
+    message: `${devices.length} device(s) in rule ${rule.name}`,
+    data: { rule: rule.name, scopeType: rule.scope?.type ?? null, devices },
+    summary: `Rule "${rule.name}" (${c.name}) applies to ${devices.length} device(s)${
+      rule.scopeProfiles?.length ? `, profiles: ${rule.scopeProfiles.join(', ')}` : ''
+    }.`,
+  };
+}
+
+// ── compare_alarm_rules ───────────────────────────────────────────────────────
+export const compareAlarmRulesSchema = z.object({
+  customerA: z.string().describe('First customer name or code (fuzzy)'),
+  customerB: z.string().describe('Second customer name or code (fuzzy)'),
+});
+
+const FACETS = ['condition', 'behavior', 'schedule', 'scope'] as const;
+function facetsOf(rule: Rule) {
+  return {
+    condition: conditionFacet(rule),
+    behavior: behaviorFacet(rule),
+    schedule: scheduleFacet(rule),
+    scope: scopeFacet(rule),
+  };
+}
+
+export async function compareAlarmRules(
+  ctx: McpContext,
+  p: z.infer<typeof compareAlarmRulesSchema>,
+): Promise<ToolResponse> {
+  const [a, b] = await Promise.all([
+    resolveCustomer(ctx, p.customerA),
+    resolveCustomer(ctx, p.customerB),
+  ]);
+  if (!a) return customerNotFound(p.customerA);
+  if (!b) return customerNotFound(p.customerB);
+
+  const [rulesA, rulesB] = await Promise.all([
+    ctx.rules.getByCustomerId(ctx.tenantId, a.id),
+    ctx.rules.getByCustomerId(ctx.tenantId, b.id),
+  ]);
+
+  // Match rules across customers by normalized name.
+  const indexB = new Map(rulesB.map((r) => [normalize(r.name), r]));
+  const matchedNamesB = new Set<string>();
+  const matched: Array<Record<string, unknown>> = [];
+
+  for (const ra of rulesA) {
+    const rb = indexB.get(normalize(ra.name));
+    if (!rb) continue;
+    matchedNamesB.add(normalize(rb.name));
+    const fa = facetsOf(ra);
+    const fb = facetsOf(rb);
+    const diffs = FACETS.filter((f) => canon(fa[f]) !== canon(fb[f]));
+    matched.push({
+      name: ra.name,
+      identical: diffs.length === 0,
+      differs: diffs,
+      a: diffs.length ? Object.fromEntries(diffs.map((f) => [f, fa[f]])) : undefined,
+      b: diffs.length ? Object.fromEntries(diffs.map((f) => [f, fb[f]])) : undefined,
+    });
+  }
+
+  const onlyInA = rulesA
+    .filter((r) => !indexB.has(normalize(r.name)))
+    .map((r) => r.name);
+  const onlyInB = rulesB
+    .filter((r) => !matchedNamesB.has(normalize(r.name)))
+    .map((r) => r.name);
+
+  const identical = matched.filter((m) => m.identical).length;
+  return {
+    success: true,
+    message: `Compared ${a.name} vs ${b.name}`,
+    data: {
+      customerA: a.name,
+      customerB: b.name,
+      counts: { a: rulesA.length, b: rulesB.length, matched: matched.length, identical },
+      matched,
+      onlyInA,
+      onlyInB,
+    },
+    summary: `${a.name} (${rulesA.length}) vs ${b.name} (${rulesB.length}): ${matched.length} same-named rule(s), ${identical} identical across condition/behavior/schedule/scope; ${onlyInA.length} only in ${a.name}, ${onlyInB.length} only in ${b.name}.`,
+  };
+}

--- a/src/mcp/tools/technicians.ts
+++ b/src/mcp/tools/technicians.ts
@@ -1,0 +1,168 @@
+// RFC-0042/0043 — technician tools. Resolve a person (the responsible
+// technician of a work order = workOrders.assignedTo) by fuzzy name/email and
+// list their work orders. Read-only.
+import { z } from 'zod';
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { McpContext, ToolResponse } from '../context';
+import { fuzzyMatch } from '../utils/fuzzyMatch';
+import { customerRoster } from './customers';
+
+export interface TechnicianRef {
+  id: string;
+  name: string;
+  email: string | null;
+  assignedCount: number;
+}
+
+interface ProfileName {
+  displayName?: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+function userDisplayName(profile: unknown, username: string | null, email: string): string {
+  const p = (profile ?? {}) as ProfileName;
+  const full = [p.firstName, p.lastName].filter(Boolean).join(' ').trim();
+  return p.displayName || full || username || email || 'Sem nome';
+}
+
+/**
+ * The set of people who appear as work-order responsibles (assignedTo) or event
+ * actors in this tenant — i.e. the technicians the data actually knows about.
+ */
+export async function technicianRoster(ctx: McpContext): Promise<TechnicianRef[]> {
+  const { workOrders, workOrdersEvents, users } = ctx.schema;
+
+  const [assignedRows, actorRows] = await Promise.all([
+    ctx.db
+      .select({ id: workOrders.assignedTo, count: sql<number>`count(*)::int` })
+      .from(workOrders)
+      .where(and(eq(workOrders.tenantId, ctx.tenantId), isNotNull(workOrders.assignedTo)))
+      .groupBy(workOrders.assignedTo),
+    ctx.db
+      .selectDistinct({ id: workOrdersEvents.actorUserId })
+      .from(workOrdersEvents)
+      .where(
+        and(eq(workOrdersEvents.tenantId, ctx.tenantId), isNotNull(workOrdersEvents.actorUserId)),
+      ),
+  ]);
+
+  const counts = new Map<string, number>();
+  for (const r of assignedRows) if (r.id) counts.set(r.id as string, r.count ?? 0);
+  const ids = new Set<string>([...counts.keys()]);
+  for (const r of actorRows) if (r.id) ids.add(r.id as string);
+  if (ids.size === 0) return [];
+
+  const rows = await ctx.db
+    .select({
+      id: users.id,
+      email: users.email,
+      username: users.username,
+      profile: users.profile,
+    })
+    .from(users)
+    .where(and(eq(users.tenantId, ctx.tenantId), inArray(users.id, [...ids])));
+
+  return rows.map((u) => ({
+    id: u.id,
+    name: userDisplayName(u.profile, u.username, u.email),
+    email: u.email ?? null,
+    assignedCount: counts.get(u.id) ?? 0,
+  }));
+}
+
+export async function resolveTechnician(
+  ctx: McpContext,
+  query: string,
+): Promise<TechnicianRef | null> {
+  const roster = await technicianRoster(ctx);
+  return fuzzyMatch(query, roster, [(t) => t.name, (t) => t.email, (t) => t.id]);
+}
+
+// ── find_technician ─────────────────────────────────────────────────────────────
+export const findTechnicianSchema = z.object({
+  name: z.string().describe('Technician name or email (fuzzy, typo-tolerant)'),
+});
+
+export async function findTechnician(
+  ctx: McpContext,
+  p: z.infer<typeof findTechnicianSchema>,
+): Promise<ToolResponse> {
+  const t = await resolveTechnician(ctx, p.name);
+  if (!t) {
+    const roster = await technicianRoster(ctx);
+    return {
+      success: false,
+      message: `No technician matches "${p.name}"`,
+      data: { available: roster.slice(0, 20).map((r) => r.name) },
+      summary: `No technician matched "${p.name}". Known technicians: ${roster
+        .slice(0, 10)
+        .map((r) => r.name)
+        .join(', ')}.`,
+    };
+  }
+  return {
+    success: true,
+    message: `Technician ${t.name}`,
+    data: t,
+    summary: `${t.name} is responsible for ${t.assignedCount} work order(s).`,
+  };
+}
+
+// ── list_technician_work_orders ───────────────────────────────────────────────
+const STATUS = [
+  'PLANEJADA',
+  'EM_ANDAMENTO',
+  'INTERROMPIDA',
+  'AGUARDANDO',
+  'REAGENDADA',
+  'FINALIZADA',
+  'CANCELADA',
+] as const;
+
+export const listTechnicianWorkOrdersSchema = z.object({
+  technician: z.string().describe('Technician name or email (fuzzy)'),
+  status: z.enum(STATUS).optional(),
+});
+
+export async function listTechnicianWorkOrders(
+  ctx: McpContext,
+  p: z.infer<typeof listTechnicianWorkOrdersSchema>,
+): Promise<ToolResponse> {
+  const t = await resolveTechnician(ctx, p.technician);
+  if (!t) {
+    return {
+      success: false,
+      message: `No technician matches "${p.technician}"`,
+      data: null,
+      summary: `No technician matched "${p.technician}". Use find_technician to resolve it.`,
+    };
+  }
+
+  const res = await ctx.workOrders.list(ctx.tenantId, {
+    assignedTo: t.id,
+    status: p.status,
+    limit: 100,
+    sort: 'scheduledAt_asc',
+  });
+
+  const roster = await customerRoster(ctx);
+  const customerName = new Map(roster.map((c) => [c.id, c.name]));
+
+  const items = res.items.map((wo) => ({
+    code: wo.code,
+    type: wo.type,
+    status: wo.status,
+    customer: customerName.get(wo.customerId) ?? null,
+    scheduledAt: wo.scheduledAt,
+  }));
+
+  return {
+    success: true,
+    message: `${items.length} work order(s) for ${t.name}`,
+    data: { technician: { id: t.id, name: t.name }, workOrders: items },
+    summary: `${t.name} is responsible for ${
+      res.pagination.total ?? items.length
+    } work order(s)${p.status ? ` with status ${p.status}` : ''}.`,
+  };
+}

--- a/src/services/assistant/AssistantService.ts
+++ b/src/services/assistant/AssistantService.ts
@@ -1,0 +1,112 @@
+// RFC-0043 — GCDR Copiloto. Runs an Anthropic tool-use loop bound to the
+// read-only tool registry, scoped to the caller's tenant. Transport-agnostic
+// (the HTTP controller is the only caller today).
+import Anthropic from '@anthropic-ai/sdk';
+import { makeContext } from '../../mcp/context';
+import { ASSISTANT_TOOLS, toolByName } from './registry';
+import { AppError } from '../../shared/errors/AppError';
+
+const MODEL = process.env.ASSISTANT_MODEL || 'claude-sonnet-4-6';
+const MAX_STEPS = 6;
+
+const SYSTEM = `You are the GCDR Copiloto, a read-only assistant inside the MYIO GCDR platform.
+You help operations staff understand customers, work orders (OS), devices, maintenance and installation progress.
+- Use the provided tools to fetch real data; never invent numbers, codes or names.
+- All tools are already scoped to the current tenant; you cannot see other tenants' data.
+- You are READ-ONLY: you cannot create, edit, schedule or cancel anything. If asked, explain that and point to the relevant screen.
+- Answer in the user's language (Portuguese by default). Be concise; prefer short paragraphs and small lists.
+- When you cite a work order, use its code (e.g. OS-ABC1D2). When data is missing, say so plainly.`;
+
+export interface AssistantMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AssistantResult {
+  answer: string;
+  toolCalls: string[];
+}
+
+export function isAssistantConfigured(): boolean {
+  return Boolean(process.env.ANTHROPIC_API_KEY);
+}
+
+export async function runAssistant(
+  tenantId: string,
+  message: string,
+  history: AssistantMessage[] = [],
+): Promise<AssistantResult> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new AppError(
+      'ASSISTANT_NOT_CONFIGURED',
+      'Assistant is not configured (ANTHROPIC_API_KEY missing).',
+      503,
+    );
+  }
+
+  const client = new Anthropic({ apiKey });
+  const ctx = makeContext(tenantId);
+  const tools: Anthropic.Tool[] = ASSISTANT_TOOLS.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+  }));
+
+  const messages: Anthropic.MessageParam[] = [
+    ...history.map((h) => ({ role: h.role, content: h.content })),
+    { role: 'user', content: message },
+  ];
+
+  const toolCalls: string[] = [];
+
+  for (let step = 0; step < MAX_STEPS; step++) {
+    const resp = await client.messages.create({
+      model: MODEL,
+      max_tokens: 1500,
+      system: SYSTEM,
+      tools,
+      messages,
+    });
+
+    if (resp.stop_reason === 'tool_use') {
+      messages.push({ role: 'assistant', content: resp.content });
+      const results: Anthropic.ToolResultBlockParam[] = [];
+      for (const block of resp.content) {
+        if (block.type !== 'tool_use') continue;
+        toolCalls.push(block.name);
+        const tool = toolByName.get(block.name);
+        let output: unknown;
+        try {
+          output = tool
+            ? await tool.run(ctx, block.input)
+            : { success: false, message: `Unknown tool: ${block.name}` };
+        } catch (err) {
+          output = {
+            success: false,
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
+        results.push({
+          type: 'tool_result',
+          tool_use_id: block.id,
+          content: JSON.stringify(output),
+        });
+      }
+      messages.push({ role: 'user', content: results });
+      continue;
+    }
+
+    const answer = resp.content
+      .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n')
+      .trim();
+    return { answer, toolCalls };
+  }
+
+  return {
+    answer: 'Não consegui concluir a resposta (muitos passos de consulta). Tente reformular a pergunta.',
+    toolCalls,
+  };
+}

--- a/src/services/assistant/AssistantService.ts
+++ b/src/services/assistant/AssistantService.ts
@@ -47,11 +47,24 @@ export async function runAssistant(
 
   const client = new Anthropic({ apiKey });
   const ctx = makeContext(tenantId);
-  const tools: Anthropic.Tool[] = ASSISTANT_TOOLS.map((t) => ({
+
+  // Prompt caching (5-min ephemeral): the tools + system prefix is identical on
+  // every call, so cache it. Within one ask the tool-use loop re-sends it up to
+  // MAX_STEPS times, and quick follow-ups reuse it too — cache reads cost 0.1x.
+  // Breakpoints MUST sit on stable content (no per-request data here). Order is
+  // tools -> system -> messages, so a breakpoint on the last tool + on system
+  // covers the whole static prefix.
+  const tools: Anthropic.Tool[] = ASSISTANT_TOOLS.map((t, i) => ({
     name: t.name,
     description: t.description,
     input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+    ...(i === ASSISTANT_TOOLS.length - 1
+      ? { cache_control: { type: 'ephemeral' as const } }
+      : {}),
   }));
+  const system: Anthropic.TextBlockParam[] = [
+    { type: 'text', text: SYSTEM, cache_control: { type: 'ephemeral' } },
+  ];
 
   const messages: Anthropic.MessageParam[] = [
     ...history.map((h) => ({ role: h.role, content: h.content })),
@@ -64,7 +77,7 @@ export async function runAssistant(
     const resp = await client.messages.create({
       model: MODEL,
       max_tokens: 1500,
-      system: SYSTEM,
+      system,
       tools,
       messages,
     });

--- a/src/services/assistant/AssistantService.ts
+++ b/src/services/assistant/AssistantService.ts
@@ -10,7 +10,7 @@ const MODEL = process.env.ASSISTANT_MODEL || 'claude-sonnet-4-6';
 const MAX_STEPS = 6;
 
 const SYSTEM = `You are the GCDR Copiloto, a read-only assistant inside the MYIO GCDR platform.
-You help operations staff understand customers, work orders (OS), devices, maintenance and installation progress.
+You help operations staff understand customers, work orders (OS), devices, maintenance, installation progress and alarm rules.
 - Use the provided tools to fetch real data; never invent numbers, codes or names.
 - All tools are already scoped to the current tenant; you cannot see other tenants' data.
 - You are READ-ONLY: you cannot create, edit, schedule or cancel anything. If asked, explain that and point to the relevant screen.

--- a/src/services/assistant/conversationStore.ts
+++ b/src/services/assistant/conversationStore.ts
@@ -1,0 +1,153 @@
+// RFC-0043 — persistence for the GCDR Copiloto chat history.
+// A conversation is private to its owner unless `shared` = true, when other
+// users in the tenant can read it (read-only). Owner-only edit/delete.
+import { and, desc, eq, inArray, ne, or } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+import { NotFoundError } from '../../shared/errors/AppError';
+
+export interface ConversationTurn {
+  role: 'user' | 'assistant';
+  content: string;
+  tools?: string[];
+}
+
+export interface ConversationInput {
+  title?: string;
+  messages: ConversationTurn[];
+  shared?: boolean;
+}
+
+export type ConversationScope = 'mine' | 'shared' | 'all';
+
+const { assistantConversations: T, users } = schema;
+
+interface ProfileName {
+  displayName?: string;
+  firstName?: string;
+  lastName?: string;
+}
+function ownerName(profile: unknown, email: string | null): string {
+  const p = (profile ?? {}) as ProfileName;
+  return (
+    p.displayName ||
+    [p.firstName, p.lastName].filter(Boolean).join(' ').trim() ||
+    email ||
+    'Usuário'
+  );
+}
+
+function brief(row: typeof T.$inferSelect, myUserId: string) {
+  const msgs = Array.isArray(row.messages) ? (row.messages as ConversationTurn[]) : [];
+  return {
+    id: row.id,
+    title: row.title,
+    shared: row.shared,
+    isOwner: row.userId === myUserId,
+    ownerId: row.userId,
+    messageCount: msgs.length,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** List own conversations and/or those shared by other users in the tenant. */
+export async function listConversations(
+  tenantId: string,
+  userId: string,
+  scope: ConversationScope = 'all',
+) {
+  const mine = and(eq(T.tenantId, tenantId), eq(T.userId, userId));
+  const sharedByOthers = and(
+    eq(T.tenantId, tenantId),
+    eq(T.shared, true),
+    ne(T.userId, userId),
+  );
+  const where =
+    scope === 'mine' ? mine : scope === 'shared' ? sharedByOthers : or(mine, sharedByOthers);
+
+  const rows = await db.select().from(T).where(where).orderBy(desc(T.updatedAt)).limit(100);
+
+  // Resolve owner names for conversations not owned by the caller.
+  const otherOwnerIds = [...new Set(rows.filter((r) => r.userId !== userId).map((r) => r.userId))];
+  const nameById = new Map<string, string>();
+  if (otherOwnerIds.length) {
+    const us = await db
+      .select({ id: users.id, email: users.email, profile: users.profile })
+      .from(users)
+      .where(and(eq(users.tenantId, tenantId), inArray(users.id, otherOwnerIds)));
+    for (const u of us) nameById.set(u.id, ownerName(u.profile, u.email));
+  }
+
+  return rows.map((r) => ({
+    ...brief(r, userId),
+    ownerName: r.userId === userId ? null : nameById.get(r.userId) ?? 'Usuário',
+  }));
+}
+
+/** Get one conversation if owned by the caller or shared. Throws if not. */
+export async function getConversation(tenantId: string, userId: string, id: string) {
+  const [row] = await db
+    .select()
+    .from(T)
+    .where(and(eq(T.tenantId, tenantId), eq(T.id, id)))
+    .limit(1);
+  if (!row || (row.userId !== userId && !row.shared)) {
+    throw new NotFoundError('Conversation not found');
+  }
+  return {
+    ...brief(row, userId),
+    messages: (Array.isArray(row.messages) ? row.messages : []) as ConversationTurn[],
+  };
+}
+
+export async function createConversation(
+  tenantId: string,
+  userId: string,
+  input: ConversationInput,
+) {
+  const [row] = await db
+    .insert(T)
+    .values({
+      tenantId,
+      userId,
+      title: input.title?.slice(0, 200) || 'Conversa',
+      messages: input.messages,
+      shared: input.shared ?? false,
+    })
+    .returning();
+  return getConversation(tenantId, userId, row.id);
+}
+
+/** Update title/messages/shared. Owner only. */
+export async function updateConversation(
+  tenantId: string,
+  userId: string,
+  id: string,
+  patch: Partial<ConversationInput>,
+) {
+  const [owned] = await db
+    .select({ id: T.id })
+    .from(T)
+    .where(and(eq(T.tenantId, tenantId), eq(T.id, id), eq(T.userId, userId)))
+    .limit(1);
+  if (!owned) throw new NotFoundError('Conversation not found');
+
+  await db
+    .update(T)
+    .set({
+      ...(patch.title !== undefined ? { title: patch.title.slice(0, 200) || 'Conversa' } : {}),
+      ...(patch.messages !== undefined ? { messages: patch.messages } : {}),
+      ...(patch.shared !== undefined ? { shared: patch.shared } : {}),
+      updatedAt: new Date(),
+    })
+    .where(and(eq(T.tenantId, tenantId), eq(T.id, id)));
+  return getConversation(tenantId, userId, id);
+}
+
+/** Delete a conversation. Owner only. */
+export async function deleteConversation(tenantId: string, userId: string, id: string) {
+  const res = await db
+    .delete(T)
+    .where(and(eq(T.tenantId, tenantId), eq(T.id, id), eq(T.userId, userId)))
+    .returning({ id: T.id });
+  if (!res.length) throw new NotFoundError('Conversation not found');
+}

--- a/src/services/assistant/registry.ts
+++ b/src/services/assistant/registry.ts
@@ -9,6 +9,7 @@ import * as devices from '../../mcp/tools/devices';
 import * as maintenance from '../../mcp/tools/maintenance';
 import * as analytics from '../../mcp/tools/analytics';
 import * as technicians from '../../mcp/tools/technicians';
+import * as rules from '../../mcp/tools/rules';
 
 export interface AssistantTool {
   name: string;
@@ -102,6 +103,39 @@ export const ASSISTANT_TOOLS: AssistantTool[] = [
     description: 'Maintenance (MANUTENCAO) work orders, optionally by customer/status.',
     inputSchema: obj({ customer: { type: 'string' }, status: { type: 'string' } }),
     run: (ctx, a) => maintenance.getMaintenance(ctx, maintenance.getMaintenanceSchema.parse(a)),
+  },
+  // ── Alarm Rules (/rules) ────────────────────────────────────────────────
+  {
+    name: 'list_alarm_rules',
+    description: 'List a customer alarm rules (name, type, priority, enabled, scope, device count).',
+    inputSchema: obj(
+      { customer: { type: 'string' }, type: { type: 'string' }, enabled: { type: 'boolean' } },
+      ['customer'],
+    ),
+    run: (ctx, a) => rules.listAlarmRules(ctx, rules.listAlarmRulesSchema.parse(a)),
+  },
+  {
+    name: 'get_alarm_rule',
+    description:
+      'A customer alarm rule in detail: Condition, Behavior (guards/escalation/channels), Schedule and Scope (with devices).',
+    inputSchema: obj({ customer: { type: 'string' }, rule: { type: 'string' } }, ['customer', 'rule']),
+    run: (ctx, a) => rules.getAlarmRule(ctx, rules.getAlarmRuleSchema.parse(a)),
+  },
+  {
+    name: 'get_rule_devices',
+    description: 'The devices a given alarm rule applies to (scope).',
+    inputSchema: obj({ customer: { type: 'string' }, rule: { type: 'string' } }, ['customer', 'rule']),
+    run: (ctx, a) => rules.getRuleDevices(ctx, rules.getRuleDevicesSchema.parse(a)),
+  },
+  {
+    name: 'compare_alarm_rules',
+    description:
+      'Compare two customers alarm rule sets: same-named rules and whether Condition, Behavior, Schedule and Scope match, plus rules unique to each.',
+    inputSchema: obj(
+      { customerA: { type: 'string' }, customerB: { type: 'string' } },
+      ['customerA', 'customerB'],
+    ),
+    run: (ctx, a) => rules.compareAlarmRules(ctx, rules.compareAlarmRulesSchema.parse(a)),
   },
   {
     name: 'get_progress',

--- a/src/services/assistant/registry.ts
+++ b/src/services/assistant/registry.ts
@@ -8,6 +8,7 @@ import * as wo from '../../mcp/tools/workOrders';
 import * as devices from '../../mcp/tools/devices';
 import * as maintenance from '../../mcp/tools/maintenance';
 import * as analytics from '../../mcp/tools/analytics';
+import * as technicians from '../../mcp/tools/technicians';
 
 export interface AssistantTool {
   name: string;
@@ -51,6 +52,23 @@ export const ASSISTANT_TOOLS: AssistantTool[] = [
       ['customer'],
     ),
     run: (ctx, a) => wo.listWorkOrders(ctx, wo.listWorkOrdersSchema.parse(a)),
+  },
+  {
+    name: 'find_technician',
+    description: 'Resolve a technician (the responsible person of work orders) by fuzzy name or email.',
+    inputSchema: obj({ name: { type: 'string', description: 'Technician name or email' } }, ['name']),
+    run: (ctx, a) => technicians.findTechnician(ctx, technicians.findTechnicianSchema.parse(a)),
+  },
+  {
+    name: 'list_technician_work_orders',
+    description:
+      'List the work orders a technician is responsible for (assignedTo), optionally by status. Use this to answer "which OS belong to <person>".',
+    inputSchema: obj(
+      { technician: { type: 'string' }, status: { type: 'string' } },
+      ['technician'],
+    ),
+    run: (ctx, a) =>
+      technicians.listTechnicianWorkOrders(ctx, technicians.listTechnicianWorkOrdersSchema.parse(a)),
   },
   {
     name: 'get_work_order',

--- a/src/services/assistant/registry.ts
+++ b/src/services/assistant/registry.ts
@@ -1,0 +1,121 @@
+// RFC-0043 — GCDR Copiloto tool registry.
+// Domain-agnostic: each entry adapts a read-only tool for the LLM (JSON schema
+// for Anthropic + a zod-validated runner). Seeded with the Work Orders tools
+// (RFC-0042); add tools from other domains here as they come.
+import { McpContext } from '../../mcp/context';
+import * as customers from '../../mcp/tools/customers';
+import * as wo from '../../mcp/tools/workOrders';
+import * as devices from '../../mcp/tools/devices';
+import * as maintenance from '../../mcp/tools/maintenance';
+import * as analytics from '../../mcp/tools/analytics';
+
+export interface AssistantTool {
+  name: string;
+  description: string;
+  /** JSON Schema for the Anthropic tool definition. */
+  inputSchema: Record<string, unknown>;
+  /** Parse + run; returns the tool result object (serialized to the model). */
+  run: (ctx: McpContext, args: unknown) => Promise<unknown>;
+}
+
+const obj = (properties: Record<string, unknown>, required: string[] = []) => ({
+  type: 'object',
+  properties,
+  required,
+});
+
+export const ASSISTANT_TOOLS: AssistantTool[] = [
+  // ── Work Orders (RFC-0042) ──────────────────────────────────────────────
+  {
+    name: 'list_customers',
+    description: 'List OS-enabled customers with their work-order counts by status.',
+    inputSchema: obj({}),
+    run: (ctx) => customers.listCustomers(ctx),
+  },
+  {
+    name: 'find_customer',
+    description: 'Resolve a customer by fuzzy name or code (typo-tolerant).',
+    inputSchema: obj({ name: { type: 'string', description: 'Customer name or code' } }, ['name']),
+    run: (ctx, a) => customers.findCustomer(ctx, customers.findCustomerSchema.parse(a)),
+  },
+  {
+    name: 'list_work_orders',
+    description: 'List a customer work orders, optionally filtered by status and type.',
+    inputSchema: obj(
+      {
+        customer: { type: 'string' },
+        status: { type: 'string' },
+        type: { type: 'string' },
+        limit: { type: 'number' },
+      },
+      ['customer'],
+    ),
+    run: (ctx, a) => wo.listWorkOrders(ctx, wo.listWorkOrdersSchema.parse(a)),
+  },
+  {
+    name: 'get_work_order',
+    description: 'Full work order by code: type, status, device scope and recent timeline.',
+    inputSchema: obj({ code: { type: 'string' } }, ['code']),
+    run: (ctx, a) => wo.getWorkOrder(ctx, wo.getWorkOrderSchema.parse(a)),
+  },
+  {
+    name: 'get_transitions',
+    description: 'Rules engine (RFC-0041): which events can/cannot be appended next and why.',
+    inputSchema: obj({ code: { type: 'string' } }, ['code']),
+    run: (ctx, a) => wo.getTransitions(ctx, wo.getTransitionsSchema.parse(a)),
+  },
+  {
+    name: 'get_devices',
+    description: 'Devices in a customer work-order scope, filterable by install state.',
+    inputSchema: obj(
+      { customer: { type: 'string' }, filter: { type: 'string', enum: ['all', 'installed', 'pending'] } },
+      ['customer'],
+    ),
+    run: (ctx, a) => devices.getDevices(ctx, devices.getDevicesSchema.parse(a)),
+  },
+  {
+    name: 'get_device_details',
+    description: 'A device (fuzzy by name/serial/code) with its event history.',
+    inputSchema: obj({ customer: { type: 'string' }, device: { type: 'string' } }, ['customer', 'device']),
+    run: (ctx, a) => devices.getDeviceDetails(ctx, devices.getDeviceDetailsSchema.parse(a)),
+  },
+  {
+    name: 'get_maintenance',
+    description: 'Maintenance (MANUTENCAO) work orders, optionally by customer/status.',
+    inputSchema: obj({ customer: { type: 'string' }, status: { type: 'string' } }),
+    run: (ctx, a) => maintenance.getMaintenance(ctx, maintenance.getMaintenanceSchema.parse(a)),
+  },
+  {
+    name: 'get_progress',
+    description: 'Installation progress % for a customer or tenant-wide.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+    run: (ctx, a) => analytics.getProgress(ctx, analytics.getProgressSchema.parse(a)),
+  },
+  {
+    name: 'get_average_time',
+    description: 'Average installation time (gap model) for a customer or tenant-wide.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+    run: (ctx, a) => analytics.getAverageTime(ctx, analytics.getAverageTimeSchema.parse(a)),
+  },
+  {
+    name: 'get_technician_performance',
+    description: 'Technician ranking by installs with total/average time.',
+    inputSchema: obj({ customer: { type: 'string' } }),
+    run: (ctx, a) =>
+      analytics.getTechnicianPerformance(ctx, analytics.getTechnicianPerformanceSchema.parse(a)),
+  },
+  {
+    name: 'get_activity_log',
+    description: 'Recent work-order events (timeline feed).',
+    inputSchema: obj({ customer: { type: 'string' }, limit: { type: 'number' } }),
+    run: (ctx, a) => analytics.getActivityLog(ctx, analytics.getActivityLogSchema.parse(a)),
+  },
+  {
+    name: 'get_daily_summary',
+    description: "Today's installs and the open work-order backlog.",
+    inputSchema: obj({ customer: { type: 'string' } }),
+    run: (ctx, a) => analytics.getDailySummary(ctx, analytics.getDailySummarySchema.parse(a)),
+  },
+];
+
+export const toolByName = new Map(ASSISTANT_TOOLS.map((t) => [t.name, t]));


### PR DESCRIPTION
@
## What

POC of the **GCDR Copiloto** (RFC-0043 Option A): a read-only LLM assistant over the platform tools, scoped to the caller tenant. Backend half.

### Endpoints
- `POST /assistant` (ask) and `GET /assistant/status` (is it configured), behind `authMiddleware`. Tenant comes from the JWT, never the body.

### Architecture
- `src/services/assistant/registry.ts` - domain-agnostic tool registry.
- `src/services/assistant/AssistantService.ts` - Anthropic tool-use loop via `makeContext(tenantId)`; read-only.
- `makeContext()` added to `src/mcp/context.ts` (tenant by param, no env). `ruleService` wired into the context.

### Tools wired
- Work Orders (13, from RFC-0042).
- Technicians: `find_technician`, `list_technician_work_orders` (OS by responsible, via `workOrders.assignedTo`).
- Alarm rules: `list_alarm_rules`, `get_alarm_rule` (Condition/Behavior/Schedule/Scope + devices), `get_rule_devices`, `compare_alarm_rules` (same-named rules across two customers + per-facet diffs).

## Config
- `ANTHROPIC_API_KEY` (required to enable) + optional `ASSISTANT_MODEL` (default `claude-sonnet-4-6`). If unset, `POST /assistant` returns 503 and the UI degrades gracefully. Added to `.env.example`.
- Adds `@anthropic-ai/sdk` (`npm install` needed). No migrations, no seeds.

## Pairs with
The frontend widget PR in `gcdr-frontend` (`feat/gcdr-assistant`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@