### PR TITLE
RFC-0046: Customer Consumption Goals (backend)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+  // Live debugging for the GCDR API.
+  //
+  // 1) Run the dev server with the inspector on:  npm run dev:debug
+  //    (hot-reload via tsx watch + Node inspector on 127.0.0.1:9229)
+  // 2) Then start "Attach to GCDR API (dev:debug)" here, set breakpoints,
+  //    hit an endpoint — execution stops at your breakpoints, live.
+  //
+  // Use "Launch GCDR API (dev:debug)" to start + attach in one step instead.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to GCDR API (dev:debug)",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch GCDR API (dev:debug)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev:debug"],
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true
+    }
+  ]
+}

--- a/docs/RFC-0046-Customer-Consumption-Goals-feedback-v2.md
+++ b/docs/RFC-0046-Customer-Consumption-Goals-feedback-v2.md
@@ -1,0 +1,187 @@
+# RFC-0046 — Customer Consumption Goals · Review Feedback v2
+
+- **Reviews of:** `docs/RFC-0046-Customer-Consumption-Goals.md`
+- **Supersedes:** `docs/RFC-0046-Customer-Consumption-Goals-feedback.md` (v1) — see "What changed since v1".
+- **Date:** 2026-06-18
+- **Format:** BMAD party-mode roundtable, **round 2** — agents reacting to the author's written answers on the v1 feedback.
+- **Reviewers:** 🏗️ Winston (System Architect) · 📋 John (Product Manager) · 🎨 Sally (UX Designer) · 💻 Amelia (Senior Software Engineer)
+
+---
+
+## Headline: the design pivoted
+
+The author's answers changed three load-bearing assumptions, and the panel **unanimously reversed the v1 storage recommendation**:
+
+1. **HOUR is required NOW** (not deferred): the client wants goals analysed by hour, plus a change history; "model the DB for the worst case". Hour = up to 8,760 buckets/year/entity.
+2. **Per-asset goals are OUT of scope.**
+3. **The DOMAIN owns the schema**, not the `GoalsPanel` — so byte-for-byte mirroring of the panel JSON is no longer a constraint.
+
+Consequence: **the v1 "JSONB envelope, defer hour" is withdrawn. v2 recommends a NORMALISED model.** The author's own intuition was correct — normalising resolves the same-envelope month-collision concurrency raised in v1.
+
+---
+
+## Endorsed direction (v2 consensus)
+
+- **Normalised storage:** one row per **leaf** bucket (the finest level actually filled on each branch); coarser levels are **not stored** — they are computed on read.
+- **Granularity is a MIXED TREE per year:** within one year, some months may be hourly, others daily, others monthly — they coexist as distinct rows, no conflict.
+- **Aggregation method is per-DOMAIN, stored, not per-row:** `SUM` for `ENERGY`/`WATER`, `AVERAGE` for `TEMPERATURE`. `total = 25` on a temperature goal reads as "25 °C".
+- **History → its own append-only table;** `?fetchHistory=true` returns ≤100 entries, newest first.
+- **No per-asset:** the goal key is `(customer, domain, time-bucket)`. This **dissolves the v1 "asset key" question (B-2)**.
+
+---
+
+## Proposed data model (normalised)
+
+### `consumption_goals` — leaf values only
+```
+id           uuid PK
+tenant_id    uuid
+customer_id  uuid
+domain       text         -- ENERGY | WATER | TEMPERATURE
+year         smallint
+month        smallint NULL -- NULL ⇒ leaf is the year
+day          smallint NULL -- NULL ⇒ leaf is the month
+hour         smallint NULL -- NULL ⇒ leaf is the day
+value        numeric
+updated_by   uuid
+updated_at   timestamptz
+UNIQUE (tenant_id, customer_id, domain, year, month, day, hour)
+```
+Leaf granularity is **implicit by the deepest non-null level**: `(2026,–,–,–)`=year; `(2026,3,–,–)`=March; `(2026,3,15,9)`=09:00 on Mar-15. (Amelia's variant uses an explicit `granularity` enum + a `bucket_key` text — same idea, more explicit; pick one at implementation.)
+
+**Coexistence invariant:** a branch may not hold both a coarse leaf and a finer leaf. Detailing March into days **deletes** the March month-leaf (it becomes computed); collapsing March back deletes its day/hour children. This is **transactional service logic**, not a SQL constraint.
+
+### `consumption_goal_domains` — aggregation config (per domain)
+```
+tenant_id          uuid
+domain             text
+aggregation_method text   -- SUM | AVERAGE
+unit               text   -- kWh | m³ | °C
+PK (tenant_id, domain)
+```
+Keep the method on the **domain**, not on each value row, to prevent "one hour SUM, another AVERAGE" inconsistency. (Amelia would also persist a denormalised `value_type` on the value row for read stability — acceptable as a derived copy.)
+
+### `consumption_goal_history` — append-only audit
+```
+id, tenant_id, customer_id, domain,
+year/month/day/hour (or granularity + bucket_key)  -- which bucket changed
+old_value numeric NULL, new_value numeric NULL,
+action text (CREATE|UPDATE|DELETE),
+changed_by uuid, changed_at timestamptz
+INDEX (tenant_id, customer_id, changed_at DESC)
+```
+`?fetchHistory=true` → `ORDER BY changed_at DESC LIMIT 100`.
+
+---
+
+## Granularity precedence — the UX state machine (🎨 Sally)
+
+**Golden rule for the screen:** *"the finest level you filled wins; everything above it becomes a reflection."*
+
+Each node has exactly **two states** — a node is CALCULATED **iff** at least one descendant is detailed; there is no third state:
+
+| Level | Finest descendant filled? | State | Written by |
+|---|---|---|---|
+| Year | none (year is the leaf) | EDITABLE | operator |
+| Year | any month detailed | CALCULATED | system (Σ/x̄ of months) |
+| Month | month is the leaf | EDITABLE | operator |
+| Month | days/hours detailed | CALCULATED | system |
+| Day | day is the leaf | EDITABLE | operator |
+| Day | hours detailed | CALCULATED | system |
+| Hour | always leaf | EDITABLE | operator |
+
+- **Drill (override-down):** the parent becomes CALCULATED; children are born EDITABLE, **pre-seeded** with an even split (e.g. `10000/31`) flagged "suggested" so the calculated parent still equals the prior total (zero surprise). Warning shown **at the moment of drilling**.
+- **Clear (revert-up):** a destructive, honest confirmation ("the 31 daily values will be discarded…"); the parent returns to an EDITABLE field that is **empty with the last computed total as placeholder** (Tab accepts) — it does not pretend the operator already decided.
+- **Editable = pencil icon; calculated = Σ (sum) or x̄ (average) icon + greyed/italic.** One grammar across manual and CSV.
+
+### Mixed-tree visualisation
+- Per-month **granularity badge**: `MONTHLY` (grey) / `DAILY` (blue) / `HOURLY` (purple); `DAILY · 3 hourly days` when mixed inside a month.
+- A 4px coloured left rail per month and a **12-cell year mini-map** (the "establishing shot") so the operator instantly sees which months are hourly vs daily.
+- **Disabled hours** (outside operating window): rendered with hatching and a locked `0` ("not counted"), **not hidden** — hiding triggers "where are the 24 hours?".
+
+### Temperature without lying
+Same state machine; the calculated node uses **x̄ (weighted average)** with an explicit glyph + °C unit and tooltip "weighted average by days (°C does not sum)". A fixed header chip ("Temperature · average" / "Energy · sum") keeps the operator on the right ruler. The glyph makes a sum visibly impossible — the cure for v1's "interface lying".
+
+---
+
+## CSV import — experience, not parse (🎨 Sally, from the author's flow)
+1. **Drop** → "Preview. Nothing is saved until you confirm."
+2. **Dry-run** (split): left = a *ghost* tree of how the year would look (changed badges blink); right = line-by-line diagnostics ("8,380 OK · 32 problems", each citing the exact line; granularity conflicts → "kept HOURLY, finest wins"). **Partial import is explicit** + "download error report (CSV)". Never silent, never all-or-nothing.
+3. **Confirm** in numbers ("3 months become HOURLY, 5 DAILY, 4 stay MONTHLY; 32 lines ignored").
+4. **Full log** — downloadable, auditable; closing it opens straight into the imported tree for tweaking specific hours. CSV is the fast way to seed the same tree the operator edits by hand.
+
+---
+
+## Product — revised scope (📋 John)
+
+- **No longer deferred:** HOUR and DAILY (the client's core need; operator imports a mixed year). TEMPERATURE stays — the per-domain aggregation method removed the blocker.
+- **Still cut:** per-asset (confirmed out). **Still deferred (decision pending):** the *derived* roll-up (the rule that auto-sums hours up to close a month). Not the granularity — the auto-derivation. In the MVP each bucket is stored as entered.
+- **Revised MVP:** goals by **customer × domain (ENERGY/WATER/TEMPERATURE) × time-bucket (HOUR/DAY/MONTH/YEAR)**, with per-domain aggregation method, manual **and** CSV entry, and change history. No per-asset, no derived roll-up (pending decision below).
+- **Schema owner = domain** ✅ — a goal is a business entity (customer+domain+period), not a screen artefact. Caveat: `aggregation_method` is domain metadata, never an operator per-row choice.
+
+### The goals-vs-actuals JOIN contract (plain language — author said "não entendi")
+Two separate things must meet on the dashboard: the **GOAL** (the operator's target number) and the **ACTUAL** (measured device readings). The join contract is simply *which key matches one to the other*. With per-asset gone it has **3 parts**:
+```
+(customer_id, domain, time_bucket)        e.g. 2026-06-01T14:00 / HOUR
+```
+The dashboard aggregates the actual readings (SUM or AVG per the domain) for that customer+domain within the bucket, and looks up the goal with the same `(customer, domain, bucket)`. Two rules or it breaks: **goal granularity = actual bucket granularity**, and **`aggregation_method` belongs to the domain**, not the individual goal.
+
+---
+
+## Engineering — re-issued ACs for the normalised model (💻 Amelia)
+
+What "hour-now" breaks in v1: JSONB write-amplification (rewriting the whole year to edit one hour), per-bucket audit impossible inline, single-row lock contention.
+
+1. **AC-1 (leaf-only):** persist only the finest filled level per branch; coarser never stored as a row.
+2. **AC-2 (rollup on read):** GET returns the tree; YEAR=f(MONTH), MONTH=f(DAY), DAY=f(HOUR) via the domain's method (SUM / AVG). **Computed-on-read** (do not materialise in MVP; add a materialised view only if profiling demands).
+3. **AC-3 (mixed-tree integrity):** detailing a finer child DELETES the ancestor's coarse leaf + logs a DELETE; collapse inverse likewise. Coarse-leaf and fine-leaf never coexist on a branch.
+4. **AC-4 (idempotency):** upsert by the UNIQUE bucket key; identical resend = no-op, no new history row.
+5. **AC-5 (concurrency):** lock per bucket (row), not whole-tree; two users editing different hours of the same day don't block.
+6. **AC-6 (PUT = replace):** `PUT` of (year+domain) deletes buckets absent from that scope; each delete logged.
+7. **AC-7 (PATCH/import = merge):** touches only the buckets sent; absent ones preserved.
+8. **AC-8 (history schema):** every mutation logs (bucket, old→new, changed_by, changed_at, action).
+9. **AC-9 (fetchHistory):** `?fetchHistory=true` → ≤100 entries, `ORDER BY changed_at DESC`; default false.
+10. **AC-10 (temperature AVERAGE):** AVG ignores empty buckets — `DAY = AVG(filled hours)`, not divide-by-24; `total=25` = 25 °C.
+11. **AC-11 (CSV dry-run):** import always dry-run preview (no persist) → confirm → persist; response carries ok/error counts.
+12. **AC-12 (CSV partial+log):** valid lines import; invalid cite line number + reason; full log returned; partial never aborts the batch.
+
+### B-3 explained (PUT replace vs merge — author said "não entendi")
+You `PUT` a payload with 3 months. What happens to the other 9 that already existed and you did **not** send?
+- **REPLACE (full):** the PUT is the absolute truth of the resource — the 9 absent are **deleted**.
+- **MERGE (upsert):** only the 3 sent are written — the 9 absent **stay**.
+- **Recommendation:** `PUT` = replace per (year+domain); `PATCH`/import = merge per bucket. Without this, "I didn't send hour X" is ambiguous between "zero it" and "keep it".
+
+---
+
+## Two decisions the author still owes (both affect the number the client sees)
+
+| # | Decision | Where it surfaced | Note |
+|---|---|---|---|
+| **DEC-1** | **Does the derived roll-up enter the MVP?** When a year has June hourly and July daily, should June *also* appear as a monthly goal (sum of 720 hours)? | John (product) — Amelia already models it as computed-on-read, so it's cheap to include; it's a product/UX call. | "Yes" → roll-up back in MVP. "No, each bucket is independent" → John's cut holds. |
+| **DEC-2** | **Temperature average: average-of-averages or weighted?** Rolling DAY→MONTH→YEAR for temperature — each day weighs equally, or weighted by the filled hours/days? | Amelia + Sally | Both recommend **weighted** (statistically correct), with a tooltip "weighted by days". Changes the displayed number. |
+
+---
+
+## What changed since v1
+
+| Topic | v1 position | v2 position (after author answers) |
+|---|---|---|
+| Storage | JSONB envelope per (customer, domain), mirroring GoalsPanel | **Normalised, leaf-per-bucket rows** (envelope withdrawn) |
+| Hour | Deferred to a separate time-series store | **In scope now**; drives the whole model |
+| Granularity | One per year (month default, optional day) | **Mixed tree** per year; finest-wins, coarser computed |
+| Temperature (B-1) | Sub-shape vs disabled roll-up; likely defer | **Per-domain `aggregation_method` = AVERAGE**; kept in MVP |
+| Asset key (B-2) | Decide `gcdrAssetId` vs TB id (blocking) | **Moot** — per-asset out of scope |
+| Schema owner (D-6) | Open ("domain or screen?") | **Domain** owns the schema |
+| History (D-4) | Inline vs own table (divergent) | **Own append-only table** + `fetchHistory=true` (≤100) |
+| Routing columns (D-5) | Promote `domain`/`year` out of JSONB | **Moot** — normalised model is all columns |
+| Concurrency | Whole-envelope lock; 409→reapply on front | **Per-bucket lock**; collisions largely gone |
+| PUT semantics (B-3) | Undecided (blocking) | **PUT = replace (year+domain); PATCH/import = merge (bucket)** |
+| MVP scope (D-7) | ENERGY+WATER, annual+monthly | **ENERGY+WATER+TEMPERATURE, all granularities incl. HOUR**; no per-asset; derived roll-up pending (DEC-1) |
+
+---
+
+## Still endorsed (carried from v1)
+- Goals-vs-actuals split (GCDR stores targets only); document the join contract (now done above).
+- Optimistic concurrency, `goals:read`/`goals:write` scopes, and a `CUSTOMER_GOALS_UPDATED` audit event.
+
+_Generated from round 2 of a BMAD party-mode review of RFC-0046. Design-only; no implementation implied. Resolve DEC-1 and DEC-2, then the RFC can be rewritten around the normalised model._

--- a/docs/RFC-0046-Customer-Consumption-Goals-feedback.md
+++ b/docs/RFC-0046-Customer-Consumption-Goals-feedback.md
@@ -1,0 +1,113 @@
+# RFC-0046 — Customer Consumption Goals · Review Feedback
+
+- **Reviews of:** `docs/RFC-0046-Customer-Consumption-Goals.md`
+- **Date:** 2026-06-18
+- **Format:** BMAD party-mode roundtable (independent reviewers)
+- **Reviewers:** 🏗️ Winston (System Architect) · 📋 John (Product Manager) · 🎨 Sally (UX Designer) · 💻 Amelia (Senior Software Engineer)
+- **Status of RFC after review:** Draft — **not yet implementation-ready.** Three decisions are blocking; the storage shape itself is endorsed.
+
+---
+
+## Executive summary
+
+The **JSONB-envelope-per-`(customer, domain)`** storage choice is **endorsed by all reviewers** — precisely because the `goalsData` shape is a contract owned by an external component (`GoalsPanel`), so storing it byte-for-byte and round-tripping it without translation is the low-risk move. Month/day volumes are tiny; deferring **hour** to a separate time-series store is correct.
+
+However, the RFC treats as "open questions" several items that the panel agreed are actually **blocking** — they sit at the intersection of data model, UX, and implementation. The review converges on **three must-resolve-before-coding** decisions and a set of clarifications.
+
+---
+
+## Consensus — blocking decisions (resolve before implementation)
+
+1. **B-1 — Temperature semantics.** `TEMPERATURE` is a setpoint/band, not additive; `annual.total` has no meaning for it. Flagged by *all four* reviewers as blocking model **and** UX **and** code. Decide one of:
+   - (a) a domain-specific sub-shape (e.g. `{ setpoint, min, max }`) — breaks the "single shape" premise; or
+   - (b) keep `total` carrying the setpoint, **disable** the day→month→year roll-up, document it — *only if `GoalsPanel` already tolerates this* (depends on the panel contract).
+   - Engineering corollary: define **exactly what `GET` returns at month/year for temperature** (`null`? average? setpoint? — "disabled" is not a response value).
+
+2. **B-2 — Asset key (`gcdrAssetId` vs ThingsBoard id).** A one-way door and the **only open question that blocks integration** (the dashboard's goals↔actuals join needs a stable key). Architecture + Product agree: key by **`gcdrAssetId`** (GCDR is the master-data source of truth); translate to TB id at the edge. Changing later = data migration across every envelope.
+
+3. **B-3 — `PUT` semantics: replace vs merge.** Not stated in the RFC and the most expensive ambiguity. If replace → simple, idempotent. If merge → the verb should be `PATCH`. Also define: roll-up runs **on write (materialised)** or **on read (computed)**, and which of `daily`/`monthly` is the source of truth when both exist.
+
+---
+
+## Architecture (🏗️ Winston)
+
+- **Endorses the envelope, rejects premature normalisation** — the contract is external; translation layers risk silent drift. Bucket tables are justified **only** for hourly and heavy cross-customer analytics (out of scope).
+- **Move `history` out of the envelope** into its own append-only table (`customer_goals_history`, FK to the goal). Inlining couples the hot path (read/write current goal) to the cold path (audit), and the "~20" bound becomes manual pruning someone forgets. (Engineering accepts inline *only if* append+trim+version-bump is a single atomic statement — see Q-9.)
+- **Promote routing columns** — surface `domain` (and likely `year`/`granularity`) as top-level columns alongside the JSONB payload, for indexable `WHERE` without denormalising content ("routing columns + JSONB payload" pattern). Cheap now; expensive later.
+- **Document concurrency semantics** — the lock granularity is the whole `(customer, domain)` envelope; two operators editing different months collide. Acceptable (low-contention data) but the RFC must say so, and the front-end must handle `409` as **reload-and-reapply**, not reload-and-discard.
+- **One paragraph on hour↔envelope reconciliation** — when hourly arrives it lives in a second store with its own version/audit; describe how they coexist now, even if implemented later.
+
+## Product (📋 John)
+
+- **Name the JTBD explicitly** in the RFC: GCDR's job is "a single, versioned, audited source of *targets* so each dashboard stops inventing its own" — not "is the mall on track" (that's the consumer's job). Half the open questions dissolve once this is written.
+- **Keep the goals-vs-actuals split** (master data vs time series). The friction risk is *not* the split — it's **failing to document the join contract** (which key matches goal↔actual). Resolve B-2 now.
+- **Cut from MVP / defer:** holding/ROOT-RESELLER roll-up (derivable = a sum; and re-imports the temperature non-additivity problem; nobody asked for it), **TEMPERATURE**, **DAILY granularity**, and history-retention policy (append-only is enough; retention is ops).
+- **Do not economise on:** optimistic concurrency, `goals:read`/`goals:write` scopes, and audit — the spine of a "source of truth".
+- **Proposed MVP:** ENERGY + WATER · annual + monthly · asset key decided & documented · optimistic concurrency + scopes + audit · split kept with the join contract written down.
+- **Two questions that gate approval:** (1) Who is the *named* consumer calling `GET /customers/:id/goals` in week 1? No name → no MVP. (2) Does mirroring the `GoalsPanel` JSON mean "smart round-trip" or "GCDR inherits a UI's format as its domain contract"? **Who owns the schema — the domain or the screen?**
+
+## UX (🎨 Sally)
+
+- **Mirror contract is the best decision and the most dangerous** — business rules that live in the panel's head become invisible backend contract. The RFC must state, **in the document**, which field is source-of-truth and which is derived (so a direct API write to `monthly` doesn't silently crack the mirror).
+- **Temperature is "interface lying"** — putting a setpoint in the additive 12-month grid makes the operator read the annual column as a total. Needs its own semantics/component, not "one more domain in the same sum grid". Open question: **comfort band or single target?** — changes the whole component.
+- **Granularity switch is a data-loss trap** — when daily import makes monthly derived, what happens to manually-typed months? The RFC must specify the **transition state machine** and the warning text ("importing daily makes monthly calculated — your manual values will be replaced. Continue?"). Silent transition = the #1 support ticket.
+- **Disabled hour** — needs an explicit "coming soon" tooltip (not bare `disabled`), and **no phantom `hourly: null`** leaking into the contract.
+- **Per-asset goals** — define whether the assets must sum to the mall total (error / warning / allowed, with the exact message) and require a **stable, resolvable asset key** so renamed/disabled assets don't show as "unknown asset".
+- **Treat CSV import as an experience, not a parse** — 365 rows with 3 errors: reject all? import partial? preview before save? cite the offending line. The RFC names "imported via CSV" as if it were a button.
+- **Open question that re-weights everything:** is the operator's flow mostly manual grid entry or mostly CSV? If ~90% CSV, the editable grid is theatre and the design rigor belongs in import/preview/error.
+
+## Engineering (💻 Amelia) — required clarifications & ACs
+
+Underspecified areas: Zod validation of the sparse envelope, optimistic concurrency, PUT idempotency, daily→monthly aggregation (+ temperature), atomic bounded `history`, tenant isolation.
+
+**Acceptance criteria to add before the story is estimable:**
+
+- **AC1** — `PUT` = full replace of the year envelope (or rename to `PATCH`); define `200/201/404/422`.
+- **AC2** — `PUT` without `version` on an existing resource → `428 Precondition Required` (recommended).
+- **AC3** — atomic conditional update `SET version = version + 1 WHERE id = ? AND version = ?`; `rowCount = 0` → `409` with body carrying `currentVersion`.
+- **AC4** — month key regex `^(0[1-9]|1[0-2])$`; daily `^\d{4}-\d{2}-\d{2}$` **+ real-date validation** (leap-year `02-29`) **+** key year must equal the route `:year`.
+- **AC5** — `granularity:"hour"` → `422`; `daily` present with `granularity:"month"` → `422`.
+- **AC6** — values `.finite()`, `>= 0` for ENERGY/WATER (define a ceiling and decimal precision); TEMPERATURE may be negative.
+- **AC7** — roll-up spec: timing (read vs write), source of truth, partial-month behaviour (e.g. 10 of 30 days → partial sum or `null`), and the temperature month/year read result.
+- **AC8** — `unit` is a closed enum per domain; roll-up rejects mixed units (no summing `kWh` + `MWh`).
+- **AC9** — `history` item schema `{ version, ts, userId, snapshot|diff }`, an exact cap (e.g. 20), append + trim + version-bump in **one transaction**; `DELETE` must also be versioned/audited (append-only + physical delete = lost history).
+- **AC10** — exact shape of `assets{}` / `metaTag` (or a declared `z.passthrough()` **and** a byte ceiling on the envelope, given `history` × dense `daily`).
+- **AC11** — idempotency: identical repeated `PUT` is a no-op (version unchanged) — recommended.
+- **AC12** — tenant isolation in every `WHERE` (`tenant_id` + `customer_id` + `domain`); cross-tenant test returns `404`.
+
+**Blocking before estimation:** B-1 (temperature read result), B-3 (PUT replace vs merge), and roll-up timing (write vs read).
+
+---
+
+## Open decisions to settle (owner → RFC author)
+
+| # | Decision | Recommendation from review |
+| --- | --- | --- |
+| B-1 | Temperature shape + month/year read value | Decide sub-shape vs disabled-roll-up; pin the read value. Likely defer TEMPERATURE out of MVP. |
+| B-2 | Asset key | `gcdrAssetId`; translate to TB id at the edge. |
+| B-3 | `PUT` replace vs merge + roll-up timing | Full replace per year; roll-up materialised on write; `daily` is source when present. |
+| D-4 | History storage | Prefer a separate `customer_goals_history` table; if inline, make it atomic + capped + byte-bounded. |
+| D-5 | Routing columns | Promote `domain` (+ `year`/`granularity`) to top-level columns. |
+| D-6 | Schema ownership | State who owns the schema (domain vs `GoalsPanel`) and the versioning/compat policy if the panel's JSON changes. |
+| D-7 | MVP scope | ENERGY + WATER, annual + monthly; defer TEMPERATURE, DAILY, holding roll-up, retention policy. |
+| D-8 | Named MVP consumer | Identify the dashboard that calls the endpoint in week 1, or the MVP is speculative. |
+| D-9 | Operator flow | Confirm manual-grid vs CSV-dominant; weight UX rigor accordingly (import/preview/error). |
+
+---
+
+## Points of agreement (carry forward unchanged)
+
+- JSONB envelope per `(tenant, customer, domain)`; **do not** normalise buckets for month/day.
+- Keep hour **out** of the JSON → separate time-series store.
+- Keep the goals-vs-actuals split (GCDR stores targets only).
+- Keep optimistic concurrency, `goals:read`/`goals:write` scopes, and the `CUSTOMER_GOALS_UPDATED` audit event.
+- ENERGY + WATER with daily→monthly **sum** is the clean, endorsed path; the hard cases are temperature, granularity transition, and orphaned assets.
+
+---
+
+## Divergence to resolve
+
+- **`history` location** — Winston: move to its own table (decouple hot/cold). Amelia: inline acceptable *iff* atomic + capped + byte-bounded. → Pick one; both are safe if the constraints are met.
+- **Schema ownership (John's challenge)** — unaddressed in the RFC: is mirroring the `GoalsPanel` JSON a smart round-trip or inheriting a UI format as the domain contract? Add a compatibility/versioning policy for when the panel's JSON evolves.
+
+_Generated from a BMAD party-mode review of RFC-0046. Design-only; no implementation implied._

--- a/docs/RFC-0046-Customer-Consumption-Goals-feedback.pt-BR.md
+++ b/docs/RFC-0046-Customer-Consumption-Goals-feedback.pt-BR.md
@@ -1,0 +1,172 @@
+# RFC-0046 — Metas de Consumo do Cliente · Feedback da Revisão
+
+- **Revisão de:** `docs/RFC-0046-Customer-Consumption-Goals.md`
+- **Data:** 2026-06-18
+- **Formato:** Roundtable BMAD (party-mode) — revisores independentes
+- **Revisores:** 🏗️ Winston (Arquiteto de Sistemas) · 📋 John (Product Manager) · 🎨 Sally (UX Designer) · 💻 Amelia (Engenheira de Software Sênior)
+- **Status do RFC após a revisão:** Draft — **ainda não pronto para implementação.** Três decisões são bloqueantes; o formato de armazenamento em si está endossado.
+
+---
+
+## Resumo executivo
+
+A escolha de armazenamento — **envelope JSONB por `(customer, domain)`** — é **endossada por todos os revisores**, justamente porque o shape `goalsData` é um contrato pertencente a um componente externo (`GoalsPanel`); logo, guardá-lo byte-a-byte e devolvê-lo sem tradução é a opção de menor risco. Os volumes de mês/dia são pequenos; deixar **hora** fora, num armazenamento time-series separado, está correto.
+
+R: não vejo sentido para guardar mês, dia em JSONB e hora fora, na verdade minha dor hoje é a "hora" quero modelar o banco para o pior caso.
+
+Porém, o RFC trata como "questões em aberto" itens que a mesa considerou de fato **bloqueantes** — eles ficam na interseção de modelagem de dados, UX e implementação. A revisão converge para **três decisões obrigatórias antes de codar** e um conjunto de esclarecimentos.
+
+---
+
+## Consenso — decisões bloqueantes (resolver antes de implementar)
+
+1. **B-1 — Semântica de temperatura.** `TEMPERATURE` é setpoint/faixa, não é aditivo; `annual.total` não tem significado para ela. Apontado pelos *quatro* revisores como bloqueante de modelo **e** UX **e** código. Decidir uma de:
+   - (a) um sub-shape específico do domínio (ex.: `{ setpoint, min, max }`) — quebra a premissa do "shape único"; ou
+   - (b) manter `total` carregando o setpoint, **desabilitar** o roll-up dia→mês→ano, e documentar — *apenas se o `GoalsPanel` já tolerar isso* (depende do contrato do painel).
+   - Corolário de engenharia: definir **exatamente o que o `GET` devolve em mês/ano para temperatura** (`null`? média? setpoint? — "desabilitado" não é um valor de resposta).
+
+R: Nesse caso teríamos que ter uma espécie de annual.total = 25 , seria 25 graus celsius, e o domain type temperature, e uma variável que guardasse annualTypeNumber, ou annularTypeValue ou annualValueType, sei lá, algo assim, onde annualValueType = AVERAGE
+
+se fosse para domain energy, annualValueType = SUM
+
+2. **B-2 — Chave do asset (`gcdrAssetId` vs id do ThingsBoard).** Porta de mão única e a **única questão em aberto que bloqueia integração** (o join meta↔real do dashboard precisa de uma chave estável). Arquitetura + Produto concordam: chavear por **`gcdrAssetId`** (GCDR é a fonte da verdade de dado mestre); traduzir para o id do TB na borda. Mudar depois = migração de dados em todos os envelopes.
+
+R: Não entendi aqui.
+
+3. **B-3 — Semântica do `PUT`: replace vs merge.** Não está dito no RFC e é a ambiguidade mais cara. Se replace → simples e idempotente. Se merge → o verbo deveria ser `PATCH`. Definir também: o roll-up roda **na escrita (materializado)** ou **na leitura (computado)**, e qual entre `daily`/`monthly` é a fonte da verdade quando ambos existem.
+
+R: Nao entendi
+
+---
+
+## Arquitetura (🏗️ Winston)
+
+- **Endossa o envelope e rejeita normalização precoce** — o contrato é externo; camadas de tradução arriscam drift silencioso. Tabelas de bucket só se justificam para **hora** e para análises pesadas cross-customer (fora de escopo).
+R: Bem na verdade o cliente agora quer METAS analisadas por HORA e temos que ter histórico de mudanças se ele mudar algum valor.
+
+- **Tirar o `history` do envelope** para uma tabela própria (`customer_goals_history`, append-only, FK para o goal). Inlining acopla o caminho quente (ler/gravar a meta atual) ao caminho frio (auditoria), e o limite "~20" vira poda manual que alguém esquece. (Engenharia aceita inline *somente se* append
++trim+version-bump for um único comando atômico — ver Q-9.)
+
+R: acho que history deve ser uma tabela anexa mesmo.
+mas talvez endpoint pessoa ter fetchHistory=true e trazer 100 históricos limit 
+
+- **Promover colunas de roteamento** — expor `domain` (e provavelmente `year`/`granularity`) como colunas top-level ao lado do payload JSONB, para `WHERE`/index sem desnormalizar o conteúdo (padrão "colunas de roteamento + payload JSONB"). Barato agora; caro depois.
+R: Não entendi
+
+- **Documentar a semântica de concorrência** — o lock é o envelope `(customer, domain)` inteiro; dois operadores editando meses diferentes colidem. Aceitável (dado de baixa 
+contenção), mas o RFC precisa dizer isso, e o front precisa tratar o `409` como **recarregar-e-reaplicar**, não recarregar-e-descartar.
+
+R: acho que não sendo JSONB e com uma modelagem mais eficiente estaria resolvido certo ?
+
+- **Um parágrafo sobre a reconciliação hora↔envelope** — quando a hora chegar, ela vive num segundo store com versão/audit próprios; descrever como coexistem desde já, mesmo que a implementação fique para depois.
+
+R: Implementação é para agora e nào mais para depois.
+
+## Produto (📋 John)
+
+- **Nomear o JTBD explicitamente** no RFC: o job do GCDR é "uma fonte única, versionada e auditável de *alvos*, para cada dashboard parar de inventar a sua" — e não "o shopping está dentro da meta" (esse é o job do consumidor). Metade das questões em aberto some quando isso é escrito.
+R: OK
+
+- **Manter a separação metas-vs-real** (dado mestre vs série temporal). O risco de fricção *não* é a separação — é **não documentar o contrato do join** (qual chave casa meta↔real). Resolver B-2 já.
+
+R: Não entendi
+
+- **Cortar do MVP / deferir:** roll-up de holding/ROOT-RESELLER (derivável = uma soma; e re-importa o problema da não-aditividade da temperatura; ninguém pediu), **TEMPERATURE**, granularidade **DAILY**, e política de retenção do history (append-only basta; retenção é operação).
+R: Revise isso.
+
+- **Onde NÃO economizar:** concorrência otimista, escopos `goals:read`/`goals:write`, e auditoria — a espinha de uma "fonte da verdade".
+R: ok
+
+- **MVP proposto:** ENERGY + WATER · annual + monthly · chave de asset decidida e documentada · concorrência otimista + escopos + audit · separação mantida com o contrato do join escrito.
+R: revise
+
+- **Duas perguntas que decidem a aprovação:** (1) Quem é o consumidor *nomeado* chamando `GET /customers/:id/goals` na semana 1? Sem nome → não tem MVP. (2) Espelhar o JSON do `GoalsPanel` é "round-trip esperto" ou "o GCDR herdando o formato de uma UI como contrato de domínio"? **Quem manda no schema — o domínio ou a tela?**
+
+R: domínio, mas revise isso
+
+## UX (🎨 Sally)
+
+- **O contrato espelho é a melhor decisão e a mais perigosa** — regras de negócio que hoje moram na cabeça do painel viram contrato invisível do backend. O RFC precisa declarar, **no documento**, qual campo é fonte da verdade e qual é derivado (para uma escrita direta de API em `monthly` não rachar o espelho em silêncio).
+R: algumas regras básicas precisam existir como se escolher mes a mes, não pode escrever ano, ano é calcumado, se escrever dia a dia, não pode definir a meta do mês, é calculada e ano também, se escrever hora a hora, dia é calculado, mês e ano também
+
+- **Temperatura é "mentira de interface"** — pôr um setpoint na grade aditiva de 12 meses faz o operador ler a coluna anual como total. Precisa de semântica/componente próprios, não "mais um domínio na mesma grade somativa". Questão aberta: **faixa de conforto ou alvo único?** — muda o componente inteiro.
+
+R: revise com o que eu disse antes
+
+- **A troca de granularidade é uma armadilha de perda de dados** — quando o import diário torna o mensal derivado, o que acontece com os meses digitados na mão? O RFC precisa especificar a **máquina de estados da transição** e o texto do aviso ("ao importar diário, o mensal passa a ser calculado — seus valores manuais serão substituídos. Continuar?"). Transição silenciosa = o ticket de suporte nº 1.
+
+R: vamos revisar, por o user pode escolher a meta do ano, pode escolher a meta mes a mes, mas cada mes ele pode definir o valor do mes ou para um mes específico pode definir a meta dia a dia e para cada dia desse, pode eventualmente definir o valor do dia ou valor de hora.
+
+- **Hora desabilitada** — precisa de tooltip explícito ("disponível em breve"), não `disabled` cru, e **nenhum `hourly: null` fantasma** vazando para o contrato.
+R: precisa para agora mesmo
+
+- **Metas por asset** — definir se os assets precisam fechar com o total do mall (erro / warning / liberado, com a mensagem exata) e exigir uma **chave de asset estável e resolvível** para assets renomeados/desativados não virarem "asset desconhecido".
+
+R: Por asset não disponível
+
+- **Tratar o import CSV como experiência, não como parse** — 365 linhas com 3 erradas: rejeita tudo? importa o parcial? preview antes de gravar? citar a linha. O RFC nomeia "importado via CSV" como se fosse um botão.
+
+R: importa parcial e aponta erro, sempre gera um preview dry run antes de persistir, pede confirmação e persiste e depois um LOG completo
+
+- **Questão aberta que re-pesa tudo:** o fluxo do operador é mais digitação manual no grid ou mais CSV? Se for ~90% CSV, o grid editável é teatro e o rigor de design vai para import/preview/erro.
+
+R: meio a meio
+muitas vezes vai importar um ano inteiro, com granularidade hora a hora para alguns meses, dia a dia para outros, e o user poder especificar via UI depois para hora por exemplo
+
+## Engenharia (💻 Amelia) — esclarecimentos e ACs obrigatórios
+
+Áreas subespecificadas: validação Zod do envelope esparso, concorrência otimista, idempotência do PUT, agregação dia→mês (+ temperatura), `history` bounded atômico, isolamento de tenant.
+
+**Critérios de aceite a adicionar antes de a story ser estimável:**
+
+- **AC1** — `PUT` = replace total do envelope do ano (ou renomear para `PATCH`); definir `200/201/404/422`.
+- **AC2** — `PUT` sem `version` num recurso existente → `428 Precondition Required` (recomendado).
+- **AC3** — update condicional atômico `SET version = version + 1 WHERE id = ? AND version = ?`; `rowCount = 0` → `409` com body trazendo `currentVersion`.
+- **AC4** — regex de mês `^(0[1-9]|1[0-2])$`; diário `^\d{4}-\d{2}-\d{2}$` **+ validação de data real** (29/02 bissexto) **+** o ano da chave deve bater com o `:year` da rota.
+- **AC5** — `granularity:"hour"` → `422`; `daily` presente com `granularity:"month"` → `422`.
+- **AC6** — valores `.finite()`, `>= 0` para ENERGY/WATER (definir teto e precisão decimal); TEMPERATURE pode ser negativo.
+- **AC7** — spec do roll-up: momento (leitura vs escrita), fonte da verdade, comportamento com mês parcial (ex.: 10 de 30 dias → soma parcial ou `null`), e o valor de leitura de temperatura em mês/ano.
+- **AC8** — `unit` é enum fechado por domínio; o roll-up rejeita unidades mistas (não somar `kWh` + `MWh`).
+- **AC9** — schema do item de `history` `{ version, ts, userId, snapshot|diff }`, cap exato (ex.: 20), append + trim + version-bump em **uma transação**; `DELETE` também deve ser versionado/auditado (append-only + delete físico = história perdida).
+- **AC10** — shape exato de `assets{}` / `metaTag` (ou um `z.passthrough()` declarado **e** um teto de bytes no envelope, dado `history` × `daily` denso).
+- **AC11** — idempotência: `PUT` idêntico repetido é no-op (version inalterado) — recomendado.
+- **AC12** — isolamento de tenant em todo `WHERE` (`tenant_id` + `customer_id` + `domain`); teste cross-tenant retorna `404`.
+
+**Bloqueantes antes da estimativa:** B-1 (valor de leitura de temperatura), B-3 (`PUT` replace vs merge) e o momento do roll-up (escrita vs leitura).
+
+
+R: Depois posso me aprofundar aqui, mas talvez Amelia possa fazer um review com pontos que eu citei acima
+---
+
+## Decisões em aberto a fechar (responsável → autor do RFC)
+
+| # | Decisão | Recomendação da revisão |
+| --- | --- | --- |
+| B-1 | Shape de temperatura + valor de leitura em mês/ano | Decidir sub-shape vs roll-up-desligado; cravar o valor de leitura. Provavelmente deferir TEMPERATURE para fora do MVP. |
+| B-2 | Chave de asset | `gcdrAssetId`; traduzir para id do TB na borda. |
+| B-3 | `PUT` replace vs merge + momento do roll-up | Replace total por ano; roll-up materializado na escrita; `daily` é a fonte quando presente. |
+| D-4 | Armazenamento do history | Preferir tabela própria `customer_goals_history`; se inline, torná-lo atômico + capped + limitado por bytes. |
+| D-5 | Colunas de roteamento | Promover `domain` (+ `year`/`granularity`) para colunas top-level. |
+| D-6 | Dono do schema | Declarar quem é o dono do schema (domínio vs `GoalsPanel`) e a política de versão/compat se o JSON do painel mudar. |
+| D-7 | Escopo do MVP | ENERGY + WATER, annual + monthly; deferir TEMPERATURE, DAILY, holding roll-up, retenção. |
+| D-8 | Consumidor nomeado do MVP | Identificar o dashboard que chama o endpoint na semana 1, ou o MVP é especulativo. |
+| D-9 | Fluxo do operador | Confirmar manual-grid vs CSV-dominante; pesar o rigor de UX de acordo (import/preview/erro). |
+
+---
+
+## Pontos de acordo (manter inalterados)
+
+- Envelope JSONB por `(tenant, customer, domain)`; **não** normalizar buckets para mês/dia.
+- Manter a hora **fora** do JSON → store time-series separado.
+- Manter a separação metas-vs-real (GCDR guarda só os alvos).
+- Manter concorrência otimista, escopos `goals:read`/`goals:write` e o evento de auditoria `CUSTOMER_GOALS_UPDATED`.
+- ENERGY + WATER com **soma** dia→mês é o caminho limpo e endossado; os casos difíceis são temperatura, transição de granularidade e assets órfãos.
+
+---
+
+## Divergência a resolver
+
+- **Local do `history`** — Winston: mover para tabela própria (desacoplar quente/frio). Amelia: inline é aceitável *se* for atômico + capped + limitado por bytes. → Escolher um; ambos são seguros se as restrições forem atendidas.
+- **Dono do schema (provocação do John)** — não endereçado no RFC: espelhar o JSON do `GoalsPanel` é round-trip esperto ou herdar um formato de UI como contrato de domínio? Adicionar uma política de compat/versão para quando o JSON do painel evoluir.
+
+_Gerado a partir de uma revisão BMAD party-mode do RFC-0046. Apenas design; nenhuma implementação implícita._

--- a/docs/RFC-0046-Customer-Consumption-Goals.md
+++ b/docs/RFC-0046-Customer-Consumption-Goals.md
@@ -1,0 +1,248 @@
+# RFC-0046 — Customer Consumption Goals
+
+- **Status:** Draft — **design closed** (decisions DEC-1…DEC-7 resolved 2026-06-18); ready for implementation.
+- **Created:** 2026-06-18
+- **Author:** MYIO Engineering
+- **Domain:** Customers / Consumption Goals (Energy · Water · Temperature)
+- **Reviews:** `docs/RFC-0046-Customer-Consumption-Goals-feedback.md` (round 1), `…-feedback-v2.md` (round 2).
+- **Related:**
+  - `myio-js-library/src/docs/GoalsPanel-DataModel.md` — the `GoalsPanel` (`openGoalsPanel`, RFC-0075) UI contract that consumes/produces goals.
+  - RFC-0019 — Customer Config · RFC-0028 — Device Calibration Offsets (audit/history precedent) · RFC-0016 — TB Entity Mapping · RFC-0009 — Events/Audit Logs.
+  - `docs/DB-MIGRATIONS.md` — custom migration-runner conventions.
+
+---
+
+## Why this matters
+
+Every shopping/customer operates against **targets**: "this mall should not exceed 1,200 MWh this year", "the food court should stay under 85 m³ in March", "hold the common areas at 23 °C". Today these targets live **outside GCDR** — in a ThingsBoard `SERVER_SCOPE` attribute edited by the `GoalsPanel` modal, in spreadsheets, or nowhere. The dashboard can *show* consumption but has no authoritative source to compare against.
+
+GCDR is the source of truth for customer master data. **Consumption goals belong with the customer.** One authoritative, versioned, audited store that every consumer (dashboard gauges, reports) reads from — and, critically, one that supports the new client requirement: **goals analysed down to the hour**, with a full change history.
+
+This RFC formalises a normalised model for per-customer goals across energy, water and temperature, at hourly grain with coarser views derived on read.
+
+---
+
+## Summary
+
+Per-customer goals, scoped by **domain** (`ENERGY`, `WATER`, `TEMPERATURE`), persisted at a **single canonical grain — the hour**. The operator may enter a target at any level (year, month, day, hour); GCDR **distributes it down to hourly buckets** on write and **aggregates hours up** on read (sum for energy/water, weighted average for temperature). There is no mixed-granularity storage and no per-asset goal in this version.
+
+- **Canonical store:** hourly rows under a per-`(customer, domain, year)` parent that carries an optimistic `version`.
+- **Aggregation method is fixed per domain** (`SUM` energy/water, `AVERAGE` temperature) — not an operator choice.
+- **History** is a separate append-only table recording the **level the user acted on** (e.g. "edited a day → system distributed to 24 hours"); `?fetchHistory=true` returns ≤100 entries.
+- **Write semantics:** `PUT` replaces a whole `(year, domain)`; `PATCH`/import merges specific buckets.
+- New API-key scopes `goals:read` / `goals:write`; audit event `CUSTOMER_GOALS_UPDATED`.
+
+---
+
+## Goals & non-goals
+
+**Goals** — a durable, versioned, audited home for per-customer targets; hourly grain with derived coarser views; energy/water/temperature; CSV import with dry-run/partial/log; customer-scoped REST under the existing hybrid auth.
+
+**Non-goals (future — see §10):** per-asset goals; holding/ROOT-RESELLER roll-up; operating-window/excluded hours; proportional (non-even) distribution; tenant-configurable aggregation method; computing **actual** consumption or "% of goal" (that stays in the consumers).
+
+---
+
+## Domain model & units
+
+| Domain | `unit` | Aggregation (`aggregation_method`) | Distribution on write |
+| --- | --- | --- | --- |
+| `ENERGY` | `kWh` | `SUM` | even split: `parent / hoursInScope` |
+| `WATER` | `m3` | `SUM` | even split |
+| `TEMPERATURE` | `C` | `AVERAGE` (weighted) | copy parent to each hour |
+
+The method is a **fixed property of the domain**, stored in config (not on each value row, not chosen by the operator). `total = 25` on a temperature goal reads as "25 °C".
+
+---
+
+## Granularity, distribution & roll-up (DEC-1, DEC-2, DEC-3)
+
+**The hour is the only stored grain.** The granularity the operator picks is an *input mode*, not a storage shape.
+
+### Distribution (set a coarser level → store hours)
+- **`SUM` domains (energy/water):** the parent value is split **evenly** across the hours in scope: `hourValue = parentValue / hoursInScope` (e.g. a month total ÷ that month's hours). Proportional/profile-weighted distribution is **future**.
+- **`AVERAGE` domains (temperature):** the parent value is **copied** to each hour, so the weighted average back up equals the parent.
+- Every generated hour row records:
+  - `source_level` — the level the user actually set (`YEAR | MONTH | DAY | HOUR`);
+  - `derived` — `true` when the value was system-distributed, `false` when the operator set this exact hour.
+- On a later coarser edit, re-distribution overwrites only `derived = true` hours by default (explicit hourly values the operator confirmed are preserved unless the operator forces a reset). This is the storage backing for the panel's "suggested vs confirmed" UX.
+
+### Roll-up (read a coarser level)
+Computed **on read** (not materialised in the MVP; add a materialised view per `(customer, domain, year)` only if profiling demands):
+- `DAY` = `SUM(hours)` (energy/water) or **weighted `AVG(hours)`** (temperature);
+- `MONTH` = sum/weighted-avg of its hours; `YEAR` likewise.
+- **Weighted** = by the count of contributing hours (DEC-2), so a long month does not weigh the same as a short one. The read response declares the method per node so a temperature average is never mistaken for a sum.
+
+> **Volume (DEC-3, accepted):** a fully-specified year is up to **8,760 hour-rows per (customer, domain, year)**. This is the deliberate "model for the worst case" choice; coarser views are derived, not stored.
+
+---
+
+## Data model
+
+### `consumption_goals` — parent (holds the optimistic version)
+```sql
+CREATE TABLE consumption_goals (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   uuid NOT NULL,
+  customer_id uuid NOT NULL REFERENCES customers(id) ON DELETE CASCADE,
+  domain      text NOT NULL,            -- ENERGY | WATER | TEMPERATURE
+  year        smallint NOT NULL,
+  unit        text NOT NULL,            -- kWh | m3 | C (from domain config)
+  version     integer NOT NULL DEFAULT 1,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  created_by  uuid,
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  updated_by  uuid,
+  CONSTRAINT consumption_goals_uq UNIQUE (tenant_id, customer_id, domain, year)
+);
+CREATE INDEX consumption_goals_customer_idx ON consumption_goals (tenant_id, customer_id);
+```
+
+### `consumption_goal_hours` — the canonical hourly grain
+```sql
+CREATE TABLE consumption_goal_hours (
+  goal_id      uuid NOT NULL REFERENCES consumption_goals(id) ON DELETE CASCADE,
+  month        smallint NOT NULL,       -- 1..12
+  day          smallint NOT NULL,       -- 1..31 (valid for the month/year)
+  hour         smallint NOT NULL,       -- 0..23
+  value        numeric NOT NULL,
+  source_level text NOT NULL,           -- YEAR | MONTH | DAY | HOUR (level the user set)
+  derived      boolean NOT NULL,        -- true = system-distributed
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  updated_by   uuid,
+  CONSTRAINT consumption_goal_hours_uq UNIQUE (goal_id, month, day, hour)
+);
+```
+
+### `consumption_goal_domains` — fixed aggregation config
+```sql
+CREATE TABLE consumption_goal_domains (
+  tenant_id          uuid NOT NULL,
+  domain             text NOT NULL,
+  aggregation_method text NOT NULL,     -- SUM | AVERAGE
+  unit               text NOT NULL,     -- kWh | m3 | C
+  PRIMARY KEY (tenant_id, domain)
+);
+```
+Seeded per tenant: `ENERGY→SUM/kWh`, `WATER→SUM/m3`, `TEMPERATURE→AVERAGE/C`. Tenant-configurable override is future.
+
+### `consumption_goal_history` — append-only audit (DEC-4)
+```sql
+CREATE TABLE consumption_goal_history (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  goal_id        uuid NOT NULL,
+  actor          uuid,                  -- who changed it
+  action_level   text NOT NULL,         -- YEAR | MONTH | DAY | HOUR (what the user touched)
+  bucket_ref     text NOT NULL,         -- "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  old_value      numeric,               -- at the input level (NULL on create)
+  new_value      numeric,               -- at the input level (NULL on delete)
+  distributed    boolean NOT NULL,      -- true = system spread to hours
+  hours_affected integer NOT NULL,      -- count of hour rows written by this change
+  version        integer NOT NULL,      -- the version this change produced
+  changed_at     timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX consumption_goal_history_idx ON consumption_goal_history (goal_id, changed_at DESC);
+```
+
+**Example (the author's case):** an operator edits day `2026-03-15` → one history row `{ action_level: DAY, bucket_ref: "2026-03-15", old_value, new_value, distributed: true, hours_affected: 24, actor, version }`; the 24 updated hour rows carry `source_level: DAY, derived: true`.
+
+---
+
+## Versioning & concurrency (DEC-4, A)
+
+- `version` lives on `consumption_goals` (per `(tenant, customer, domain, year)`) and **increments on every successful change** within that year.
+- `PUT`/`PATCH` may carry the expected `version`; a mismatch → **`409 Conflict`** with the current `version` in the body. Contention grain is the year (low-contention data; acceptable). The front-end treats `409` as **reload-and-reapply**, not reload-and-discard.
+- The hourly upsert, the `version` bump and the history append run in **one transaction**.
+
+---
+
+## API
+
+`domain` and `year` are query discriminators. The wire shape returns the tree at the requested granularity, computed from hours, plus the `version`.
+
+```jsonc
+// GET /api/v1/customers/{id}/goals?domain=ENERGY&year=2026&granularity=month  →
+{
+  "customerId": "…", "domain": "ENERGY", "unit": "kWh",
+  "aggregationMethod": "SUM", "year": 2026, "version": 7,
+  "tree": {                              // requested granularity, derived from hours
+    "annual": { "value": 1200000, "method": "SUM" },
+    "monthly": { "01": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false } }
+  }
+  // ?granularity=hour returns the full hourly tree; ?fetchHistory=true adds "history": [ ≤100 entries ]
+}
+```
+
+### Endpoints (customer-scoped, hybrid auth, hierarchy honoured)
+
+| Action | Method | Path | Notes |
+| --- | --- | --- | --- |
+| List domains with goals | `GET` | `/customers/:id/goals` | Summary per domain (`unit`, `version`, years present). |
+| Get goals | `GET` | `/customers/:id/goals?domain=&year=&granularity=&fetchHistory=` | `granularity` ∈ `year\|month\|day\|hour` (default `month`); derived from hours. `fetchHistory=true` → ≤100 entries, newest first. |
+| Replace a year | `PUT` | `/customers/:id/goals?domain=&year=` | **Replace**: the payload is the whole year; buckets absent from the payload's scope are removed; system distributes to hours; `version` optimistic. |
+| Merge buckets | `PATCH` | `/customers/:id/goals?domain=&year=` | **Merge**: only the sent buckets are (re)distributed; the rest are preserved. |
+| Import (CSV) | `POST` | `/customers/:id/goals/import?domain=&year=` | Dry-run/preview by default; see §CSV. |
+| Delete | `DELETE` | `/customers/:id/goals?domain=&year=` | Removes the year (or a sub-bucket); logged + versioned. |
+
+- **Validation:** `granularity:"hour"` is fully supported; month `01..12`, day valid for the month/year (leap-year aware), hour `0..23`; values `.finite()`, `>= 0` for energy/water (temperature may be negative); `unit` matches the domain.
+
+---
+
+## CSV import — experience, not parse
+
+Always a **dry-run preview** before persisting:
+1. **Upload** → "Preview. Nothing is saved until you confirm."
+2. **Dry-run** → a ghost tree of how the year would look + line-by-line diagnostics (`8,380 OK · 32 problems`, each citing the exact line; granularity conflicts resolve as "finest wins"). **Partial import is explicit** (valid lines import; invalid are listed) with a downloadable error report. Never silent; never all-or-nothing.
+3. **Confirm** in numbers ("3 months become hourly, 5 daily, 4 monthly; 32 lines ignored").
+4. **Full log** — downloadable, auditable; the importer then lands on the imported tree for hourly tweaks.
+
+Import is **merge by bucket** (PATCH semantics) and idempotent per bucket.
+
+---
+
+## Auth & scopes
+
+- **API keys:** add `goals:read` / `goals:write` to the customer-API-key scope catalogue; reads require `goals:read` (or `*:read`), writes require `goals:write`.
+- **JWT:** RBAC permissions `goals:read` / `goals:write`, granted to roles that manage customer configuration.
+- Customer-scoped via the existing `hybridAuthByMethod`; hierarchy access (`SELF`/`SUBTREE`/`TENANT`) honoured.
+- Every write emits an audit event `CUSTOMER_GOALS_UPDATED` `{ customerId, domain, year, version, actionLevel }` — no goal values in the audit row.
+
+---
+
+## Migration & backward compatibility
+
+- One additive migration creating the four tables (custom runner, no `BEGIN/COMMIT` in the file; number assigned at implementation time) + a seed of `consumption_goal_domains` per tenant.
+- No backfill; customers start with no goals (`GET` returns an empty tree).
+- **Schema ownership = the domain (GCDR), not the `GoalsPanel`** (DEC-6). The panel adapts to this contract; an adapter maps the panel's `goalsData` to/from these endpoints. If the panel's JSON evolves, the adapter absorbs it — the stored model does not change.
+
+---
+
+## Decisions resolved (closing record)
+
+| # | Decision | Resolution |
+| --- | --- | --- |
+| DEC-1 | Storage grain / roll-up | **Always hourly**; coarser derived on read (sum / weighted-avg). |
+| DEC-2 | Temperature reduction | **Weighted average** (by contributing hours/days). |
+| DEC-3 | Bucket representation | Uniform hourly rows (no granularity discriminator); ~8,760/yr accepted. |
+| DEC-4 | Version & history | `version` per `(customer, domain, year)`, bumped per change; history at hour grain but records the **input level** + distribution. |
+| DEC-5 | Write semantics | `PUT` = replace (year+domain); `PATCH`/import = merge (bucket). |
+| DEC-6 | Aggregation config | **Fixed per domain** (ENERGY/WATER `SUM`, TEMPERATURE `AVERAGE`); not operator-editable. |
+| DEC-7 | Excluded/operating-window hours | **Future** (not modelled now). |
+
+---
+
+## Future possibilities
+
+- **Per-asset goals** — add a nullable `asset_id` to the key (the normalised model extends cleanly).
+- **Holding/ROOT-RESELLER roll-up** — derivable by summing children; a dedicated read endpoint.
+- **Operating-window / excluded hours** — mark hours as not-counted on the goal (DEC-7).
+- **Proportional distribution** — split a coarse value by a load profile instead of evenly (B).
+- **Tenant-configurable aggregation method** — override the per-domain default.
+- **Materialised roll-up view** — only if hourly read aggregation proves slow.
+
+---
+
+## References
+
+- `myio-js-library/src/docs/GoalsPanel-DataModel.md` — the `GoalsPanel` UI contract.
+- `docs/RFC-0046-Customer-Consumption-Goals-feedback.md` / `…-feedback-v2.md` — the two review rounds that shaped this design.
+- RFC-0019 (Customer Config) · RFC-0028 (Calibration history) · RFC-0016 (TB mapping) · RFC-0009 (Audit) · `docs/DB-MIGRATIONS.md`.

--- a/docs/RFC-0046-Customer-Consumption-Goals.md
+++ b/docs/RFC-0046-Customer-Consumption-Goals.md
@@ -1,7 +1,9 @@
 # RFC-0046 — Customer Consumption Goals
 
-- **Status:** Draft — **design closed** (decisions DEC-1…DEC-7 resolved 2026-06-18); ready for implementation.
+- **Status:** **Implemented** (backend + frontend) on branch `feat/rfc-0046-consumption-goals` — not yet merged/in prod. Design closed (DEC-1…DEC-7, 2026-06-18).
 - **Created:** 2026-06-18
+- **Updated:** 2026-06-19
+- **Migrations:** `0047_consumption_goals.sql` (four tables + domain seed) · `0048_consumption_goals_history_ops.sql` (operation-level audit columns). Applied to local Docker; **pending prod**.
 - **Author:** MYIO Engineering
 - **Domain:** Customers / Consumption Goals (Energy · Water · Temperature)
 - **Reviews:** `docs/RFC-0046-Customer-Consumption-Goals-feedback.md` (round 1), `…-feedback-v2.md` (round 2).
@@ -28,9 +30,9 @@ Per-customer goals, scoped by **domain** (`ENERGY`, `WATER`, `TEMPERATURE`), per
 
 - **Canonical store:** hourly rows under a per-`(customer, domain, year)` parent that carries an optimistic `version`.
 - **Aggregation method is fixed per domain** (`SUM` energy/water, `AVERAGE` temperature) — not an operator choice.
-- **History** is a separate append-only table recording the **level the user acted on** (e.g. "edited a day → system distributed to 24 hours"); `?fetchHistory=true` returns ≤100 entries.
-- **Write semantics:** `PUT` replaces a whole `(year, domain)`; `PATCH`/import merges specific buckets.
-- New API-key scopes `goals:read` / `goals:write`; audit event `CUSTOMER_GOALS_UPDATED`.
+- **History** is a separate append-only audit, **one row per operation** (a mutation = a version = one entry): it records the `source` (IMPORT / REPLACE / MERGE / DELETE), the level acted on, the bucket count and a compact `details` sample. `?fetchHistory=true` returns ≤100 entries, newest-first. *(This per-goal history table is the implemented audit mechanism; the global `CUSTOMER_GOALS_UPDATED` event below is designed but not yet emitted.)*
+- **Write semantics:** `PUT` replaces a whole `(year, domain)` with a nested tree body; `PATCH` merges a sparse `buckets[]` list; import merges via a **stateless** `?dryRun=true|false` CSV post.
+- New API-key scopes `goals:read` / `goals:write`; audit event `CUSTOMER_GOALS_UPDATED` (planned).
 
 ---
 
@@ -125,25 +127,33 @@ CREATE TABLE consumption_goal_domains (
 ```
 Seeded per tenant: `ENERGY→SUM/kWh`, `WATER→SUM/m3`, `TEMPERATURE→AVERAGE/C`. Tenant-configurable override is future.
 
-### `consumption_goal_history` — append-only audit (DEC-4)
+### `consumption_goal_history` — append-only audit, **one row per operation** (DEC-4)
 ```sql
 CREATE TABLE consumption_goal_history (
   id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   goal_id        uuid NOT NULL,
   actor          uuid,                  -- who changed it
-  action_level   text NOT NULL,         -- YEAR | MONTH | DAY | HOUR (what the user touched)
-  bucket_ref     text NOT NULL,         -- "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
-  old_value      numeric,               -- at the input level (NULL on create)
-  new_value      numeric,               -- at the input level (NULL on delete)
+  source         text NOT NULL DEFAULT 'EDIT',  -- IMPORT | REPLACE | MERGE | DELETE | EDIT (the operation)
+  action_level   text NOT NULL,         -- YEAR | MONTH | DAY | HOUR (coarsest level the operation touched)
+  bucket_ref     text NOT NULL,         -- representative ref: "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  old_value      numeric,               -- at the input level (NULL on create / multi-bucket op)
+  new_value      numeric,               -- single-bucket value, else NULL
+  bucket_count   integer NOT NULL DEFAULT 1,    -- how many operator buckets the operation carried
+  details        jsonb   NOT NULL DEFAULT '[]', -- compact [{ ref, value }] sample (capped at 50) for the timeline
   distributed    boolean NOT NULL,      -- true = system spread to hours
-  hours_affected integer NOT NULL,      -- count of hour rows written by this change
-  version        integer NOT NULL,      -- the version this change produced
+  hours_affected integer NOT NULL,      -- total hour rows written by this operation
+  version        integer NOT NULL,      -- the version this operation produced
   changed_at     timestamptz NOT NULL DEFAULT now()
 );
 CREATE INDEX consumption_goal_history_idx ON consumption_goal_history (goal_id, changed_at DESC);
 ```
 
-**Example (the author's case):** an operator edits day `2026-03-15` → one history row `{ action_level: DAY, bucket_ref: "2026-03-15", old_value, new_value, distributed: true, hours_affected: 24, actor, version }`; the 24 updated hour rows carry `source_level: DAY, derived: true`.
+> **One row per operation, not per bucket.** A mutation = a version = exactly one audit entry. This keeps the UI timeline clean and stops a large hourly import from flooding the ≤100-row window. The `details` array carries up to 50 of the operation's buckets so the timeline can show the breakdown ("`2026-01-15T08 → 500`").
+
+**Example A — operator edits day `2026-03-15` (PATCH/merge):** one row `{ source: MERGE, action_level: DAY, bucket_ref: "2026-03-15", new_value: 3500, bucket_count: 1, details: [{ref:"2026-03-15", value:3500}], distributed: true, hours_affected: 24, version }`; the 24 updated hour rows carry `source_level: DAY, derived: true`.
+**Example B — spreadsheet import of 120 hour buckets:** one row `{ source: IMPORT, action_level: HOUR, bucket_count: 120, new_value: null, details: [ …up to 50… ], hours_affected: 120, version }`.
+
+> **Note — whole-year DELETE.** Deleting an entire `(domain, year)` cascades and removes the parent *and its history* (a destructive reset), so it leaves no timeline entry. Only sub-bucket deletes append a `DELETE` audit row. A global, customer-level audit log (`CUSTOMER_GOALS_UPDATED`) would capture full-year deletes too — that remains future work.
 
 ---
 
@@ -178,10 +188,12 @@ CREATE INDEX consumption_goal_history_idx ON consumption_goal_history (goal_id, 
 | --- | --- | --- | --- |
 | List domains with goals | `GET` | `/customers/:id/goals` | Summary per domain (`unit`, `version`, years present). |
 | Get goals | `GET` | `/customers/:id/goals?domain=&year=&granularity=&fetchHistory=` | `granularity` ∈ `year\|month\|day\|hour` (default `month`); derived from hours. `fetchHistory=true` → ≤100 entries, newest first. |
-| Replace a year | `PUT` | `/customers/:id/goals?domain=&year=` | **Replace**: the payload is the whole year; buckets absent from the payload's scope are removed; system distributes to hours; `version` optimistic. |
-| Merge buckets | `PATCH` | `/customers/:id/goals?domain=&year=` | **Merge**: only the sent buckets are (re)distributed; the rest are preserved. |
-| Import (CSV) | `POST` | `/customers/:id/goals/import?domain=&year=` | Dry-run/preview by default; see §CSV. |
-| Delete | `DELETE` | `/customers/:id/goals?domain=&year=` | Removes the year (or a sub-bucket); logged + versioned. |
+| Replace a year | `PUT` | `/customers/:id/goals?domain=&year=` | **Replace**: body is a **nested tree** (`{ annual?, monthly{ daily{ hourly }}, expectedVersion? }`); buckets absent from the payload's scope are removed; system distributes to hours; `version` optimistic. |
+| Merge buckets | `PATCH` | `/customers/:id/goals?domain=&year=` | **Merge**: body is a sparse `{ buckets: [{ level, ref, value }], expectedVersion? }`; only the sent buckets are (re)distributed; the rest are preserved. |
+| Import (CSV) | `POST` | `/customers/:id/goals/import?domain=&year=&dryRun=true\|false` | **Stateless** — `dryRun=true` (default) previews; `dryRun=false` persists the SAME body; no previewToken. Body `{ csv, expectedVersion? }`. See §CSV. |
+| Delete | `DELETE` | `/customers/:id/goals?domain=&year=` | Body `{ bucket?{ level, ref }, expectedVersion? }`. Removes the year (or a sub-bucket); sub-bucket delete is logged + versioned. |
+
+> The exact wire bodies and worked examples live in [`RFC-0046-Goals-API.md`](./RFC-0046-Goals-API.md) (kept in sync with the implementation).
 
 - **Validation:** `granularity:"hour"` is fully supported; month `01..12`, day valid for the month/year (leap-year aware), hour `0..23`; values `.finite()`, `>= 0` for energy/water (temperature may be negative); `unit` matches the domain.
 
@@ -195,7 +207,30 @@ Always a **dry-run preview** before persisting:
 3. **Confirm** in numbers ("3 months become hourly, 5 daily, 4 monthly; 32 lines ignored").
 4. **Full log** — downloadable, auditable; the importer then lands on the imported tree for hourly tweaks.
 
-Import is **merge by bucket** (PATCH semantics) and idempotent per bucket.
+Import is **merge by bucket** (PATCH semantics) and idempotent per bucket. The implemented flow is **stateless**: the client posts the CSV with `?dryRun=true` for the preview, then re-posts the *same* CSV with `?dryRun=false` to persist (there is no `previewToken`).
+
+---
+
+## UI (as built)
+
+The goals UI is a **customer-detail tab** ("Metas"), not the standalone `GoalsPanel`. Implemented in the frontend repo:
+
+- `src/components/customers/CustomerGoalsTab.tsx` — the tab (selectors, summary, drill-editor, version chip).
+- `src/components/customers/GoalsCsvImportModal.tsx` — the CSV import modal.
+- `src/components/customers/GoalsHistoryTimeline.tsx` — the version-history timeline.
+- `src/types/goals.ts`, `src/services/api/goalsService.ts`, `src/hooks/useGoals.ts` — types/service/hooks.
+
+**Default view = read-only summary.** On open the tab shows a dashboard for the selected `(domain, year)`:
+- KPI cards: year, annual total (Σ) / annual average (x̄, per domain), months-with-a-goal (`X / 12`), days-with-a-goal ("total de registros"), average per month, average per day.
+- **Top 3 months** and **Top 3 days** (ranked, with their values).
+- A **"Versão atual: vN"** chip (the optimistic `version`).
+- An **"Habilitar edição"** button toggles into the editor.
+
+**Editor (drill).** Month grid → click a month → day grid → click a day → 24-hour grid. Coarser levels show a read-only computed total (Σ for SUM, x̄ for AVERAGE). Saving: the month grid does a **PUT replace**; day/hour grids do a **PATCH merge** with explicit year-aware buckets. 409 → reload-and-reapply.
+
+**CSV import.** A modal with dry-run preview → per-line diagnostics → confirm → applied log; includes a **"Baixar modelo CSV"** button that downloads a domain/year-aware template (`bucket,value`).
+
+**Version history.** Below the editor, a timeline (visual design mirrors the Work Order detail timeline) renders `goals.history` newest-first — one node per operation: an icon + label by `source` ("Importação de planilha" / "Edição de metas" / "Remoção de meta"), the actor and relative time, a `vN` badge, "`N registros · <level>`", and chips of the `details` (`ref → value`, capped with "+N mais").
 
 ---
 
@@ -210,7 +245,9 @@ Import is **merge by bucket** (PATCH semantics) and idempotent per bucket.
 
 ## Migration & backward compatibility
 
-- One additive migration creating the four tables (custom runner, no `BEGIN/COMMIT` in the file; number assigned at implementation time) + a seed of `consumption_goal_domains` per tenant.
+- **`0047_consumption_goals.sql`** — creates the four tables + indexes + seeds `consumption_goal_domains` per tenant (idempotent: `CREATE TABLE IF NOT EXISTS`, `ON CONFLICT DO NOTHING`).
+- **`0048_consumption_goals_history_ops.sql`** — additive `ALTER` adding `source`, `bucket_count`, `details` to `consumption_goal_history` (operation-level audit) + the `source` CHECK.
+- Both applied to local Docker; **prod pending** (ship with the rest of RFC-0046).
 - No backfill; customers start with no goals (`GET` returns an empty tree).
 - **Schema ownership = the domain (GCDR), not the `GoalsPanel`** (DEC-6). The panel adapts to this contract; an adapter maps the panel's `goalsData` to/from these endpoints. If the panel's JSON evolves, the adapter absorbs it — the stored model does not change.
 
@@ -223,8 +260,8 @@ Import is **merge by bucket** (PATCH semantics) and idempotent per bucket.
 | DEC-1 | Storage grain / roll-up | **Always hourly**; coarser derived on read (sum / weighted-avg). |
 | DEC-2 | Temperature reduction | **Weighted average** (by contributing hours/days). |
 | DEC-3 | Bucket representation | Uniform hourly rows (no granularity discriminator); ~8,760/yr accepted. |
-| DEC-4 | Version & history | `version` per `(customer, domain, year)`, bumped per change; history at hour grain but records the **input level** + distribution. |
-| DEC-5 | Write semantics | `PUT` = replace (year+domain); `PATCH`/import = merge (bucket). |
+| DEC-4 | Version & history | `version` per `(customer, domain, year)`, bumped per change; history is **one row per operation** recording `source` + input level + bucket count + a `details` sample. |
+| DEC-5 | Write semantics | `PUT` = replace (nested year tree); `PATCH` = merge (`buckets[]`); import = stateless `?dryRun` CSV merge. |
 | DEC-6 | Aggregation config | **Fixed per domain** (ENERGY/WATER `SUM`, TEMPERATURE `AVERAGE`); not operator-editable. |
 | DEC-7 | Excluded/operating-window hours | **Future** (not modelled now). |
 

--- a/docs/RFC-0046-Goals-API.md
+++ b/docs/RFC-0046-Goals-API.md
@@ -1,14 +1,14 @@
 # RFC-0046 — Customer Consumption Goals API
 
-**Contract document** shared by the GCDR backend and frontend (`GoalsPanel` / `openGoalsPanel`) teams.
-This is the authoritative wire contract derived from [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md).
-If this document and the RFC disagree, the RFC wins; open a PR to reconcile.
+**Contract document** shared by the GCDR backend and frontend teams.
+This is the authoritative wire contract derived from [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md), **kept in sync with the implementation** (`src/controllers/consumption-goals.controller.ts`, `src/dto/request/GoalsDTO.ts`, `src/services/consumptionGoalService.ts`). If this document and the code disagree, the code wins; open a PR to reconcile.
 
-- **Status:** Design closed (DEC-1…DEC-7). Implementation contract — first backend step.
+- **Status:** **Implemented** (branch `feat/rfc-0046-consumption-goals`, not yet merged/in prod).
 - **Base path:** `/api/v1`
 - **Auth:** hybrid (`hybridAuthByMethod`) — JWT Bearer *or* customer API key (`X-API-Key: gcdr_cust_*`).
 - **Scopes:** reads need `goals:read` (or `*:read`); writes need `goals:write`.
-- **Audit:** every write emits `CUSTOMER_GOALS_UPDATED` `{ customerId, domain, year, version, actionLevel }` (no goal values in the audit row).
+- **Audit:** every change appends a per-goal `consumption_goal_history` row (one per operation — see §1.7). A global `CUSTOMER_GOALS_UPDATED` event is designed but **not yet emitted**.
+- **Last updated:** 2026-06-19
 
 ---
 
@@ -36,7 +36,7 @@ The method is a property of the domain, not an operator choice and not stored on
 - Each generated hour row carries:
   - `sourceLevel` — the level the operator actually set (`YEAR | MONTH | DAY | HOUR`).
   - `derived` — `true` when system-distributed, `false` when the operator set that exact hour.
-- A later coarser edit re-distributes over `derived = true` hours **only** by default. Operator-confirmed (`derived = false`) hours are preserved unless the operator forces a reset. This backs the panel's "suggested vs confirmed" UX.
+- A later coarser edit re-distributes over `derived = true` hours **only** by default. Operator-confirmed (`derived = false`) hours are preserved unless the operator forces a reset. This backs the "suggested vs confirmed" UX.
 
 ### 1.4 Roll-up on read (coarser output ← hour rows)
 Computed on read:
@@ -46,17 +46,35 @@ Computed on read:
 - Every node in the returned tree declares its `method`, so a temperature average is never mistaken for a sum.
 
 ### 1.5 Write semantics — `PUT` (replace) vs `PATCH` (merge) — DEC-5
-- **`PUT` = replace** the whole `(year, domain)`. The payload *is* the year; buckets absent from the payload's scope are **removed**.
-- **`PATCH` = merge** only the sent buckets; everything else is preserved. CSV import uses PATCH/merge semantics and is idempotent per bucket.
+- **`PUT` = replace** the whole `(year, domain)`. The body is a **nested tree** (`{ annual?, monthly{ daily{ hourly }} }`); buckets absent from the payload's scope are **removed**.
+- **`PATCH` = merge** a sparse **`buckets[]`** list — only the named buckets are (re)distributed; everything else is preserved. Re-distribution overwrites `derived:true` hours only.
+- **Import** uses PATCH/merge semantics over a CSV and is **stateless**: post the CSV with `?dryRun=true` to preview, then re-post the *same* CSV with `?dryRun=false` to persist. There is **no `previewToken`**.
 
 ### 1.6 Versioning & optimistic concurrency — DEC-4
 - `version` lives on the parent `(tenant, customer, domain, year)` and **increments on every successful change**.
-- `PUT`/`PATCH`/`DELETE` MAY send the expected `version` (body field or `If-Match`-style). A mismatch → **`409 Conflict`** with the current `version` in the body (`error.currentVersion`).
+- `PUT`/`PATCH`/`DELETE`/import-confirm MAY send `expectedVersion` in the body. A mismatch → **`409 Conflict`** with the current version in the body (`error.currentVersion`, also `error.details.currentVersion`).
 - The front-end treats `409` as **reload-and-reapply**, not reload-and-discard.
 - The hourly upsert, the version bump, and the history append run in **one transaction**.
 
-### 1.7 History
-`?fetchHistory=true` adds a `history` array of **≤100 entries, newest-first**. Each entry records the **level the operator acted on** (not the 8,760 underlying hours): `actionLevel`, `bucketRef`, `oldValue`, `newValue`, `distributed`, `hoursAffected`, `version`, `actor`, `changedAt`.
+### 1.7 History — one row per operation
+`?fetchHistory=true` adds a `history` array of **≤100 entries, newest-first**. History is **one row per operation** (a mutation = a version = one entry), *not* one per bucket. Each entry:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `source` | enum | `IMPORT` \| `REPLACE` \| `MERGE` \| `DELETE` \| `EDIT` — the operation. (`REPLACE`/`MERGE` are operator edits.) |
+| `actionLevel` | enum | `YEAR \| MONTH \| DAY \| HOUR` — the coarsest level the operation touched. |
+| `bucketRef` | string | Representative ref (the single bucket's ref, else the year). |
+| `oldValue` | number\|null | Single-bucket previous value (null on create / multi-bucket op). |
+| `newValue` | number\|null | Single-bucket new value (null on delete / multi-bucket op). |
+| `bucketCount` | number | How many operator buckets the operation carried. |
+| `details` | array | Compact `[{ ref, value }]` sample (server-capped at 50) for the breakdown. |
+| `distributed` | boolean | `true` = system spread to hours. |
+| `hoursAffected` | number | Total hour rows written by the operation. |
+| `version` | number | The version this operation produced. |
+| `actor` | string\|null | User/actor id, or null for system/seed. |
+| `changedAt` | string | ISO-8601 timestamp. |
+
+> A 120-line hourly import becomes **one** `IMPORT` entry with `bucketCount: 120`, not 120 rows — so a single import never floods the ≤100-row window. Deleting a *whole year* cascades away the goal and its history (no entry); only sub-bucket deletes append a `DELETE` row.
 
 ### 1.8 Response & error envelope
 Success and error bodies follow the standard GCDR envelope.
@@ -80,19 +98,20 @@ In examples below the `meta` wrapper is omitted for brevity; only `data` (or `er
 | --- | --- | --- |
 | `id` | uuid | Customer id. Hierarchy access (`SELF`/`SUBTREE`/`TENANT`) is honoured. |
 
-### Query discriminators (write + single-domain read)
+### Query discriminators
 | Param | Type | Required | Description |
 | --- | --- | --- | --- |
 | `domain` | enum | yes | `ENERGY` \| `WATER` \| `TEMPERATURE`. |
-| `year` | smallint | yes | e.g. `2026`. |
+| `year` | smallint | yes | `2000..2100`. |
 | `granularity` | enum | no (read only) | `year` \| `month` \| `day` \| `hour`. Default `month`. |
 | `fetchHistory` | boolean | no (read only) | `true` → adds `history` (≤100, newest-first). Default `false`. |
+| `dryRun` | boolean | no (import only) | `true` (default) previews; `false` persists. |
 
 ### Validation rules (`400 VALIDATION_ERROR`)
-- `domain` must be one of the three; `unit` (if echoed in a body) must match the domain.
-- `year` plausible; `month` `1..12`; `day` valid for the month/year (**leap-year aware**); `hour` `0..23`.
+- `domain` must be one of the three; `year` `2000..2100`; `month` `1..12`; `day` valid for the month/year (**leap-year aware**); `hour` `0..23`.
 - `value` `.finite()`. SUM domains require `value >= 0`; TEMPERATURE may be negative.
-- `granularity` ∈ the four levels; `granularity=hour` is fully supported on read and write.
+- Bucket `ref` must match its `level` (`YEAR` `2026`, `MONTH` `2026-03`, `DAY` `2026-03-15`, `HOUR` `2026-03-15T08`); a merge bucket's ref-year must equal the query `year`.
+- PUT body must define at least an `annual` value or one month; PATCH `buckets[]` must be non-empty (≤ 8760).
 
 ---
 
@@ -104,7 +123,7 @@ In examples below the `meta` wrapper is omitted for brevity; only `data` (or `er
 | 3.2 | Get goals (derived tree) | `GET` | `/customers/:id/goals?domain=&year=&granularity=&fetchHistory=` | `goals:read` |
 | 3.3 | Replace a year+domain | `PUT` | `/customers/:id/goals?domain=&year=` | `goals:write` |
 | 3.4 | Merge buckets | `PATCH` | `/customers/:id/goals?domain=&year=` | `goals:write` |
-| 3.5 | Import CSV (dry-run/confirm) | `POST` | `/customers/:id/goals/import?domain=&year=` | `goals:write` |
+| 3.5 | Import CSV (dry-run/persist) | `POST` | `/customers/:id/goals/import?domain=&year=&dryRun=` | `goals:write` |
 | 3.6 | Delete a year (or sub-bucket) | `DELETE` | `/customers/:id/goals?domain=&year=` | `goals:write` |
 
 ---
@@ -115,13 +134,6 @@ In examples below the `meta` wrapper is omitted for brevity; only `data` (or `er
 GET /api/v1/customers/:id/goals
 ```
 **Auth:** `goals:read`. **Query:** none. Returns a summary per domain that has any goals (years present, current version, unit). A customer with no goals returns an empty `domains` array.
-
-**Request**
-```bash
-curl -X GET "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals" \
-  -H "Authorization: Bearer {TOKEN}" \
-  -H "X-Tenant-Id: 11111111-1111-1111-1111-111111111111"
-```
 
 **200 OK**
 ```json
@@ -152,7 +164,7 @@ GET /api/v1/customers/:id/goals?domain=ENERGY&year=2026&granularity=month
 ```
 **Auth:** `goals:read`.
 **Query:** `domain` (req), `year` (req), `granularity` (`year|month|day|hour`, default `month`), `fetchHistory` (default `false`).
-The `tree` is derived from hours at the requested granularity. Each node declares its `method`. A `(domain, year)` with no goals returns `version: 0` and an empty `tree`.
+The `tree` is derived from hours at the requested granularity (cumulative: `day` also returns `monthly`+`annual`). Each node declares its `method`. A `(domain, year)` with no goals returns `version: 0` and an empty `tree` (`{}`).
 
 **Request**
 ```bash
@@ -164,89 +176,42 @@ curl -X GET "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-3333
 
 `?granularity=year` — single annual node:
 ```json
-{
-  "customerId": "33333333-3333-3333-3333-333333333333",
-  "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
+{ "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
   "year": 2026, "version": 7,
-  "tree": { "annual": { "value": 1200000, "method": "SUM" } }
-}
+  "tree": { "annual": { "value": 1200000, "method": "SUM" } } }
 ```
 
-`?granularity=month` (default) — annual + 12 monthly nodes:
+`?granularity=month` (default) — annual + monthly nodes keyed `"01".."12"`:
 ```json
-{
-  "customerId": "33333333-3333-3333-3333-333333333333",
-  "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
-  "year": 2026, "version": 7,
+{ "year": 2026, "version": 7,
   "tree": {
     "annual": { "value": 1200000, "method": "SUM" },
     "monthly": {
       "01": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false },
-      "02": { "value": 100000, "method": "SUM", "sourceLevel": "YEAR",  "derived": true  },
-      "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false }
-    }
-  }
-}
+      "02": { "value": 100000, "method": "SUM", "sourceLevel": "YEAR",  "derived": true  }
+    } } }
 ```
-> `sourceLevel`/`derived` on an aggregated node reflect the **finest level the user set** within it: `derived:true` means every contributing hour was system-distributed; if any hour in the node was operator-confirmed (`derived:false`) the node reports `derived:false`.
+> `sourceLevel`/`derived` on an aggregated node reflect the **finest level the user set** within it: `derived:true` means every contributing hour was system-distributed; if any hour was operator-confirmed (`derived:false`) the node reports `derived:false`.
 
-`?granularity=day` — annual + monthly + daily nodes keyed `MM-DD`:
-```json
-{
-  "tree": {
-    "annual":  { "value": 1200000, "method": "SUM" },
-    "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false } },
-    "daily": {
-      "03-15": { "value": 3500.0, "method": "SUM", "sourceLevel": "DAY",   "derived": false },
-      "03-16": { "value": 3225.8, "method": "SUM", "sourceLevel": "MONTH", "derived": true  }
-    }
-  }
-}
-```
-
-`?granularity=hour` — full hourly tree, keyed `MM-DDThh` (24 hour leaves per day):
-```json
-{
-  "tree": {
-    "annual":  { "value": 1200000, "method": "SUM" },
-    "monthly": { "03": { "value": 100000, "method": "SUM" } },
-    "daily":   { "03-15": { "value": 3500.0, "method": "SUM" } },
-    "hourly": {
-      "03-15T00": { "value": 145.83, "method": "SUM", "sourceLevel": "DAY", "derived": true },
-      "03-15T01": { "value": 145.83, "method": "SUM", "sourceLevel": "DAY", "derived": true }
-    }
-  }
-}
-```
-
-#### TEMPERATURE example (`AVERAGE`, weighted, negative allowed)
-```json
-{
-  "domain": "TEMPERATURE", "unit": "C", "aggregationMethod": "AVERAGE",
-  "year": 2026, "version": 3,
-  "tree": {
-    "annual": { "value": 23.0, "method": "AVERAGE" },
-    "monthly": {
-      "01": { "value": 23.0, "method": "AVERAGE", "sourceLevel": "YEAR", "derived": true },
-      "07": { "value": 25.0, "method": "AVERAGE", "sourceLevel": "MONTH", "derived": false }
-    }
-  }
-}
-```
+`?granularity=day` — + daily nodes keyed `MM-DD`; `?granularity=hour` — + hourly nodes keyed `MM-DDThh` (24 leaves/day).
 
 #### With `fetchHistory=true`
-Adds `history` (≤100, newest-first) alongside `tree`:
+Adds `history` (≤100, newest-first, **one row per operation** — see §1.7):
 ```json
 {
   "version": 7,
   "tree": { "annual": { "value": 1200000, "method": "SUM" } },
   "history": [
-    { "actionLevel": "DAY",   "bucketRef": "2026-03-15", "oldValue": 3225.8, "newValue": 3500.0,
-      "distributed": true, "hoursAffected": 24,  "version": 7,
-      "actor": "9a…", "changedAt": "2026-06-18T14:22:10.000Z" },
-    { "actionLevel": "MONTH", "bucketRef": "2026-03",    "oldValue": null,   "newValue": 100000,
-      "distributed": true, "hoursAffected": 744, "version": 6,
-      "actor": "9a…", "changedAt": "2026-06-18T14:00:00.000Z" }
+    { "source": "MERGE", "actionLevel": "DAY", "bucketRef": "2026-03-15",
+      "oldValue": null, "newValue": 3500.0, "bucketCount": 1,
+      "details": [ { "ref": "2026-03-15", "value": 3500.0 } ],
+      "distributed": true, "hoursAffected": 24, "version": 7,
+      "actor": "9a…", "changedAt": "2026-06-19T14:22:10.000Z" },
+    { "source": "IMPORT", "actionLevel": "HOUR", "bucketRef": "2026",
+      "oldValue": null, "newValue": null, "bucketCount": 120,
+      "details": [ { "ref": "2026-01-15T08", "value": 500 }, "…up to 50…" ],
+      "distributed": true, "hoursAffected": 120, "version": 6,
+      "actor": "9a…", "changedAt": "2026-06-19T14:00:00.000Z" }
   ]
 }
 ```
@@ -260,37 +225,50 @@ Adds `history` (≤100, newest-first) alongside `tree`:
 ```
 PUT /api/v1/customers/:id/goals?domain=ENERGY&year=2026
 ```
-**Auth:** `goals:write`. **Semantics:** REPLACE — the payload is the whole year for that domain; buckets absent from the payload's scope are **removed**. System distributes each leaf down to hours.
+**Auth:** `goals:write`. **Semantics:** REPLACE — the body is the whole year for that domain; buckets absent from the payload's scope are **removed**. The system distributes each leaf down to hours.
 
-**Body**
+**Body — a nested tree** (mirrors the read tree). At least `annual` or one `monthly` entry is required.
+
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `expectedVersion` | integer | no | Optimistic guard. Omit to force-write. `0` = "I expect no existing goal". |
-| `granularity` | enum | yes | The level the values are expressed at (`year`/`month`/`day`/`hour`). |
-| `values` | object | yes | Keyed by bucket at the chosen granularity (`"2026"`, `"03"`, `"03-15"`, `"03-15T08"`). |
+| `annual` | `{ value, sourceLevel? }` | no | Whole-year leaf. |
+| `monthly` | object | no | Keyed `"01".."12"`; each value is a **month node**. |
+| `expectedVersion` | integer (>0) | no | Optimistic guard. Omit on first write. |
 
-**Request — set a YEAR total**
+A **month node** is `{ value, sourceLevel?, daily? }`; a **day node** is `{ value, sourceLevel?, hourly? }`; an **hour node** is `{ value, sourceLevel? }`. Day keys `"01".."31"` (validated against the month/year), hour keys `"00".."23"`. `sourceLevel` is optional — inferred from depth when omitted.
+
+**Request — set 12 monthly totals**
 ```bash
 curl -X PUT "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
   -d '{
     "expectedVersion": 6,
-    "granularity": "month",
-    "values": {
-      "01": 100000, "02": 100000, "03": 100000, "04": 100000,
-      "05": 100000, "06": 100000, "07": 100000, "08": 100000,
-      "09": 100000, "10": 100000, "11": 100000, "12": 100000
+    "monthly": {
+      "01": { "value": 100000 }, "02": { "value": 100000 }, "03": { "value": 100000 },
+      "04": { "value": 100000 }, "05": { "value": 100000 }, "06": { "value": 100000 },
+      "07": { "value": 100000 }, "08": { "value": 100000 }, "09": { "value": 100000 },
+      "10": { "value": 100000 }, "11": { "value": 100000 }, "12": { "value": 100000 }
     }
   }'
 ```
 
-**200 OK** — returns the resulting derived tree at the request granularity plus the new `version`:
+**Request — a month with a confirmed hour inside it (deep nesting)**
+```jsonc
+{
+  "monthly": {
+    "03": { "value": 100000, "daily": {
+      "15": { "value": 3500, "hourly": { "08": { "value": 500 } } }
+    } }
+  }
+}
+```
+
+**200 OK** — the derived tree at the action granularity + the new `version` + `distribution`:
 ```json
 {
   "success": true,
   "data": {
-    "customerId": "33333333-3333-3333-3333-333333333333",
     "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
     "year": 2026, "version": 7,
     "tree": {
@@ -302,7 +280,7 @@ curl -X PUT "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-3333
 }
 ```
 
-**Errors:** `400`, `401`/`403`, `404`, `409` (version conflict — §4), `422` (semantically valid JSON but un-persistable, e.g. monthly buckets do not cover/exceed the replaced year scope, or mixed-granularity conflict that cannot be resolved).
+**Errors:** `400` (validation — bad domain/value/calendar, or body defines neither annual nor a month), `401`/`403`, `404`, `409` (version conflict — §4.4).
 
 ---
 
@@ -311,19 +289,27 @@ curl -X PUT "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-3333
 ```
 PATCH /api/v1/customers/:id/goals?domain=ENERGY&year=2026
 ```
-**Auth:** `goals:write`. **Semantics:** MERGE — only the sent buckets are (re)distributed; all other buckets are preserved. Re-distribution overwrites `derived:true` hours only (operator-confirmed hours preserved).
+**Auth:** `goals:write`. **Semantics:** MERGE — only the listed buckets are (re)distributed; all other buckets are preserved. Re-distribution overwrites `derived:true` hours only.
 
-**Body** — same shape as PUT, but `values` contains only the buckets to change. Buckets may mix granularity in one call (`granularity` then declares the *finest* level present; each key's depth determines its own level).
+**Body**
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `buckets` | array | yes | 1..8760 entries of `{ level, ref, value }`. |
+| `expectedVersion` | integer (>0) | no | Optimistic guard. |
 
-**Request — edit one DAY**
+Each bucket: `level` ∈ `YEAR\|MONTH\|DAY\|HOUR`; `ref` year-aware and matching the level (`"2026"`, `"2026-03"`, `"2026-03-15"`, `"2026-03-15T08"`); `value` finite (sign per domain). Buckets may **mix levels** in one call; the ref-year must equal the query `year`.
+
+**Request — edit one DAY + one HOUR**
 ```bash
 curl -X PATCH "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
   -d '{
     "expectedVersion": 6,
-    "granularity": "day",
-    "values": { "03-15": 3500.0 }
+    "buckets": [
+      { "level": "DAY",  "ref": "2026-03-15",    "value": 3500.0 },
+      { "level": "HOUR", "ref": "2026-03-15T08", "value": 500 }
+    ]
   }'
 ```
 
@@ -332,7 +318,6 @@ curl -X PATCH "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-33
 {
   "success": true,
   "data": {
-    "customerId": "33333333-3333-3333-3333-333333333333",
     "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
     "year": 2026, "version": 7,
     "tree": {
@@ -345,82 +330,78 @@ curl -X PATCH "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-33
 }
 ```
 
-**Errors:** `400`, `401`/`403`, `404`, `409` (§4), `422`.
+**Errors:** `400`, `401`/`403`, `404`, `409` (§4.4).
 
 ---
 
-### 3.5 Import CSV (dry-run / confirm)
+### 3.5 Import CSV (stateless dry-run / persist)
 
 ```
-POST /api/v1/customers/:id/goals/import?domain=ENERGY&year=2026
+POST /api/v1/customers/:id/goals/import?domain=ENERGY&year=2026&dryRun=true
 ```
-**Auth:** `goals:write`. **Semantics:** merge by bucket (PATCH), idempotent per bucket. **Always dry-run first** — nothing is saved until an explicit confirm. Finest-granularity wins on conflicting lines; partial import is explicit (valid lines import, invalid lines are listed with a downloadable error report).
+**Auth:** `goals:write`. **Semantics:** merge by bucket (PATCH), idempotent per bucket. **Stateless** — there is no `previewToken`/`mode`. To apply a previewed import, **re-post the identical body** with `dryRun=false`.
+
+**Query:** `domain`, `year`, `dryRun` (default `true`).
 
 **Body**
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `mode` | enum | yes | `dryRun` (preview, nothing saved) or `confirm` (persist). |
-| `csv` | string | yes (`dryRun`) | Raw CSV text. Header: `bucket,value` where `bucket` ∈ `2026` / `2026-03` / `2026-03-15` / `2026-03-15T08`. |
-| `token` | string | yes (`confirm`) | The `previewToken` returned by a prior `dryRun`, binding confirm to a previewed result. |
-| `expectedVersion` | integer | no (`confirm`) | Optimistic guard for the persist step. |
+| `csv` | string | yes | Raw CSV text. Header `bucket,value`; one line per bucket. `bucket` ∈ `2026` / `2026-03` / `2026-03-15` / `2026-03-15T08`. Separator `,` (pipe `\|` also accepted). Finest granularity wins on conflicts. |
+| `expectedVersion` | integer (>0) | no | Optimistic guard (applied on `dryRun=false`). |
 
-**Request — dry run**
+**Request — dry run (preview, nothing saved)**
 ```bash
-curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026" \
+curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026&dryRun=true" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
-  -d '{
-    "mode": "dryRun",
-    "csv": "bucket,value\n2026-01,100000\n2026-02,100000\n2026-03-15,3500\n2026-13,999\n"
-  }'
+  -d '{ "csv": "bucket,value\n2026-01,100000\n2026-02,100000\n2026-03-15,3500\n2026-13,999\n" }'
 ```
 
-**200 OK — dry-run preview** (nothing persisted)
+**200 OK — dry-run preview**
 ```json
 {
   "success": true,
   "data": {
-    "mode": "dryRun",
-    "previewToken": "imp_5f2c…",
-    "summary": { "linesTotal": 4, "ok": 3, "problems": 1,
-      "willApply": { "monthly": 2, "daily": 1, "hourly": 0 } },
-    "diagnostics": [
-      { "line": 4, "bucket": "2026-13", "value": 999,
-        "severity": "error", "code": "INVALID_MONTH",
-        "message": "month must be 1..12" }
-    ],
-    "ghostTree": {
+    "dryRun": true,
+    "preview": {
       "annual": { "value": 203500, "method": "SUM" },
       "monthly": { "01": { "value": 100000, "method": "SUM" }, "02": { "value": 100000, "method": "SUM" } },
       "daily": { "03-15": { "value": 3500, "method": "SUM" } }
     },
-    "errorReportUrl": "/api/v1/customers/33333333-…/goals/import/imp_5f2c…/errors.csv"
+    "diagnostics": [
+      { "line": 4, "bucket": "2026-13", "value": 999, "reason": "month must be 1..12" }
+    ],
+    "okCount": 3,
+    "errorCount": 1
   }
 }
 ```
 
-**Request — confirm**
+**Request — persist (re-post the same csv)**
 ```bash
-curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026" \
+curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026&dryRun=false" \
   -H "Content-Type: application/json" \
   -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
-  -d '{ "mode": "confirm", "token": "imp_5f2c…", "expectedVersion": 7 }'
+  -d '{ "csv": "bucket,value\n2026-01,100000\n2026-02,100000\n2026-03-15,3500\n2026-13,999\n", "expectedVersion": 7 }'
 ```
 
-**200 OK — confirmed**
+**200 OK — persisted** (adds `version` + a per-bucket `log`; one `IMPORT` history row is appended)
 ```json
 {
   "success": true,
   "data": {
-    "mode": "confirm",
-    "applied": { "monthly": 2, "daily": 1, "hourly": 0, "linesIgnored": 1 },
-    "year": 2026, "version": 8,
-    "logUrl": "/api/v1/customers/33333333-…/goals/import/imp_5f2c…/log.csv"
+    "dryRun": false,
+    "preview": { "annual": { "value": 203500, "method": "SUM" } },
+    "diagnostics": [ { "line": 4, "bucket": "2026-13", "value": 999, "reason": "month must be 1..12" } ],
+    "okCount": 3,
+    "errorCount": 1,
+    "version": 8,
+    "log": [ "applied MONTH 2026-01 = 100000", "applied MONTH 2026-02 = 100000", "applied DAY 2026-03-15 = 3500" ]
   }
 }
 ```
 
-**Errors:** `400` (malformed body/CSV header), `401`/`403`, `404`, `409` (version conflict on confirm — §4), `422` (e.g. all lines invalid, or `confirm` with an expired/unknown `token`).
+**Errors:** `400` (malformed body / empty CSV / **every line invalid** — "Import has no valid lines to apply"), `401`/`403`, `404`, `409` (version conflict on persist — §4.4). Partial import is explicit: valid lines apply, invalid lines are returned in `diagnostics`.
 
 ---
 
@@ -429,18 +410,20 @@ curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333
 ```
 DELETE /api/v1/customers/:id/goals?domain=ENERGY&year=2026
 ```
-**Auth:** `goals:write`. Removes the year for the domain. Optionally narrow the deletion to a sub-bucket. Logged + versioned (history entry with `newValue: null`).
+**Auth:** `goals:write`. Removes the year for the domain, or narrows to a sub-bucket. A sub-bucket delete is logged + versioned (a `DELETE` history row with `newValue: null`); a **whole-year** delete cascades the parent and all hours **and its history** (no history row remains).
 
-**Query (in addition to `domain`, `year`)**
-| Param | Type | Required | Description |
+**Body** (optional)
+| Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `bucket` | string | no | Narrow to a bucket: `03` (month) / `03-15` (day) / `03-15T08` (hour). Omit = delete the whole year. |
-| `expectedVersion` | integer | no | Optimistic guard. |
+| `bucket` | `{ level, ref }` | no | Narrow to a bucket: `{ "level": "MONTH", "ref": "2026-03" }` (or DAY/HOUR/YEAR). Omit = delete the whole year. |
+| `expectedVersion` | integer (>0) | no | Optimistic guard. |
 
-**Request**
+**Request — delete one month**
 ```bash
-curl -X DELETE "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026&bucket=03" \
-  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026"
+curl -X DELETE "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -d '{ "bucket": { "level": "MONTH", "ref": "2026-03" }, "expectedVersion": 8 }'
 ```
 
 **200 OK**
@@ -450,14 +433,15 @@ curl -X DELETE "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-3
   "data": {
     "customerId": "33333333-3333-3333-3333-333333333333",
     "domain": "ENERGY", "year": 2026,
-    "deleted": { "bucket": "03", "hoursRemoved": 744, "actionLevel": "MONTH" },
+    "deleted": { "bucket": "2026-03", "hoursRemoved": 744, "actionLevel": "MONTH" },
     "version": 9
   }
 }
 ```
-Deleting the **whole year** (no `bucket`) removes the parent row and all its hours; subsequent `GET` for that `(domain, year)` returns `version: 0` and an empty `tree`. Such a full delete MAY return `204 No Content` (no body) when the client sends no `expectedVersion`; with a guard it returns `200` and the body above.
 
-**Errors:** `400`, `401`/`403`, `404` (customer or `(domain, year)` not found), `409` (§4).
+Deleting the **whole year** (no `bucket`) removes the parent row and all its hours; a subsequent `GET` returns `version: 0` and an empty `tree`. A full-year delete with **no `expectedVersion`** returns **`204 No Content`** (no body); with a guard it returns `200` and `deleted.bucket: null, version: 0`.
+
+**Errors:** `400`, `401`/`403`, `404` (customer or `(domain, year)` not found), `409` (§4.4).
 
 ---
 
@@ -474,32 +458,24 @@ All errors use the standard envelope: `{ success: false, error: { message, code,
     "code": "VALIDATION_ERROR",
     "details": {
       "domain": ["Invalid enum value. Expected 'ENERGY' | 'WATER' | 'TEMPERATURE'"],
-      "values.03": ["value must be a finite number >= 0 for SUM domains"],
-      "values.02-30": ["day 30 is not valid for month 02 of year 2026"]
+      "monthly.03.value": ["value must be a finite number >= 0 for energy/water domains"],
+      "monthly.02.daily.30": ["day 30 is invalid for 2026-02 (max 28)"]
     }
   },
-  "meta": { "requestId": "…", "timestamp": "2026-06-18T14:22:10.000Z" }
+  "meta": { "requestId": "…", "timestamp": "2026-06-19T14:22:10.000Z" }
 }
 ```
+Semantic failures that other APIs might return as `422` (e.g. a PUT body with neither annual nor a month, an import where every line is invalid) surface here as `400 VALIDATION_ERROR` in this implementation.
 
 ### 4.2 `401 / 403` — auth & scope
 - `401 UNAUTHORIZED` — missing/invalid JWT or API key.
-- `403 FORBIDDEN` — authenticated but lacks the scope (`goals:read` for reads, `goals:write` for writes) or hierarchy access to the customer.
-```json
-{
-  "success": false,
-  "error": { "message": "Missing required scope: goals:write", "code": "FORBIDDEN", "details": { "requiredScope": "goals:write" } },
-  "meta": { "requestId": "…", "timestamp": "…" }
-}
-```
+- `403 FORBIDDEN` — authenticated but lacks the scope (`goals:read`/`goals:write`) or hierarchy access to the customer.
 
 ### 4.3 `404 Not Found` (`NOT_FOUND`)
 ```json
-{
-  "success": false,
+{ "success": false,
   "error": { "message": "Customer not found", "code": "NOT_FOUND", "details": { "customerId": "33333333-…" } },
-  "meta": { "requestId": "…", "timestamp": "…" }
-}
+  "meta": { "requestId": "…", "timestamp": "…" } }
 ```
 
 ### 4.4 `409 Conflict` — optimistic version mismatch (`VERSION_CONFLICT`)
@@ -517,106 +493,44 @@ Returned when `expectedVersion` does not match the stored `version`. **`currentV
 }
 ```
 
-### 4.5 `422 Unprocessable Entity` (`UNPROCESSABLE_ENTITY`)
-Syntactically valid request that cannot be applied as a goal:
-```json
-{
-  "success": false,
-  "error": {
-    "message": "Import confirm token expired or unknown",
-    "code": "UNPROCESSABLE_ENTITY",
-    "details": { "token": "imp_5f2c…", "reason": "EXPIRED" }
-  },
-  "meta": { "requestId": "…", "timestamp": "…" }
-}
-```
-Other `422` cases: every CSV line invalid; a PUT whose buckets cannot tile the replaced year scope; unresolvable mixed-granularity conflict.
-
 ---
 
 ## 5. Worked example, end-to-end
 
-A concrete trace of the author's case: an operator sets a MONTH energy value, the system distributes it to that month's hours, then edits one DAY producing a history entry.
+An operator sets a MONTH energy value, the system distributes it to that month's hours, then edits one DAY — producing two `consumption_goal_history` operation rows.
 
 **Start:** customer `33333333-…` has no ENERGY 2026 goal. `GET …?domain=ENERGY&year=2026` → `version: 0`, empty `tree`.
 
-### Step 1 — operator sets MONTH (March) = 100,000 kWh
+### Step 1 — operator sets MONTH (March) = 100,000 kWh (PATCH)
 ```bash
-curl -X PATCH ".../customers/33333333-…/goals?domain=ENERGY&year=2026" \
-  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
-  -H "Content-Type: application/json" \
-  -d '{ "granularity": "month", "values": { "03": 100000 } }'
+curl -X PATCH ".../goals?domain=ENERGY&year=2026" -H "X-API-Key: …" -H "Content-Type: application/json" \
+  -d '{ "buckets": [ { "level": "MONTH", "ref": "2026-03", "value": 100000 } ] }'
 ```
-- March 2026 has 31 days → **744 hours**. SUM domain → even split: `100000 / 744 = 134.4086… kWh/hour`.
-- 744 hour rows written with `sourceLevel: "MONTH", derived: true`.
-- `version` 0 → **1**. History row appended:
-  `{ actionLevel: "MONTH", bucketRef: "2026-03", oldValue: null, newValue: 100000, distributed: true, hoursAffected: 744, version: 1 }`.
-
-**Response `200`:**
-```json
-{ "year": 2026, "version": 1,
-  "tree": { "annual": { "value": 100000, "method": "SUM" },
-            "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": true } } },
-  "distribution": { "hoursWritten": 744, "actionLevel": "MONTH" } }
-```
+- March 2026 has 31 days → **744 hours**. SUM → even split: `100000 / 744 = 134.4086… kWh/hour`.
+- 744 hour rows written `sourceLevel: "MONTH", derived: true`.
+- `version` 0 → **1**. History row: `{ source: "MERGE", actionLevel: "MONTH", bucketRef: "2026-03", newValue: 100000, bucketCount: 1, hoursAffected: 744, version: 1 }`.
 
 ### Step 2 — GET month shows it (roll-up on read)
-```bash
-curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=month" -H "X-API-Key: …"
-```
-```json
-{ "year": 2026, "version": 1,
-  "tree": { "annual": { "value": 100000, "method": "SUM" },
-            "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": true } } } }
-```
-> `SUM(744 hours × 134.4086…) = 100000` — the roll-up reproduces the entered month total.
+`SUM(744 × 134.4086…) = 100000` — the roll-up reproduces the entered month total.
 
-### Step 3 — operator edits one DAY (2026-03-15) = 3,500 kWh
+### Step 3 — operator edits one DAY (2026-03-15) = 3,500 kWh (PATCH)
 ```bash
-curl -X PATCH ".../customers/33333333-…/goals?domain=ENERGY&year=2026" \
-  -H "X-API-Key: …" -H "Content-Type: application/json" \
-  -d '{ "expectedVersion": 1, "granularity": "day", "values": { "03-15": 3500 } }'
+curl -X PATCH ".../goals?domain=ENERGY&year=2026" -H "X-API-Key: …" -H "Content-Type: application/json" \
+  -d '{ "expectedVersion": 1, "buckets": [ { "level": "DAY", "ref": "2026-03-15", "value": 3500 } ] }'
 ```
-- 2026-03-15 has **24 hours**. SUM domain → `3500 / 24 = 145.8333… kWh/hour`.
-- 24 hour rows for `03-15` rewritten with `sourceLevel: "DAY", derived: false` (operator-set the day; its hours are now confirmed, no longer "suggested").
+- 2026-03-15 has **24 hours** → `3500 / 24 = 145.8333… kWh/hour`, written `sourceLevel: "DAY", derived: false` (operator-confirmed).
 - The other 720 March hours (`derived: true`) are untouched.
-- `version` 1 → **2**. History row appended — the author's exact case:
-```json
-{ "actionLevel": "DAY", "bucketRef": "2026-03-15",
-  "oldValue": 3225.806, "newValue": 3500.0,
-  "distributed": true, "hoursAffected": 24, "version": 2 }
-```
-(`oldValue ≈ 3225.806` = the previous day roll-up: `24 × 134.4086…`.)
+- `version` 1 → **2**. History row: `{ source: "MERGE", actionLevel: "DAY", bucketRef: "2026-03-15", newValue: 3500, bucketCount: 1, hoursAffected: 24, version: 2 }`.
 
-**New March total** = `720 × 134.4086… + 3500 = 96774.19… + 3500 = 100274.19… kWh`.
-
-### Step 4 — GET day confirms the edit
+### Step 4 — history (newest first)
 ```bash
-curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=day" -H "X-API-Key: …"
-```
-```json
-{ "year": 2026, "version": 2,
-  "tree": {
-    "annual":  { "value": 100274.19, "method": "SUM" },
-    "monthly": { "03": { "value": 100274.19, "method": "SUM", "sourceLevel": "DAY", "derived": false } },
-    "daily": {
-      "03-15": { "value": 3500.0,    "method": "SUM", "sourceLevel": "DAY",   "derived": false },
-      "03-14": { "value": 3225.806,  "method": "SUM", "sourceLevel": "MONTH", "derived": true  }
-    }
-  } }
-```
-
-### Step 5 — history (newest first)
-```bash
-curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=month&fetchHistory=true" -H "X-API-Key: …"
+curl ".../goals?domain=ENERGY&year=2026&granularity=month&fetchHistory=true" -H "X-API-Key: …"
 ```
 ```json
 { "version": 2,
   "history": [
-    { "actionLevel": "DAY",   "bucketRef": "2026-03-15", "oldValue": 3225.806, "newValue": 3500.0,
-      "distributed": true, "hoursAffected": 24,  "version": 2 },
-    { "actionLevel": "MONTH", "bucketRef": "2026-03",    "oldValue": null,     "newValue": 100000,
-      "distributed": true, "hoursAffected": 744, "version": 1 }
+    { "source": "MERGE", "actionLevel": "DAY",   "bucketRef": "2026-03-15", "newValue": 3500,   "bucketCount": 1, "details": [{ "ref": "2026-03-15", "value": 3500 }],   "distributed": true, "hoursAffected": 24,  "version": 2 },
+    { "source": "MERGE", "actionLevel": "MONTH", "bucketRef": "2026-03",    "newValue": 100000, "bucketCount": 1, "details": [{ "ref": "2026-03",    "value": 100000 }], "distributed": true, "hoursAffected": 744, "version": 1 }
   ] }
 ```
 
@@ -625,12 +539,13 @@ curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=month
 ## 6. Quick reference — invariants for the frontend adapter
 
 - Storage is hourly; you never send hours unless you mean to — coarse buckets are distributed for you.
+- **PUT** body is a **nested tree** (`annual`/`monthly{daily{hourly}}`); **PATCH** body is a flat **`buckets[]`** (`{level, ref, value}`).
+- Import is **stateless**: post with `?dryRun=true` to preview, re-post the same `csv` with `?dryRun=false` to persist. No previewToken.
 - Read `method` on every node; render AVERAGE (temperature) and SUM (energy/water) differently.
 - `derived:true` = system-suggested (safe to overwrite on coarse edits); `derived:false` = operator-confirmed (preserved).
-- `PUT` wipes the year to exactly your payload; `PATCH` only touches what you send.
-- On `409`, read `error.currentVersion`, re-`GET`, reapply the operator's intended change against the new version — do not silently discard.
-- `fetchHistory=true` is capped at 100 newest-first entries; paginate by time client-side if you need more (no server cursor in this version).
+- On `409`, read `error.currentVersion`, re-`GET`, reapply against the new version — do not silently discard.
+- `fetchHistory=true` is capped at 100 newest-first **operation** entries (one per version); paginate by time client-side if you need more (no server cursor in this version).
 
 ---
 
-**Source of truth:** [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md) · **Last updated:** 2026-06-18
+**Source of truth:** [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md) + the implementation. · **Last updated:** 2026-06-19

--- a/docs/RFC-0046-Goals-API.md
+++ b/docs/RFC-0046-Goals-API.md
@@ -1,0 +1,636 @@
+# RFC-0046 — Customer Consumption Goals API
+
+**Contract document** shared by the GCDR backend and frontend (`GoalsPanel` / `openGoalsPanel`) teams.
+This is the authoritative wire contract derived from [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md).
+If this document and the RFC disagree, the RFC wins; open a PR to reconcile.
+
+- **Status:** Design closed (DEC-1…DEC-7). Implementation contract — first backend step.
+- **Base path:** `/api/v1`
+- **Auth:** hybrid (`hybridAuthByMethod`) — JWT Bearer *or* customer API key (`X-API-Key: gcdr_cust_*`).
+- **Scopes:** reads need `goals:read` (or `*:read`); writes need `goals:write`.
+- **Audit:** every write emits `CUSTOMER_GOALS_UPDATED` `{ customerId, domain, year, version, actionLevel }` (no goal values in the audit row).
+
+---
+
+## 1. Concepts consumers MUST understand
+
+These rules govern every request/response. Read this before the endpoint reference.
+
+### 1.1 Always-hourly canonical storage
+The **hour is the only stored grain**. A fully-specified year is up to **8,760 hour rows** per `(customer, domain, year)`. The `granularity` an operator picks is an **input mode**, not a storage shape; coarser views (`year`/`month`/`day`) are **derived on read**, never materialised.
+
+### 1.2 Aggregation method is FIXED per domain
+The method is a property of the domain, not an operator choice and not stored on each hour row:
+
+| Domain | `unit` | `aggregationMethod` | Distribution on write | Roll-up on read | Negative values |
+| --- | --- | --- | --- | --- | --- |
+| `ENERGY` | `kWh` | `SUM` | even split: `hourValue = parentValue / hoursInScope` | `SUM(hours)` | rejected (`>= 0`) |
+| `WATER` | `m3` | `SUM` | even split | `SUM(hours)` | rejected (`>= 0`) |
+| `TEMPERATURE` | `C` | `AVERAGE` | **copy** parent to each hour | **weighted** `AVG(hours)` | allowed |
+
+`total = 25` on a TEMPERATURE goal reads as "25 °C", not "25 units summed".
+
+### 1.3 Distribution on write (coarser input → hour rows)
+- **`SUM` domains** — parent value is split **evenly** across the hours in scope (`parent / hoursInScope`). Example: a March total ÷ 744 hours (31 days × 24).
+- **`AVERAGE` domains** — parent value is **copied** to each hour, so the weighted average back up equals the parent.
+- Each generated hour row carries:
+  - `sourceLevel` — the level the operator actually set (`YEAR | MONTH | DAY | HOUR`).
+  - `derived` — `true` when system-distributed, `false` when the operator set that exact hour.
+- A later coarser edit re-distributes over `derived = true` hours **only** by default. Operator-confirmed (`derived = false`) hours are preserved unless the operator forces a reset. This backs the panel's "suggested vs confirmed" UX.
+
+### 1.4 Roll-up on read (coarser output ← hour rows)
+Computed on read:
+- `DAY` = `SUM(hours)` (SUM domains) or **weighted** `AVG(hours)` (AVERAGE domains).
+- `MONTH` / `YEAR` = same reduction over their hours.
+- **Weighted** = by the count of contributing hours (DEC-2) — a 31-day month does not weigh the same as February.
+- Every node in the returned tree declares its `method`, so a temperature average is never mistaken for a sum.
+
+### 1.5 Write semantics — `PUT` (replace) vs `PATCH` (merge) — DEC-5
+- **`PUT` = replace** the whole `(year, domain)`. The payload *is* the year; buckets absent from the payload's scope are **removed**.
+- **`PATCH` = merge** only the sent buckets; everything else is preserved. CSV import uses PATCH/merge semantics and is idempotent per bucket.
+
+### 1.6 Versioning & optimistic concurrency — DEC-4
+- `version` lives on the parent `(tenant, customer, domain, year)` and **increments on every successful change**.
+- `PUT`/`PATCH`/`DELETE` MAY send the expected `version` (body field or `If-Match`-style). A mismatch → **`409 Conflict`** with the current `version` in the body (`error.currentVersion`).
+- The front-end treats `409` as **reload-and-reapply**, not reload-and-discard.
+- The hourly upsert, the version bump, and the history append run in **one transaction**.
+
+### 1.7 History
+`?fetchHistory=true` adds a `history` array of **≤100 entries, newest-first**. Each entry records the **level the operator acted on** (not the 8,760 underlying hours): `actionLevel`, `bucketRef`, `oldValue`, `newValue`, `distributed`, `hoursAffected`, `version`, `actor`, `changedAt`.
+
+### 1.8 Response & error envelope
+Success and error bodies follow the standard GCDR envelope.
+
+Success:
+```json
+{ "success": true, "data": { /* ... */ }, "meta": { "requestId": "…", "timestamp": "…" } }
+```
+Error:
+```json
+{ "success": false, "error": { "message": "…", "code": "…", "details": { } }, "meta": { "requestId": "…", "timestamp": "…" } }
+```
+In examples below the `meta` wrapper is omitted for brevity; only `data` (or `error`) contents are shown unless noted.
+
+---
+
+## 2. Common parameters
+
+### Path
+| Param | Type | Description |
+| --- | --- | --- |
+| `id` | uuid | Customer id. Hierarchy access (`SELF`/`SUBTREE`/`TENANT`) is honoured. |
+
+### Query discriminators (write + single-domain read)
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `domain` | enum | yes | `ENERGY` \| `WATER` \| `TEMPERATURE`. |
+| `year` | smallint | yes | e.g. `2026`. |
+| `granularity` | enum | no (read only) | `year` \| `month` \| `day` \| `hour`. Default `month`. |
+| `fetchHistory` | boolean | no (read only) | `true` → adds `history` (≤100, newest-first). Default `false`. |
+
+### Validation rules (`400 VALIDATION_ERROR`)
+- `domain` must be one of the three; `unit` (if echoed in a body) must match the domain.
+- `year` plausible; `month` `1..12`; `day` valid for the month/year (**leap-year aware**); `hour` `0..23`.
+- `value` `.finite()`. SUM domains require `value >= 0`; TEMPERATURE may be negative.
+- `granularity` ∈ the four levels; `granularity=hour` is fully supported on read and write.
+
+---
+
+## 3. Endpoints
+
+| # | Action | Method | Path | Scope |
+| --- | --- | --- | --- | --- |
+| 3.1 | List domains with goals | `GET` | `/customers/:id/goals` | `goals:read` |
+| 3.2 | Get goals (derived tree) | `GET` | `/customers/:id/goals?domain=&year=&granularity=&fetchHistory=` | `goals:read` |
+| 3.3 | Replace a year+domain | `PUT` | `/customers/:id/goals?domain=&year=` | `goals:write` |
+| 3.4 | Merge buckets | `PATCH` | `/customers/:id/goals?domain=&year=` | `goals:write` |
+| 3.5 | Import CSV (dry-run/confirm) | `POST` | `/customers/:id/goals/import?domain=&year=` | `goals:write` |
+| 3.6 | Delete a year (or sub-bucket) | `DELETE` | `/customers/:id/goals?domain=&year=` | `goals:write` |
+
+---
+
+### 3.1 List domains with goals
+
+```
+GET /api/v1/customers/:id/goals
+```
+**Auth:** `goals:read`. **Query:** none. Returns a summary per domain that has any goals (years present, current version, unit). A customer with no goals returns an empty `domains` array.
+
+**Request**
+```bash
+curl -X GET "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals" \
+  -H "Authorization: Bearer {TOKEN}" \
+  -H "X-Tenant-Id: 11111111-1111-1111-1111-111111111111"
+```
+
+**200 OK**
+```json
+{
+  "success": true,
+  "data": {
+    "customerId": "33333333-3333-3333-3333-333333333333",
+    "domains": [
+      { "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM", "years": [
+          { "year": 2026, "version": 7 },
+          { "year": 2025, "version": 2 }
+        ] },
+      { "domain": "WATER", "unit": "m3", "aggregationMethod": "SUM", "years": [
+          { "year": 2026, "version": 1 }
+        ] },
+      { "domain": "TEMPERATURE", "unit": "C", "aggregationMethod": "AVERAGE", "years": [] }
+    ]
+  }
+}
+```
+
+---
+
+### 3.2 Get goals (derived tree)
+
+```
+GET /api/v1/customers/:id/goals?domain=ENERGY&year=2026&granularity=month
+```
+**Auth:** `goals:read`.
+**Query:** `domain` (req), `year` (req), `granularity` (`year|month|day|hour`, default `month`), `fetchHistory` (default `false`).
+The `tree` is derived from hours at the requested granularity. Each node declares its `method`. A `(domain, year)` with no goals returns `version: 0` and an empty `tree`.
+
+**Request**
+```bash
+curl -X GET "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026&granularity=month&fetchHistory=true" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026"
+```
+
+#### Response shape by granularity
+
+`?granularity=year` — single annual node:
+```json
+{
+  "customerId": "33333333-3333-3333-3333-333333333333",
+  "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
+  "year": 2026, "version": 7,
+  "tree": { "annual": { "value": 1200000, "method": "SUM" } }
+}
+```
+
+`?granularity=month` (default) — annual + 12 monthly nodes:
+```json
+{
+  "customerId": "33333333-3333-3333-3333-333333333333",
+  "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
+  "year": 2026, "version": 7,
+  "tree": {
+    "annual": { "value": 1200000, "method": "SUM" },
+    "monthly": {
+      "01": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false },
+      "02": { "value": 100000, "method": "SUM", "sourceLevel": "YEAR",  "derived": true  },
+      "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false }
+    }
+  }
+}
+```
+> `sourceLevel`/`derived` on an aggregated node reflect the **finest level the user set** within it: `derived:true` means every contributing hour was system-distributed; if any hour in the node was operator-confirmed (`derived:false`) the node reports `derived:false`.
+
+`?granularity=day` — annual + monthly + daily nodes keyed `MM-DD`:
+```json
+{
+  "tree": {
+    "annual":  { "value": 1200000, "method": "SUM" },
+    "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": false } },
+    "daily": {
+      "03-15": { "value": 3500.0, "method": "SUM", "sourceLevel": "DAY",   "derived": false },
+      "03-16": { "value": 3225.8, "method": "SUM", "sourceLevel": "MONTH", "derived": true  }
+    }
+  }
+}
+```
+
+`?granularity=hour` — full hourly tree, keyed `MM-DDThh` (24 hour leaves per day):
+```json
+{
+  "tree": {
+    "annual":  { "value": 1200000, "method": "SUM" },
+    "monthly": { "03": { "value": 100000, "method": "SUM" } },
+    "daily":   { "03-15": { "value": 3500.0, "method": "SUM" } },
+    "hourly": {
+      "03-15T00": { "value": 145.83, "method": "SUM", "sourceLevel": "DAY", "derived": true },
+      "03-15T01": { "value": 145.83, "method": "SUM", "sourceLevel": "DAY", "derived": true }
+    }
+  }
+}
+```
+
+#### TEMPERATURE example (`AVERAGE`, weighted, negative allowed)
+```json
+{
+  "domain": "TEMPERATURE", "unit": "C", "aggregationMethod": "AVERAGE",
+  "year": 2026, "version": 3,
+  "tree": {
+    "annual": { "value": 23.0, "method": "AVERAGE" },
+    "monthly": {
+      "01": { "value": 23.0, "method": "AVERAGE", "sourceLevel": "YEAR", "derived": true },
+      "07": { "value": 25.0, "method": "AVERAGE", "sourceLevel": "MONTH", "derived": false }
+    }
+  }
+}
+```
+
+#### With `fetchHistory=true`
+Adds `history` (≤100, newest-first) alongside `tree`:
+```json
+{
+  "version": 7,
+  "tree": { "annual": { "value": 1200000, "method": "SUM" } },
+  "history": [
+    { "actionLevel": "DAY",   "bucketRef": "2026-03-15", "oldValue": 3225.8, "newValue": 3500.0,
+      "distributed": true, "hoursAffected": 24,  "version": 7,
+      "actor": "9a…", "changedAt": "2026-06-18T14:22:10.000Z" },
+    { "actionLevel": "MONTH", "bucketRef": "2026-03",    "oldValue": null,   "newValue": 100000,
+      "distributed": true, "hoursAffected": 744, "version": 6,
+      "actor": "9a…", "changedAt": "2026-06-18T14:00:00.000Z" }
+  ]
+}
+```
+
+**Errors:** `400` (bad `domain`/`year`/`granularity`), `401`/`403` (auth/scope), `404` (customer not found).
+
+---
+
+### 3.3 Replace a year+domain (`PUT`)
+
+```
+PUT /api/v1/customers/:id/goals?domain=ENERGY&year=2026
+```
+**Auth:** `goals:write`. **Semantics:** REPLACE — the payload is the whole year for that domain; buckets absent from the payload's scope are **removed**. System distributes each leaf down to hours.
+
+**Body**
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `expectedVersion` | integer | no | Optimistic guard. Omit to force-write. `0` = "I expect no existing goal". |
+| `granularity` | enum | yes | The level the values are expressed at (`year`/`month`/`day`/`hour`). |
+| `values` | object | yes | Keyed by bucket at the chosen granularity (`"2026"`, `"03"`, `"03-15"`, `"03-15T08"`). |
+
+**Request — set a YEAR total**
+```bash
+curl -X PUT "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -d '{
+    "expectedVersion": 6,
+    "granularity": "month",
+    "values": {
+      "01": 100000, "02": 100000, "03": 100000, "04": 100000,
+      "05": 100000, "06": 100000, "07": 100000, "08": 100000,
+      "09": 100000, "10": 100000, "11": 100000, "12": 100000
+    }
+  }'
+```
+
+**200 OK** — returns the resulting derived tree at the request granularity plus the new `version`:
+```json
+{
+  "success": true,
+  "data": {
+    "customerId": "33333333-3333-3333-3333-333333333333",
+    "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
+    "year": 2026, "version": 7,
+    "tree": {
+      "annual": { "value": 1200000, "method": "SUM" },
+      "monthly": { "01": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": true } }
+    },
+    "distribution": { "hoursWritten": 8760, "actionLevel": "MONTH" }
+  }
+}
+```
+
+**Errors:** `400`, `401`/`403`, `404`, `409` (version conflict — §4), `422` (semantically valid JSON but un-persistable, e.g. monthly buckets do not cover/exceed the replaced year scope, or mixed-granularity conflict that cannot be resolved).
+
+---
+
+### 3.4 Merge buckets (`PATCH`)
+
+```
+PATCH /api/v1/customers/:id/goals?domain=ENERGY&year=2026
+```
+**Auth:** `goals:write`. **Semantics:** MERGE — only the sent buckets are (re)distributed; all other buckets are preserved. Re-distribution overwrites `derived:true` hours only (operator-confirmed hours preserved).
+
+**Body** — same shape as PUT, but `values` contains only the buckets to change. Buckets may mix granularity in one call (`granularity` then declares the *finest* level present; each key's depth determines its own level).
+
+**Request — edit one DAY**
+```bash
+curl -X PATCH "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -d '{
+    "expectedVersion": 6,
+    "granularity": "day",
+    "values": { "03-15": 3500.0 }
+  }'
+```
+
+**200 OK**
+```json
+{
+  "success": true,
+  "data": {
+    "customerId": "33333333-3333-3333-3333-333333333333",
+    "domain": "ENERGY", "unit": "kWh", "aggregationMethod": "SUM",
+    "year": 2026, "version": 7,
+    "tree": {
+      "annual": { "value": 1200256.0, "method": "SUM" },
+      "monthly": { "03": { "value": 100256.0, "method": "SUM", "sourceLevel": "DAY", "derived": false } },
+      "daily":   { "03-15": { "value": 3500.0, "method": "SUM", "sourceLevel": "DAY", "derived": false } }
+    },
+    "distribution": { "hoursWritten": 24, "actionLevel": "DAY" }
+  }
+}
+```
+
+**Errors:** `400`, `401`/`403`, `404`, `409` (§4), `422`.
+
+---
+
+### 3.5 Import CSV (dry-run / confirm)
+
+```
+POST /api/v1/customers/:id/goals/import?domain=ENERGY&year=2026
+```
+**Auth:** `goals:write`. **Semantics:** merge by bucket (PATCH), idempotent per bucket. **Always dry-run first** — nothing is saved until an explicit confirm. Finest-granularity wins on conflicting lines; partial import is explicit (valid lines import, invalid lines are listed with a downloadable error report).
+
+**Body**
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `mode` | enum | yes | `dryRun` (preview, nothing saved) or `confirm` (persist). |
+| `csv` | string | yes (`dryRun`) | Raw CSV text. Header: `bucket,value` where `bucket` ∈ `2026` / `2026-03` / `2026-03-15` / `2026-03-15T08`. |
+| `token` | string | yes (`confirm`) | The `previewToken` returned by a prior `dryRun`, binding confirm to a previewed result. |
+| `expectedVersion` | integer | no (`confirm`) | Optimistic guard for the persist step. |
+
+**Request — dry run**
+```bash
+curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -d '{
+    "mode": "dryRun",
+    "csv": "bucket,value\n2026-01,100000\n2026-02,100000\n2026-03-15,3500\n2026-13,999\n"
+  }'
+```
+
+**200 OK — dry-run preview** (nothing persisted)
+```json
+{
+  "success": true,
+  "data": {
+    "mode": "dryRun",
+    "previewToken": "imp_5f2c…",
+    "summary": { "linesTotal": 4, "ok": 3, "problems": 1,
+      "willApply": { "monthly": 2, "daily": 1, "hourly": 0 } },
+    "diagnostics": [
+      { "line": 4, "bucket": "2026-13", "value": 999,
+        "severity": "error", "code": "INVALID_MONTH",
+        "message": "month must be 1..12" }
+    ],
+    "ghostTree": {
+      "annual": { "value": 203500, "method": "SUM" },
+      "monthly": { "01": { "value": 100000, "method": "SUM" }, "02": { "value": 100000, "method": "SUM" } },
+      "daily": { "03-15": { "value": 3500, "method": "SUM" } }
+    },
+    "errorReportUrl": "/api/v1/customers/33333333-…/goals/import/imp_5f2c…/errors.csv"
+  }
+}
+```
+
+**Request — confirm**
+```bash
+curl -X POST "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals/import?domain=ENERGY&year=2026" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -d '{ "mode": "confirm", "token": "imp_5f2c…", "expectedVersion": 7 }'
+```
+
+**200 OK — confirmed**
+```json
+{
+  "success": true,
+  "data": {
+    "mode": "confirm",
+    "applied": { "monthly": 2, "daily": 1, "hourly": 0, "linesIgnored": 1 },
+    "year": 2026, "version": 8,
+    "logUrl": "/api/v1/customers/33333333-…/goals/import/imp_5f2c…/log.csv"
+  }
+}
+```
+
+**Errors:** `400` (malformed body/CSV header), `401`/`403`, `404`, `409` (version conflict on confirm — §4), `422` (e.g. all lines invalid, or `confirm` with an expired/unknown `token`).
+
+---
+
+### 3.6 Delete a year (or sub-bucket)
+
+```
+DELETE /api/v1/customers/:id/goals?domain=ENERGY&year=2026
+```
+**Auth:** `goals:write`. Removes the year for the domain. Optionally narrow the deletion to a sub-bucket. Logged + versioned (history entry with `newValue: null`).
+
+**Query (in addition to `domain`, `year`)**
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `bucket` | string | no | Narrow to a bucket: `03` (month) / `03-15` (day) / `03-15T08` (hour). Omit = delete the whole year. |
+| `expectedVersion` | integer | no | Optimistic guard. |
+
+**Request**
+```bash
+curl -X DELETE "http://localhost:3015/api/v1/customers/33333333-3333-3333-3333-333333333333/goals?domain=ENERGY&year=2026&bucket=03" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026"
+```
+
+**200 OK**
+```json
+{
+  "success": true,
+  "data": {
+    "customerId": "33333333-3333-3333-3333-333333333333",
+    "domain": "ENERGY", "year": 2026,
+    "deleted": { "bucket": "03", "hoursRemoved": 744, "actionLevel": "MONTH" },
+    "version": 9
+  }
+}
+```
+Deleting the **whole year** (no `bucket`) removes the parent row and all its hours; subsequent `GET` for that `(domain, year)` returns `version: 0` and an empty `tree`. Such a full delete MAY return `204 No Content` (no body) when the client sends no `expectedVersion`; with a guard it returns `200` and the body above.
+
+**Errors:** `400`, `401`/`403`, `404` (customer or `(domain, year)` not found), `409` (§4).
+
+---
+
+## 4. Error responses
+
+All errors use the standard envelope: `{ success: false, error: { message, code, details }, meta }`.
+
+### 4.1 `400 Bad Request` — validation (`VALIDATION_ERROR`)
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Validation failed",
+    "code": "VALIDATION_ERROR",
+    "details": {
+      "domain": ["Invalid enum value. Expected 'ENERGY' | 'WATER' | 'TEMPERATURE'"],
+      "values.03": ["value must be a finite number >= 0 for SUM domains"],
+      "values.02-30": ["day 30 is not valid for month 02 of year 2026"]
+    }
+  },
+  "meta": { "requestId": "…", "timestamp": "2026-06-18T14:22:10.000Z" }
+}
+```
+
+### 4.2 `401 / 403` — auth & scope
+- `401 UNAUTHORIZED` — missing/invalid JWT or API key.
+- `403 FORBIDDEN` — authenticated but lacks the scope (`goals:read` for reads, `goals:write` for writes) or hierarchy access to the customer.
+```json
+{
+  "success": false,
+  "error": { "message": "Missing required scope: goals:write", "code": "FORBIDDEN", "details": { "requiredScope": "goals:write" } },
+  "meta": { "requestId": "…", "timestamp": "…" }
+}
+```
+
+### 4.3 `404 Not Found` (`NOT_FOUND`)
+```json
+{
+  "success": false,
+  "error": { "message": "Customer not found", "code": "NOT_FOUND", "details": { "customerId": "33333333-…" } },
+  "meta": { "requestId": "…", "timestamp": "…" }
+}
+```
+
+### 4.4 `409 Conflict` — optimistic version mismatch (`VERSION_CONFLICT`)
+Returned when `expectedVersion` does not match the stored `version`. **`currentVersion` is in the body** so the front-end can reload-and-reapply.
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Version conflict: goal was modified by another change",
+    "code": "VERSION_CONFLICT",
+    "currentVersion": 9,
+    "details": { "expectedVersion": 6, "currentVersion": 9, "domain": "ENERGY", "year": 2026 }
+  },
+  "meta": { "requestId": "…", "timestamp": "…" }
+}
+```
+
+### 4.5 `422 Unprocessable Entity` (`UNPROCESSABLE_ENTITY`)
+Syntactically valid request that cannot be applied as a goal:
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Import confirm token expired or unknown",
+    "code": "UNPROCESSABLE_ENTITY",
+    "details": { "token": "imp_5f2c…", "reason": "EXPIRED" }
+  },
+  "meta": { "requestId": "…", "timestamp": "…" }
+}
+```
+Other `422` cases: every CSV line invalid; a PUT whose buckets cannot tile the replaced year scope; unresolvable mixed-granularity conflict.
+
+---
+
+## 5. Worked example, end-to-end
+
+A concrete trace of the author's case: an operator sets a MONTH energy value, the system distributes it to that month's hours, then edits one DAY producing a history entry.
+
+**Start:** customer `33333333-…` has no ENERGY 2026 goal. `GET …?domain=ENERGY&year=2026` → `version: 0`, empty `tree`.
+
+### Step 1 — operator sets MONTH (March) = 100,000 kWh
+```bash
+curl -X PATCH ".../customers/33333333-…/goals?domain=ENERGY&year=2026" \
+  -H "X-API-Key: gcdr_cust_test_bundle_key_myio2026" \
+  -H "Content-Type: application/json" \
+  -d '{ "granularity": "month", "values": { "03": 100000 } }'
+```
+- March 2026 has 31 days → **744 hours**. SUM domain → even split: `100000 / 744 = 134.4086… kWh/hour`.
+- 744 hour rows written with `sourceLevel: "MONTH", derived: true`.
+- `version` 0 → **1**. History row appended:
+  `{ actionLevel: "MONTH", bucketRef: "2026-03", oldValue: null, newValue: 100000, distributed: true, hoursAffected: 744, version: 1 }`.
+
+**Response `200`:**
+```json
+{ "year": 2026, "version": 1,
+  "tree": { "annual": { "value": 100000, "method": "SUM" },
+            "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": true } } },
+  "distribution": { "hoursWritten": 744, "actionLevel": "MONTH" } }
+```
+
+### Step 2 — GET month shows it (roll-up on read)
+```bash
+curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=month" -H "X-API-Key: …"
+```
+```json
+{ "year": 2026, "version": 1,
+  "tree": { "annual": { "value": 100000, "method": "SUM" },
+            "monthly": { "03": { "value": 100000, "method": "SUM", "sourceLevel": "MONTH", "derived": true } } } }
+```
+> `SUM(744 hours × 134.4086…) = 100000` — the roll-up reproduces the entered month total.
+
+### Step 3 — operator edits one DAY (2026-03-15) = 3,500 kWh
+```bash
+curl -X PATCH ".../customers/33333333-…/goals?domain=ENERGY&year=2026" \
+  -H "X-API-Key: …" -H "Content-Type: application/json" \
+  -d '{ "expectedVersion": 1, "granularity": "day", "values": { "03-15": 3500 } }'
+```
+- 2026-03-15 has **24 hours**. SUM domain → `3500 / 24 = 145.8333… kWh/hour`.
+- 24 hour rows for `03-15` rewritten with `sourceLevel: "DAY", derived: false` (operator-set the day; its hours are now confirmed, no longer "suggested").
+- The other 720 March hours (`derived: true`) are untouched.
+- `version` 1 → **2**. History row appended — the author's exact case:
+```json
+{ "actionLevel": "DAY", "bucketRef": "2026-03-15",
+  "oldValue": 3225.806, "newValue": 3500.0,
+  "distributed": true, "hoursAffected": 24, "version": 2 }
+```
+(`oldValue ≈ 3225.806` = the previous day roll-up: `24 × 134.4086…`.)
+
+**New March total** = `720 × 134.4086… + 3500 = 96774.19… + 3500 = 100274.19… kWh`.
+
+### Step 4 — GET day confirms the edit
+```bash
+curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=day" -H "X-API-Key: …"
+```
+```json
+{ "year": 2026, "version": 2,
+  "tree": {
+    "annual":  { "value": 100274.19, "method": "SUM" },
+    "monthly": { "03": { "value": 100274.19, "method": "SUM", "sourceLevel": "DAY", "derived": false } },
+    "daily": {
+      "03-15": { "value": 3500.0,    "method": "SUM", "sourceLevel": "DAY",   "derived": false },
+      "03-14": { "value": 3225.806,  "method": "SUM", "sourceLevel": "MONTH", "derived": true  }
+    }
+  } }
+```
+
+### Step 5 — history (newest first)
+```bash
+curl ".../customers/33333333-…/goals?domain=ENERGY&year=2026&granularity=month&fetchHistory=true" -H "X-API-Key: …"
+```
+```json
+{ "version": 2,
+  "history": [
+    { "actionLevel": "DAY",   "bucketRef": "2026-03-15", "oldValue": 3225.806, "newValue": 3500.0,
+      "distributed": true, "hoursAffected": 24,  "version": 2 },
+    { "actionLevel": "MONTH", "bucketRef": "2026-03",    "oldValue": null,     "newValue": 100000,
+      "distributed": true, "hoursAffected": 744, "version": 1 }
+  ] }
+```
+
+---
+
+## 6. Quick reference — invariants for the frontend adapter
+
+- Storage is hourly; you never send hours unless you mean to — coarse buckets are distributed for you.
+- Read `method` on every node; render AVERAGE (temperature) and SUM (energy/water) differently.
+- `derived:true` = system-suggested (safe to overwrite on coarse edits); `derived:false` = operator-confirmed (preserved).
+- `PUT` wipes the year to exactly your payload; `PATCH` only touches what you send.
+- On `409`, read `error.currentVersion`, re-`GET`, reapply the operator's intended change against the new version — do not silently discard.
+- `fetchHistory=true` is capped at 100 newest-first entries; paginate by time client-side if you need more (no server cursor in this version).
+
+---
+
+**Source of truth:** [`RFC-0046-Customer-Consumption-Goals.md`](./RFC-0046-Customer-Consumption-Goals.md) · **Last updated:** 2026-06-18

--- a/docs/RFC-0046-Goals-schema.md
+++ b/docs/RFC-0046-Goals-schema.md
@@ -9,10 +9,11 @@ four tables exactly as the RFC closes them:
 | `consumption_goals` | parent per `(tenant, customer, domain, year)`, holds the optimistic `version` |
 | `consumption_goal_hours` | the canonical hourly grain (≤ 8 760 rows/goal) |
 | `consumption_goal_domains` | fixed aggregation config (`aggregation_method` + `unit`) per `(tenant, domain)` |
-| `consumption_goal_history` | append-only audit at the input level the user acted on |
+| `consumption_goal_history` | append-only audit, **one row per operation** (source + input level + bucket count + details sample) |
 
-Companion migration: `drizzle/migrations/NNNN_consumption_goals.sql` (the `NNNN`
-number is assigned at integration time — see that file's header).
+Companion migrations:
+- `drizzle/migrations/0047_consumption_goals.sql` — the four tables + domain seed.
+- `drizzle/migrations/0048_consumption_goals_history_ops.sql` — additive `ALTER` adding the operation-level audit columns (`source`, `bucket_count`, `details`) + the `source` CHECK to `consumption_goal_history`. The Drizzle snippet below already includes these columns (the live `schema.ts` reflects post-0048).
 
 ---
 
@@ -106,18 +107,22 @@ export const consumptionGoalDomains = pgTable('consumption_goal_domains', {
   ),
 }));
 
-// 4) Append-only history. Records the level the user acted on (DEC-4).
+// 4) Append-only history. ONE row per operation (DEC-4): records the operation
+//    source, the coarsest level touched, the bucket count, and a details sample.
 export const consumptionGoalHistory = pgTable('consumption_goal_history', {
   id:            uuid('id').primaryKey().defaultRandom(),
   goalId:        uuid('goal_id').notNull(),
   actor:         uuid('actor'),                          // who changed it
-  actionLevel:   text('action_level').notNull(),         // YEAR | MONTH | DAY | HOUR — what the user touched
-  bucketRef:     text('bucket_ref').notNull(),           // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
-  oldValue:      numeric('old_value'),                   // at the input level (NULL on create)
-  newValue:      numeric('new_value'),                   // at the input level (NULL on delete)
+  source:        text('source').notNull().default('EDIT'), // IMPORT | REPLACE | MERGE | DELETE | EDIT
+  actionLevel:   text('action_level').notNull(),         // YEAR | MONTH | DAY | HOUR — coarsest level touched
+  bucketRef:     text('bucket_ref').notNull(),           // representative ref for the operation
+  oldValue:      numeric('old_value'),                   // at the input level (NULL on create / multi-bucket)
+  newValue:      numeric('new_value'),                   // single-bucket value, else NULL
+  bucketCount:   integer('bucket_count').notNull().default(1), // operator buckets this operation carried
+  details:       jsonb('details').notNull().default([]), // compact [{ ref, value }] sample (capped at 50)
   distributed:   boolean('distributed').notNull(),       // true = system spread to hours
-  hoursAffected: integer('hours_affected').notNull(),    // count of hour rows written by this change
-  version:       integer('version').notNull(),           // the version this change produced
+  hoursAffected: integer('hours_affected').notNull(),    // total hour rows written by this operation
+  version:       integer('version').notNull(),           // the version this operation produced
   changedAt:     timestamp('changed_at', { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({
   goalChronoIdx: index('consumption_goal_history_idx').on(table.goalId, table.changedAt.desc()),
@@ -125,8 +130,15 @@ export const consumptionGoalHistory = pgTable('consumption_goal_history', {
     'consumption_goal_history_action_level_check',
     sql`${table.actionLevel} IN ('YEAR','MONTH','DAY','HOUR')`
   ),
+  sourceCheck: check(
+    'consumption_goal_history_source_check',
+    sql`${table.source} IN ('IMPORT','REPLACE','MERGE','DELETE','EDIT')`
+  ),
 }));
 ```
+
+> **`jsonb` import.** `consumption_goal_history.details` needs `jsonb` from
+> `drizzle-orm/pg-core` (already imported in `schema.ts`).
 
 ---
 

--- a/docs/RFC-0046-Goals-schema.md
+++ b/docs/RFC-0046-Goals-schema.md
@@ -1,0 +1,151 @@
+# RFC-0046 — Consumption Goals · Drizzle schema snippet
+
+This is the data-model artifact for **RFC-0046 — Customer Consumption Goals**
+(`docs/RFC-0046-Customer-Consumption-Goals.md`, §"Data model"). It defines the
+four tables exactly as the RFC closes them:
+
+| Table | Role |
+| --- | --- |
+| `consumption_goals` | parent per `(tenant, customer, domain, year)`, holds the optimistic `version` |
+| `consumption_goal_hours` | the canonical hourly grain (≤ 8 760 rows/goal) |
+| `consumption_goal_domains` | fixed aggregation config (`aggregation_method` + `unit`) per `(tenant, domain)` |
+| `consumption_goal_history` | append-only audit at the input level the user acted on |
+
+Companion migration: `drizzle/migrations/NNNN_consumption_goals.sql` (the `NNNN`
+number is assigned at integration time — see that file's header).
+
+---
+
+## How to integrate into `src/infrastructure/database/drizzle/schema.ts`
+
+Append the block below to the **end** of `schema.ts` (after the work-orders /
+annotations section). It reuses the imports already present at the top of the
+file (`pgTable, uuid, text, smallint, integer, boolean, numeric, timestamp,
+index, uniqueIndex, check, primaryKey`) plus `sql` from `drizzle-orm`.
+
+> **One new import is required.** `numeric` is not yet imported in `schema.ts` —
+> add it to the existing `from 'drizzle-orm/pg-core'` import list:
+>
+> ```ts
+> import {
+>   pgTable,
+>   // …existing imports…
+>   numeric,   // ← add for RFC-0046 consumption_goal_hours.value / history values
+> } from 'drizzle-orm/pg-core';
+> ```
+
+### Drizzle snippet
+
+```ts
+// =============================================================================
+// CONSUMPTION GOALS (RFC-0046)
+// =============================================================================
+// Per-customer targets for ENERGY | WATER | TEMPERATURE, scoped by domain and
+// year, persisted at a single canonical grain — the hour. The parent row holds
+// the optimistic `version`; hours are derived-on-write / aggregated-on-read.
+
+// 1) Parent — one per (tenant, customer, domain, year); carries the version.
+export const consumptionGoals = pgTable('consumption_goals', {
+  id:         uuid('id').primaryKey().defaultRandom(),
+  tenantId:   uuid('tenant_id').notNull(),
+  customerId: uuid('customer_id').notNull().references(() => customers.id, { onDelete: 'cascade' }),
+  domain:     text('domain').notNull(),                 // ENERGY | WATER | TEMPERATURE
+  year:       smallint('year').notNull(),
+  unit:       text('unit').notNull(),                    // kWh | m3 | C (from domain config)
+  version:    integer('version').notNull().default(1),
+  createdAt:  timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  createdBy:  uuid('created_by'),
+  updatedAt:  timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedBy:  uuid('updated_by'),
+}, (table) => ({
+  uq:          uniqueIndex('consumption_goals_uq').on(table.tenantId, table.customerId, table.domain, table.year),
+  customerIdx: index('consumption_goals_customer_idx').on(table.tenantId, table.customerId),
+  domainCheck: check(
+    'consumption_goals_domain_check',
+    sql`${table.domain} IN ('ENERGY','WATER','TEMPERATURE')`
+  ),
+}));
+
+// 2) Canonical hourly grain. One row per (goal, month, day, hour).
+export const consumptionGoalHours = pgTable('consumption_goal_hours', {
+  goalId:      uuid('goal_id').notNull().references(() => consumptionGoals.id, { onDelete: 'cascade' }),
+  month:       smallint('month').notNull(),              // 1..12
+  day:         smallint('day').notNull(),                // 1..31 (valid for the month/year)
+  hour:        smallint('hour').notNull(),               // 0..23
+  value:       numeric('value').notNull(),
+  sourceLevel: text('source_level').notNull(),           // YEAR | MONTH | DAY | HOUR — level the user set
+  derived:     boolean('derived').notNull(),             // true = system-distributed
+  updatedAt:   timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedBy:   uuid('updated_by'),
+}, (table) => ({
+  uq: uniqueIndex('consumption_goal_hours_uq').on(table.goalId, table.month, table.day, table.hour),
+  monthRange:  check('consumption_goal_hours_month_check', sql`${table.month} BETWEEN 1 AND 12`),
+  dayRange:    check('consumption_goal_hours_day_check',   sql`${table.day} BETWEEN 1 AND 31`),
+  hourRange:   check('consumption_goal_hours_hour_check',  sql`${table.hour} BETWEEN 0 AND 23`),
+  sourceLevelCheck: check(
+    'consumption_goal_hours_source_level_check',
+    sql`${table.sourceLevel} IN ('YEAR','MONTH','DAY','HOUR')`
+  ),
+}));
+
+// 3) Fixed aggregation config per (tenant, domain). Seeded; operator-immutable.
+export const consumptionGoalDomains = pgTable('consumption_goal_domains', {
+  tenantId:          uuid('tenant_id').notNull(),
+  domain:            text('domain').notNull(),           // ENERGY | WATER | TEMPERATURE
+  aggregationMethod: text('aggregation_method').notNull(), // SUM | AVERAGE
+  unit:              text('unit').notNull(),             // kWh | m3 | C
+}, (table) => ({
+  pk: primaryKey({ columns: [table.tenantId, table.domain] }),
+  aggregationMethodCheck: check(
+    'consumption_goal_domains_agg_method_check',
+    sql`${table.aggregationMethod} IN ('SUM','AVERAGE')`
+  ),
+  domainCheck: check(
+    'consumption_goal_domains_domain_check',
+    sql`${table.domain} IN ('ENERGY','WATER','TEMPERATURE')`
+  ),
+}));
+
+// 4) Append-only history. Records the level the user acted on (DEC-4).
+export const consumptionGoalHistory = pgTable('consumption_goal_history', {
+  id:            uuid('id').primaryKey().defaultRandom(),
+  goalId:        uuid('goal_id').notNull(),
+  actor:         uuid('actor'),                          // who changed it
+  actionLevel:   text('action_level').notNull(),         // YEAR | MONTH | DAY | HOUR — what the user touched
+  bucketRef:     text('bucket_ref').notNull(),           // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  oldValue:      numeric('old_value'),                   // at the input level (NULL on create)
+  newValue:      numeric('new_value'),                   // at the input level (NULL on delete)
+  distributed:   boolean('distributed').notNull(),       // true = system spread to hours
+  hoursAffected: integer('hours_affected').notNull(),    // count of hour rows written by this change
+  version:       integer('version').notNull(),           // the version this change produced
+  changedAt:     timestamp('changed_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  goalChronoIdx: index('consumption_goal_history_idx').on(table.goalId, table.changedAt.desc()),
+  actionLevelCheck: check(
+    'consumption_goal_history_action_level_check',
+    sql`${table.actionLevel} IN ('YEAR','MONTH','DAY','HOUR')`
+  ),
+}));
+```
+
+---
+
+## Notes on conventions matched
+
+- **Table style** mirrors `workOrders` / `workOrdersLifecycleRules`: `pgTable`
+  with a column object and a second `(table) => ({ … })` callback for indexes,
+  unique indexes and `check` constraints.
+- **`uniqueIndex`** is used for the RFC's `UNIQUE(...)` constraints (the repo's
+  established pattern, e.g. `work_orders_tenant_code_unique`) rather than an
+  inline column `.unique()`.
+- **`numeric('value')`** maps the RFC's bare `numeric` (unbounded precision):
+  temperature may be negative, energy/water are `>= 0` — that domain rule is
+  enforced in the service/DTO layer (Zod), not as a column `CHECK`, because the
+  sign rule depends on the row's `domain` which lives on the parent.
+- **`changedAt.desc()`** inside `index(...)` produces the `(goal_id,
+  changed_at DESC)` ordering the RFC specifies for the history read path.
+- **Domain / level CHECKs** are added defensively to match the
+  `work_orders_type_check` precedent; they are a strict superset of what the RFC
+  lists in column comments and do not change the shape.
+- `consumption_goals` deliberately has **no `deletedAt`** — DELETE removes the
+  year (RFC §API · "Delete"); there is no soft-delete in this version.

--- a/drizzle/migrations/0047_consumption_goals.sql
+++ b/drizzle/migrations/0047_consumption_goals.sql
@@ -1,0 +1,129 @@
+-- Migration NNNN: RFC-0046 — Customer Consumption Goals
+--
+-- NOTE: the real migration number (NNNN) is assigned at integration time —
+-- rename this file (and this header) to the next free slot under
+-- drizzle/migrations/ when wiring it into the custom runner. As of authoring,
+-- the highest applied is 0046_devices_label_widen_255.sql.
+--
+-- Creates the four tables for per-customer consumption goals (ENERGY | WATER |
+-- TEMPERATURE), stored at the canonical hourly grain with the optimistic
+-- `version` on the parent, plus an append-only history. Seeds the fixed
+-- per-domain aggregation config for every existing tenant.
+--
+-- Companion: docs/RFC-0046-Customer-Consumption-Goals.md ·
+--            docs/RFC-0046-Goals-schema.md (Drizzle snippet for schema.ts)
+--
+-- No BEGIN/COMMIT: the custom runner wraps each file in its own transaction.
+
+-- =============================================================================
+-- 1) consumption_goals — parent; holds the optimistic version.
+--    One per (tenant, customer, domain, year).
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "consumption_goals" (
+  "id"          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "tenant_id"   uuid        NOT NULL,
+  "customer_id" uuid        NOT NULL REFERENCES "customers"("id") ON DELETE CASCADE,
+  "domain"      text        NOT NULL,            -- ENERGY | WATER | TEMPERATURE
+  "year"        smallint    NOT NULL,
+  "unit"        text        NOT NULL,            -- kWh | m3 | C (from domain config)
+  "version"     integer     NOT NULL DEFAULT 1,
+  "created_at"  timestamptz NOT NULL DEFAULT now(),
+  "created_by"  uuid,
+  "updated_at"  timestamptz NOT NULL DEFAULT now(),
+  "updated_by"  uuid,
+  CONSTRAINT "consumption_goals_uq"
+    UNIQUE ("tenant_id", "customer_id", "domain", "year"),
+  CONSTRAINT "consumption_goals_domain_check"
+    CHECK ("domain" IN ('ENERGY','WATER','TEMPERATURE'))
+);
+
+CREATE INDEX IF NOT EXISTS "consumption_goals_customer_idx"
+  ON "consumption_goals" ("tenant_id", "customer_id");
+
+-- =============================================================================
+-- 2) consumption_goal_hours — the canonical hourly grain.
+--    Up to 8,760 rows per (customer, domain, year); coarser views derived on read.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "consumption_goal_hours" (
+  "goal_id"      uuid        NOT NULL REFERENCES "consumption_goals"("id") ON DELETE CASCADE,
+  "month"        smallint    NOT NULL,           -- 1..12
+  "day"          smallint    NOT NULL,           -- 1..31 (valid for the month/year)
+  "hour"         smallint    NOT NULL,           -- 0..23
+  "value"        numeric     NOT NULL,
+  "source_level" text        NOT NULL,           -- YEAR | MONTH | DAY | HOUR (level the user set)
+  "derived"      boolean     NOT NULL,           -- true = system-distributed
+  "updated_at"   timestamptz NOT NULL DEFAULT now(),
+  "updated_by"   uuid,
+  CONSTRAINT "consumption_goal_hours_uq"
+    UNIQUE ("goal_id", "month", "day", "hour"),
+  CONSTRAINT "consumption_goal_hours_month_check"
+    CHECK ("month" BETWEEN 1 AND 12),
+  CONSTRAINT "consumption_goal_hours_day_check"
+    CHECK ("day" BETWEEN 1 AND 31),
+  CONSTRAINT "consumption_goal_hours_hour_check"
+    CHECK ("hour" BETWEEN 0 AND 23),
+  CONSTRAINT "consumption_goal_hours_source_level_check"
+    CHECK ("source_level" IN ('YEAR','MONTH','DAY','HOUR'))
+);
+
+-- =============================================================================
+-- 3) consumption_goal_domains — fixed aggregation config per (tenant, domain).
+--    Operator-immutable; tenant override is future.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "consumption_goal_domains" (
+  "tenant_id"          uuid NOT NULL,
+  "domain"             text NOT NULL,            -- ENERGY | WATER | TEMPERATURE
+  "aggregation_method" text NOT NULL,            -- SUM | AVERAGE
+  "unit"               text NOT NULL,            -- kWh | m3 | C
+  PRIMARY KEY ("tenant_id", "domain"),
+  CONSTRAINT "consumption_goal_domains_agg_method_check"
+    CHECK ("aggregation_method" IN ('SUM','AVERAGE')),
+  CONSTRAINT "consumption_goal_domains_domain_check"
+    CHECK ("domain" IN ('ENERGY','WATER','TEMPERATURE'))
+);
+
+-- =============================================================================
+-- 4) consumption_goal_history — append-only audit (DEC-4).
+--    Records the level the user acted on + how it distributed.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS "consumption_goal_history" (
+  "id"             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "goal_id"        uuid        NOT NULL,
+  "actor"          uuid,                          -- who changed it
+  "action_level"   text        NOT NULL,          -- YEAR | MONTH | DAY | HOUR (what the user touched)
+  "bucket_ref"     text        NOT NULL,          -- "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  "old_value"      numeric,                        -- at the input level (NULL on create)
+  "new_value"      numeric,                        -- at the input level (NULL on delete)
+  "distributed"    boolean     NOT NULL,           -- true = system spread to hours
+  "hours_affected" integer     NOT NULL,           -- count of hour rows written by this change
+  "version"        integer     NOT NULL,           -- the version this change produced
+  "changed_at"     timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT "consumption_goal_history_action_level_check"
+    CHECK ("action_level" IN ('YEAR','MONTH','DAY','HOUR'))
+);
+
+CREATE INDEX IF NOT EXISTS "consumption_goal_history_idx"
+  ON "consumption_goal_history" ("goal_id", "changed_at" DESC);
+
+-- =============================================================================
+-- 5) Seed consumption_goal_domains for every existing tenant.
+--    ENERGY -> SUM/kWh, WATER -> SUM/m3, TEMPERATURE -> AVERAGE/C.
+--    Tenants are enumerated from the customers table (the only authoritative
+--    list of live tenant_ids). Idempotent via ON CONFLICT; new tenants created
+--    after this migration are seeded by the service on first goals access.
+-- =============================================================================
+
+INSERT INTO "consumption_goal_domains" ("tenant_id", "domain", "aggregation_method", "unit")
+SELECT t."tenant_id", d."domain", d."aggregation_method", d."unit"
+FROM (SELECT DISTINCT "tenant_id" FROM "customers") AS t
+CROSS JOIN (
+  VALUES
+    ('ENERGY',      'SUM',     'kWh'),
+    ('WATER',       'SUM',     'm3'),
+    ('TEMPERATURE', 'AVERAGE', 'C')
+) AS d("domain", "aggregation_method", "unit")
+ON CONFLICT ("tenant_id", "domain") DO NOTHING;

--- a/drizzle/migrations/0048_consumption_goals_history_ops.sql
+++ b/drizzle/migrations/0048_consumption_goals_history_ops.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- RFC-0046 — Customer Consumption Goals · OPERATION-LEVEL AUDIT (history)
+-- =============================================================================
+-- Evolves consumption_goal_history from one row PER BUCKET to one row PER
+-- OPERATION (one mutation = one version = one audit entry), so the UI timeline
+-- can read clean, human entries like:
+--   "Importação de planilha — 120 registros"
+--   "Edição de metas — 12/05/2026, horários 08..18"
+-- and a single large import no longer floods the ≤100-row history window.
+--
+-- Additive + idempotent:
+--   - source        : the operation that produced this version.
+--   - bucket_count  : how many operator buckets the operation carried.
+--   - details       : compact [{ ref, value }] sample (capped by the service)
+--                     used to render the per-entry breakdown.
+--
+-- Apply locally:
+--   docker exec -i -e PGPASSWORD=postgres gcdr-db-local \
+--     psql -U postgres -d db_gcdr -v ON_ERROR_STOP=1 \
+--     < drizzle/migrations/0048_consumption_goals_history_ops.sql
+-- =============================================================================
+
+ALTER TABLE consumption_goal_history
+  ADD COLUMN IF NOT EXISTS source       text    NOT NULL DEFAULT 'EDIT',
+  ADD COLUMN IF NOT EXISTS bucket_count integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS details      jsonb   NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE consumption_goal_history
+  DROP CONSTRAINT IF EXISTS consumption_goal_history_source_check;
+
+ALTER TABLE consumption_goal_history
+  ADD CONSTRAINT consumption_goal_history_source_check
+  CHECK (source IN ('IMPORT','REPLACE','MERGE','DELETE','EDIT'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "cors": "^2.8.5",
         "drizzle-orm": "^0.45.1",
         "express": "^4.21.0",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.0.0",
         "js-yaml": "^4.1.1",
         "multer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cors": "^2.8.5",
     "drizzle-orm": "^0.45.1",
     "express": "^4.21.0",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.0.0",
     "js-yaml": "^4.1.1",
     "multer": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc && mkdir -p dist/docs && cp docs/openapi.yaml dist/docs/openapi.yaml",
     "start": "node dist/app.js",
     "dev": "tsx watch --env-file-if-exists=.env --env-file-if-exists=.env.local src/app.ts",
+    "dev:debug": "tsx watch --inspect --env-file-if-exists=.env --env-file-if-exists=.env.local src/app.ts",
+    "dev:debug-brk": "tsx watch --inspect-brk --env-file-if-exists=.env --env-file-if-exists=.env.local src/app.ts",
     "offline": "serverless offline start",
     "deploy": "serverless deploy",
     "deploy:prod": "serverless deploy --stage prod",

--- a/scripts/db/seeds/rfc0046-goals-test.sql
+++ b/scripts/db/seeds/rfc0046-goals-test.sql
@@ -1,0 +1,105 @@
+-- =============================================================================
+-- RFC-0046 — Customer Consumption Goals · LOCAL TEST SEED
+-- =============================================================================
+-- Idempotent test data for the four goals tables (apply migration
+-- 0047_consumption_goals.sql first). Demonstrates the canonical model:
+--   - ENERGY (SUM): a monthly target distributed evenly across the month hours
+--     (source_level=MONTH, derived=true), with ONE explicit hour override
+--     (source_level=HOUR, derived=false) to show "confirmed vs suggested";
+--   - TEMPERATURE (AVERAGE): a monthly setpoint COPIED to each hour;
+--   - an append-only history row per change (the level the user acted on).
+--
+-- Target: the seeded test customer "Dimension".
+--   tenant_id   = 11111111-1111-1111-1111-111111111111
+--   customer_id = 77777777-7777-7777-7777-777777777777
+-- Re-runnable: parent uses ON CONFLICT DO UPDATE, hours upsert, history is
+-- cleared for the seeded goals before re-insert so it does not accumulate.
+--
+-- Run locally:
+--   docker exec -i -e PGPASSWORD=postgres gcdr-db-local \
+--     psql -U postgres -d db_gcdr -v ON_ERROR_STOP=1 \
+--     < scripts/db/seeds/rfc0046-goals-test.sql
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_tenant   uuid := '11111111-1111-1111-1111-111111111111';
+  v_customer uuid := '77777777-7777-7777-7777-777777777777';
+  v_year     smallint := 2026;
+
+  v_energy_goal uuid;
+  v_temp_goal   uuid;
+
+  -- January 2026: 31 days x 24 hours = 744 hours.
+  v_jan_hours      int     := 31 * 24;
+  v_energy_target  numeric := 100000;  -- kWh for January (SUM domain)
+  v_temp_setpoint  numeric := 22;      -- C for January (AVERAGE domain — copied)
+BEGIN
+  -- ---------------------------------------------------------------------------
+  -- ENERGY 2026 (SUM) ----------------------------------------------------------
+  -- ---------------------------------------------------------------------------
+  INSERT INTO consumption_goals (tenant_id, customer_id, domain, year, unit, version, updated_at)
+  VALUES (v_tenant, v_customer, 'ENERGY', v_year, 'kWh', 1, now())
+  ON CONFLICT (tenant_id, customer_id, domain, year)
+    DO UPDATE SET updated_at = now()
+  RETURNING id INTO v_energy_goal;
+
+  DELETE FROM consumption_goal_history WHERE goal_id = v_energy_goal;
+  DELETE FROM consumption_goal_hours   WHERE goal_id = v_energy_goal;
+
+  -- January distributed evenly across its 744 hours (source_level=MONTH).
+  INSERT INTO consumption_goal_hours (goal_id, month, day, hour, value, source_level, derived)
+  SELECT v_energy_goal, 1, d, h, round(v_energy_target / v_jan_hours, 6), 'MONTH', true
+  FROM generate_series(1, 31) AS d, generate_series(0, 23) AS h;
+
+  -- One explicit hour override: 2026-01-15 08:00 confirmed by the operator.
+  INSERT INTO consumption_goal_hours (goal_id, month, day, hour, value, source_level, derived)
+  VALUES (v_energy_goal, 1, 15, 8, 500.000000, 'HOUR', false)
+  ON CONFLICT (goal_id, month, day, hour)
+    DO UPDATE SET value = EXCLUDED.value, source_level = 'HOUR', derived = false, updated_at = now();
+
+  INSERT INTO consumption_goal_history
+    (goal_id, actor, action_level, bucket_ref, old_value, new_value, distributed, hours_affected, version)
+  VALUES
+    (v_energy_goal, NULL, 'MONTH', '2026-01', NULL, v_energy_target, true,  v_jan_hours, 1),
+    (v_energy_goal, NULL, 'HOUR', '2026-01-15T08', NULL, 500, false, 1, 1);
+
+  -- ---------------------------------------------------------------------------
+  -- TEMPERATURE 2026 (AVERAGE) -------------------------------------------------
+  -- ---------------------------------------------------------------------------
+  INSERT INTO consumption_goals (tenant_id, customer_id, domain, year, unit, version, updated_at)
+  VALUES (v_tenant, v_customer, 'TEMPERATURE', v_year, 'C', 1, now())
+  ON CONFLICT (tenant_id, customer_id, domain, year)
+    DO UPDATE SET updated_at = now()
+  RETURNING id INTO v_temp_goal;
+
+  DELETE FROM consumption_goal_history WHERE goal_id = v_temp_goal;
+  DELETE FROM consumption_goal_hours   WHERE goal_id = v_temp_goal;
+
+  -- January setpoint COPIED to each hour (so the weighted average back up = 22).
+  INSERT INTO consumption_goal_hours (goal_id, month, day, hour, value, source_level, derived)
+  SELECT v_temp_goal, 1, d, h, v_temp_setpoint, 'MONTH', true
+  FROM generate_series(1, 31) AS d, generate_series(0, 23) AS h;
+
+  INSERT INTO consumption_goal_history
+    (goal_id, actor, action_level, bucket_ref, old_value, new_value, distributed, hours_affected, version)
+  VALUES
+    (v_temp_goal, NULL, 'MONTH', '2026-01', NULL, v_temp_setpoint, true, v_jan_hours, 1);
+
+  RAISE NOTICE 'RFC-0046 test seed applied: ENERGY goal %, TEMPERATURE goal %', v_energy_goal, v_temp_goal;
+END $$;
+
+-- Quick verification (SUM rolls Jan up to ~100000 kWh including the +500 override
+-- replacing one ~134 hour; TEMPERATURE averages to 22 C):
+SELECT g.domain,
+       g.year,
+       count(h.*)                                   AS hours,
+       sum(CASE WHEN h.derived THEN 0 ELSE 1 END)   AS explicit_hours,
+       round(sum(h.value::numeric), 2)              AS jan_sum,
+       round(avg(h.value::numeric), 4)              AS jan_avg
+FROM consumption_goals g
+JOIN consumption_goal_hours h ON h.goal_id = g.id
+WHERE g.customer_id = '77777777-7777-7777-7777-777777777777'
+  AND g.year = 2026
+GROUP BY g.domain, g.year
+ORDER BY g.domain;

--- a/scripts/db/seeds/rfc0046-goals-test.sql
+++ b/scripts/db/seeds/rfc0046-goals-test.sql
@@ -59,10 +59,12 @@ BEGIN
     DO UPDATE SET value = EXCLUDED.value, source_level = 'HOUR', derived = false, updated_at = now();
 
   INSERT INTO consumption_goal_history
-    (goal_id, actor, action_level, bucket_ref, old_value, new_value, distributed, hours_affected, version)
+    (goal_id, actor, source, action_level, bucket_ref, old_value, new_value, bucket_count, details, distributed, hours_affected, version)
   VALUES
-    (v_energy_goal, NULL, 'MONTH', '2026-01', NULL, v_energy_target, true,  v_jan_hours, 1),
-    (v_energy_goal, NULL, 'HOUR', '2026-01-15T08', NULL, 500, false, 1, 1);
+    (v_energy_goal, NULL, 'REPLACE', 'MONTH', '2026-01', NULL, v_energy_target, 1,
+       jsonb_build_array(jsonb_build_object('ref', '2026-01', 'value', v_energy_target)), true,  v_jan_hours, 1),
+    (v_energy_goal, NULL, 'MERGE',   'HOUR', '2026-01-15T08', NULL, 500, 1,
+       jsonb_build_array(jsonb_build_object('ref', '2026-01-15T08', 'value', 500)), false, 1, 1);
 
   -- ---------------------------------------------------------------------------
   -- TEMPERATURE 2026 (AVERAGE) -------------------------------------------------
@@ -82,9 +84,10 @@ BEGIN
   FROM generate_series(1, 31) AS d, generate_series(0, 23) AS h;
 
   INSERT INTO consumption_goal_history
-    (goal_id, actor, action_level, bucket_ref, old_value, new_value, distributed, hours_affected, version)
+    (goal_id, actor, source, action_level, bucket_ref, old_value, new_value, bucket_count, details, distributed, hours_affected, version)
   VALUES
-    (v_temp_goal, NULL, 'MONTH', '2026-01', NULL, v_temp_setpoint, true, v_jan_hours, 1);
+    (v_temp_goal, NULL, 'REPLACE', 'MONTH', '2026-01', NULL, v_temp_setpoint, 1,
+       jsonb_build_array(jsonb_build_object('ref', '2026-01', 'value', v_temp_setpoint)), true, v_jan_hours, 1);
 
   RAISE NOTICE 'RFC-0046 test seed applied: ENERGY goal %, TEMPERATURE goal %', v_energy_goal, v_temp_goal;
 END $$;

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import {
   healthController,
   docsController,
   customersController,
+  consumptionGoalsController,
   assetsController,
   partnersController,
   groupsController,
@@ -226,6 +227,10 @@ apiV1Router.use('/customers/:customerId/channels', hybridAuthByMethod(PERM_CUSTO
 // RFC-0033: Customer integration sync state (nested — must come before general /customers router)
 // hybridAuth: GET requires customers:read; POST/PATCH/DELETE require customers:write.
 apiV1Router.use('/customers/:customerId/integrations', hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'), customerIntegrationsController);
+
+// RFC-0046: Customer consumption goals (nested — must come before general /customers router)
+// hybridAuth: GET requires goals:read; PUT/PATCH/POST/DELETE require goals:write.
+apiV1Router.use('/customers/:customerId/goals', hybridAuthByMethod('goals:read', 'goals:write'), consumptionGoalsController);
 
 // Customers (general router - must come after specific nested routes)
 // hybridAuth: supports JWT + API Key for ThingsBoard integration (RFC-0016)

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import {
   errorHandler,
   notFoundHandler,
 } from './middleware';
+import { rateLimit, clientIp } from './middleware/rateLimit';
 
 import {
   authController,
@@ -230,7 +231,19 @@ apiV1Router.use('/customers/:customerId/integrations', hybridAuthByMethod(PERM_C
 
 // RFC-0046: Customer consumption goals (nested — must come before general /customers router)
 // hybridAuth: GET requires goals:read; PUT/PATCH/POST/DELETE require goals:write.
-apiV1Router.use('/customers/:customerId/goals', hybridAuthByMethod('goals:read', 'goals:write'), consumptionGoalsController);
+// Rate-limited per IP+customer (auth'd, DB-backed route). Generous ceiling so
+// dashboards / M2M bundles are not throttled in normal use; blocks abusive floods.
+const goalsRateLimiter = rateLimit('customer-goals', {
+  windowMs: 60_000,
+  max: 240,
+  keyFn: (req) => `${clientIp(req)}:${req.params.customerId ?? ''}`,
+});
+apiV1Router.use(
+  '/customers/:customerId/goals',
+  goalsRateLimiter,
+  hybridAuthByMethod('goals:read', 'goals:write'),
+  consumptionGoalsController,
+);
 
 // Customers (general router - must come after specific nested routes)
 // hybridAuth: supports JWT + API Key for ThingsBoard integration (RFC-0016)

--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,8 @@ import {
   errorHandler,
   notFoundHandler,
 } from './middleware';
-import { rateLimit, clientIp } from './middleware/rateLimit';
+import { rateLimit as expressRateLimit } from 'express-rate-limit';
+import { clientIp } from './middleware/rateLimit';
 
 import {
   authController,
@@ -231,12 +232,23 @@ apiV1Router.use('/customers/:customerId/integrations', hybridAuthByMethod(PERM_C
 
 // RFC-0046: Customer consumption goals (nested — must come before general /customers router)
 // hybridAuth: GET requires goals:read; PUT/PATCH/POST/DELETE require goals:write.
-// Rate-limited per IP+customer (auth'd, DB-backed route). Generous ceiling so
+// Rate-limited per IP+customer (auth'd, DB-backed route). Uses express-rate-limit
+// (recognized by CodeQL's js/missing-rate-limiting). Generous ceiling so
 // dashboards / M2M bundles are not throttled in normal use; blocks abusive floods.
-const goalsRateLimiter = rateLimit('customer-goals', {
+// validate:false — we key on a custom XFF-aware string (single-instance), not req.ip.
+const goalsRateLimiter = expressRateLimit({
   windowMs: 60_000,
-  max: 240,
-  keyFn: (req) => `${clientIp(req)}:${req.params.customerId ?? ''}`,
+  limit: 240,
+  standardHeaders: 'draft-7',
+  legacyHeaders: false,
+  validate: false,
+  keyGenerator: (req) => `${clientIp(req)}:${req.params.customerId ?? ''}`,
+  handler: (req, res) =>
+    res.status(429).json({
+      success: false,
+      error: { code: 'RATE_LIMITED', message: 'Too many goals requests; please slow down' },
+      meta: { requestId: req.context?.requestId, timestamp: new Date().toISOString() },
+    }),
 });
 apiV1Router.use(
   '/customers/:customerId/goals',

--- a/src/controllers/consumption-goals.controller.ts
+++ b/src/controllers/consumption-goals.controller.ts
@@ -1,0 +1,254 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import {
+  consumptionGoalService,
+  VersionConflictError,
+} from '../services/consumptionGoalService';
+import {
+  GetGoalsQuerySchema,
+  GoalsTargetQuerySchema,
+  ImportGoalsQuerySchema,
+  ReplaceGoalsBodySchema,
+  MergeGoalsBodySchema,
+  DeleteGoalsBodySchema,
+  validateReplaceTreeCalendar,
+} from '../dto/request/GoalsDTO';
+import { customerService } from '../services/CustomerService';
+import { sendSuccess, sendNoContent } from '../middleware';
+import { ValidationError } from '../shared/errors/AppError';
+import { ApiResponse } from '../shared/types';
+
+// =============================================================================
+// RFC-0046 — Customer Consumption Goals (controller)
+//
+// Mounted at /customers/:customerId/goals in app.ts. The router uses
+// `mergeParams` so :customerId from the parent route is visible in req.params.
+//
+// Routes:
+//   GET    /                  — list domains with goals  (no query)
+//                            OR get the derived tree     (with ?domain&year)
+//   PUT    /?domain=&year=    — replace whole year+domain (DEC-5)
+//   PATCH  /?domain=&year=    — merge sent buckets        (DEC-5)
+//   POST   /import?domain=&year=&dryRun=
+//                            — CSV import; dryRun=true previews (stateless,
+//                              nothing persisted), dryRun=false persists
+//   DELETE /?domain=&year=    — delete a year or a sub-bucket
+//
+// Auth (hybridAuthByMethod('goals:read','goals:write')) and hierarchy access are
+// applied at mount time in app.ts.
+//
+// The version-conflict (409) is serialised inline so the body carries
+// `currentVersion` + `details` per RFC-0046 §4.4 (the global error handler emits
+// only message+code for a bare AppError).
+// =============================================================================
+
+const router = Router({ mergeParams: true });
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Import body (csv text + optional optimistic guard); query carries dryRun/domain/year. */
+const ImportGoalsBodySchema = z.object({
+  csv: z.string().min(1, 'csv content is required'),
+  expectedVersion: z.number().int().positive().optional(),
+});
+
+function requireUuid(name: string, value: string): void {
+  if (!value || !UUID_REGEX.test(value)) {
+    throw new ValidationError(`Invalid ${name}: "${value ?? ''}"`);
+  }
+}
+
+/** The actor recorded on writes/history — the JWT user or the API-key id. */
+function actorOf(req: Request): string | null {
+  return req.context?.userId ?? req.context?.apiKeyId ?? req.user?.sub ?? null;
+}
+
+/**
+ * Serialises a VersionConflictError into the RFC-0046 §4.4 body and returns
+ * `true` when it handled the error; otherwise returns `false` so the caller
+ * forwards to the global handler.
+ */
+function handleVersionConflict(err: unknown, req: Request, res: Response): boolean {
+  if (!(err instanceof VersionConflictError)) return false;
+  const response: ApiResponse = {
+    success: false,
+    error: {
+      message: err.message,
+      code: err.code,
+      currentVersion: err.currentVersion,
+      details: err.details,
+    } as ApiResponse['error'] & { currentVersion: number },
+    meta: {
+      requestId: req.context?.requestId ?? '',
+      timestamp: new Date().toISOString(),
+    },
+  };
+  res.status(err.statusCode).json(response);
+  return true;
+}
+
+/** Validates customer existence (404) and tenant/hierarchy scoping. */
+async function ensureCustomer(tenantId: string, customerId: string): Promise<void> {
+  requireUuid('customerId', customerId);
+  await customerService.getById(tenantId, customerId); // throws NotFoundError if absent
+}
+
+/**
+ * GET /customers/:customerId/goals
+ *   - no `domain`/`year`  → list domains that have goals (RFC §3.1)
+ *   - with `domain&year`  → derived tree at `granularity` (RFC §3.2)
+ */
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+    await ensureCustomer(tenantId, customerId);
+
+    // Summary mode when no discriminator is supplied.
+    if (req.query.domain === undefined && req.query.year === undefined) {
+      const result = await consumptionGoalService.list(tenantId, customerId);
+      sendSuccess(res, result, 200, requestId);
+      return;
+    }
+
+    const query = GetGoalsQuerySchema.parse(req.query);
+    const result = await consumptionGoalService.get(
+      { tenantId, customerId, domain: query.domain, year: query.year },
+      query.granularity,
+      query.fetchHistory,
+    );
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * PUT /customers/:customerId/goals?domain=&year=
+ * Replace the whole (year, domain). Buckets absent from the payload are removed.
+ */
+router.put('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+    await ensureCustomer(tenantId, customerId);
+
+    const { domain, year } = GoalsTargetQuerySchema.parse(req.query);
+    const body = ReplaceGoalsBodySchema.parse(req.body ?? {});
+
+    // Cross-field calendar validity (leap-year aware) — needs the year from query.
+    const calIssues = validateReplaceTreeCalendar(body, year);
+    if (calIssues.length > 0) {
+      throw new ValidationError('Validation failed', issuesToDetails(calIssues));
+    }
+
+    const result = await consumptionGoalService.replace(
+      { tenantId, customerId, domain, year },
+      body,
+      actorOf(req),
+    );
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    if (handleVersionConflict(err, req, res)) return;
+    next(err);
+  }
+});
+
+/**
+ * PATCH /customers/:customerId/goals?domain=&year=
+ * Merge only the sent buckets; everything else is preserved.
+ */
+router.patch('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+    await ensureCustomer(tenantId, customerId);
+
+    const { domain, year } = GoalsTargetQuerySchema.parse(req.query);
+    const body = MergeGoalsBodySchema.parse(req.body ?? {});
+
+    const result = await consumptionGoalService.merge(
+      { tenantId, customerId, domain, year },
+      body,
+      actorOf(req),
+    );
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    if (handleVersionConflict(err, req, res)) return;
+    next(err);
+  }
+});
+
+/**
+ * POST /customers/:customerId/goals/import?domain=&year=&dryRun=
+ * CSV import. dryRun=true (default) returns a preview + diagnostics WITHOUT
+ * persisting (stateless — no previewToken); dryRun=false persists via merge.
+ */
+router.post('/import', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+    await ensureCustomer(tenantId, customerId);
+
+    const { domain, year, dryRun } = ImportGoalsQuerySchema.parse(req.query);
+    const body = ImportGoalsBodySchema.parse(req.body ?? {});
+
+    const result = await consumptionGoalService.importData(
+      { tenantId, customerId, domain, year },
+      body.csv,
+      dryRun,
+      body.expectedVersion,
+      actorOf(req),
+    );
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    if (handleVersionConflict(err, req, res)) return;
+    next(err);
+  }
+});
+
+/**
+ * DELETE /customers/:customerId/goals?domain=&year=
+ * Removes the whole year (or a sub-bucket via body.bucket). A whole-year delete
+ * with no expectedVersion returns 204; with a guard it returns 200 + body.
+ */
+router.delete('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+    await ensureCustomer(tenantId, customerId);
+
+    const { domain, year } = GoalsTargetQuerySchema.parse(req.query);
+    const body = DeleteGoalsBodySchema.parse(req.body ?? undefined);
+
+    const result = await consumptionGoalService.remove(
+      { tenantId, customerId, domain, year },
+      body,
+      actorOf(req),
+    );
+
+    // Whole-year delete with no optimistic guard → 204 No Content (RFC §3.6).
+    if (result && result.deleted.bucket === null && body?.expectedVersion === undefined) {
+      sendNoContent(res);
+      return;
+    }
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    if (handleVersionConflict(err, req, res)) return;
+    next(err);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+function issuesToDetails(issues: Array<{ path: string; message: string }>): Record<string, string[]> {
+  const details: Record<string, string[]> = {};
+  for (const i of issues) {
+    (details[i.path] ??= []).push(i.message);
+  }
+  return details;
+}
+
+export default router;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -9,6 +9,7 @@ export { monitorAdminController } from './admin/monitor-admin.controller';
 
 // Protected routes
 export { default as customersController } from './customers.controller';
+export { default as consumptionGoalsController } from './consumption-goals.controller';
 export { default as assetsController } from './assets.controller';
 export { default as partnersController } from './partners.controller';
 export { default as groupsController } from './groups.controller';

--- a/src/domain/entities/CustomerApiKey.ts
+++ b/src/domain/entities/CustomerApiKey.ts
@@ -26,6 +26,8 @@ export type ApiKeyScope =
   | 'simulator:write'   // Start/stop simulations (RFC-0010)
   | 'simulator:admin'   // Manage all tenant simulations (RFC-0010)
   | 'sync:write'        // Write integration mapping fields (RFC-0016)
+  | 'goals:read'        // Read consumption goals (RFC-0046)
+  | 'goals:write'       // Write consumption goals (RFC-0046)
   | '*:read';           // Read all resources
 
 /**

--- a/src/dto/request/CustomerApiKeyDTO.ts
+++ b/src/dto/request/CustomerApiKeyDTO.ts
@@ -15,6 +15,8 @@ export const ApiKeyScopeSchema = z.enum([
   'assets:write',      // RFC-0016 integration
   'groups:read',
   'sync:write',        // RFC-0016 integration mapping fields
+  'goals:read',        // RFC-0046 consumption goals
+  'goals:write',       // RFC-0046 consumption goals
   '*:read',
 ]);
 

--- a/src/dto/request/GoalsDTO.ts
+++ b/src/dto/request/GoalsDTO.ts
@@ -1,0 +1,435 @@
+import { z } from 'zod';
+
+// =============================================================================
+// RFC-0046: Customer Consumption Goals — request contracts (Zod + types)
+//
+// Per-customer consumption goals scoped by domain (ENERGY | WATER | TEMPERATURE)
+// and year. The operator submits a target at any granularity (year, month, day,
+// hour); GCDR distributes it to the canonical hourly grain on write and rolls it
+// up on read. This file defines ONLY the request-side wire contracts — the
+// endpoint shapes, query discriminators and write bodies — not business logic.
+//
+// Validation rules (authoritative, per RFC §API "Validation"):
+//   - month: 1..12
+//   - day:   valid for the (month, year), leap-year aware
+//   - hour:  0..23
+//   - value: finite; >= 0 for ENERGY/WATER; TEMPERATURE may be negative.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// Enums
+// -----------------------------------------------------------------------------
+
+/** Goal domain. Aggregation method is a fixed property of the domain. */
+export const GoalDomainSchema = z.enum(['ENERGY', 'WATER', 'TEMPERATURE']);
+export type GoalDomain = z.infer<typeof GoalDomainSchema>;
+
+/**
+ * Read granularity (the requested view derived from hours) AND the operator's
+ * input mode on write. Lower-case on the wire to match the query-param style.
+ */
+export const GoalGranularitySchema = z.enum(['year', 'month', 'day', 'hour']);
+export type GoalGranularity = z.infer<typeof GoalGranularitySchema>;
+
+/**
+ * The level the operator actually set, recorded per stored hour (`source_level`)
+ * and per history row (`action_level`). Upper-case to match the stored column
+ * values in `consumption_goal_hours.source_level` / `consumption_goal_history`.
+ */
+export const GoalSourceLevelSchema = z.enum(['YEAR', 'MONTH', 'DAY', 'HOUR']);
+export type GoalSourceLevel = z.infer<typeof GoalSourceLevelSchema>;
+
+/** Fixed aggregation method per domain (ENERGY/WATER → SUM, TEMPERATURE → AVERAGE). */
+export const GoalAggregationMethodSchema = z.enum(['SUM', 'AVERAGE']);
+export type GoalAggregationMethod = z.infer<typeof GoalAggregationMethodSchema>;
+
+// -----------------------------------------------------------------------------
+// Calendar helpers (leap-year aware day validation)
+// -----------------------------------------------------------------------------
+
+/** Gregorian leap-year test. */
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/** Number of days in a given month (1..12) of a given year. */
+export function daysInMonth(year: number, month: number): number {
+  // month is 1-based; new Date(year, month, 0) gives the last day of `month`.
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+  return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+// Reasonable year window: covers historical edits and near-future targets.
+const MIN_GOAL_YEAR = 2000;
+const MAX_GOAL_YEAR = 2100;
+
+const YearSchema = z
+  .number()
+  .int()
+  .min(MIN_GOAL_YEAR, `year must be >= ${MIN_GOAL_YEAR}`)
+  .max(MAX_GOAL_YEAR, `year must be <= ${MAX_GOAL_YEAR}`);
+
+const MonthSchema = z
+  .number()
+  .int()
+  .min(1, 'month must be between 1 and 12')
+  .max(12, 'month must be between 1 and 12');
+
+const HourSchema = z
+  .number()
+  .int()
+  .min(0, 'hour must be between 0 and 23')
+  .max(23, 'hour must be between 0 and 23');
+
+// -----------------------------------------------------------------------------
+// Value validation
+//
+// A bare value is finite (and not NaN/Infinity). Sign validation is
+// domain-dependent and therefore applied after the domain is known via
+// `refineGoalValuesForDomain` below.
+// -----------------------------------------------------------------------------
+
+/** Finite numeric value; per-domain sign constraints applied separately. */
+export const GoalValueSchema = z.number().finite('value must be a finite number');
+
+/**
+ * Returns true when `value` satisfies the per-domain sign constraint:
+ *   - ENERGY / WATER: value must be >= 0
+ *   - TEMPERATURE: any finite value (may be negative)
+ */
+export function isValidValueForDomain(domain: GoalDomain, value: number): boolean {
+  if (!Number.isFinite(value)) return false;
+  if (domain === 'TEMPERATURE') return true;
+  return value >= 0;
+}
+
+// -----------------------------------------------------------------------------
+// Query-param schemas
+//
+// Query strings arrive as strings; `z.coerce` mirrors the project style
+// (see ListCustomerApiKeysQuerySchema). `fetchHistory` accepts the canonical
+// "true"/"false" pair like other boolean query flags in the codebase.
+// -----------------------------------------------------------------------------
+
+/** Optional "true"/"false" query flag with a default applied before transform. */
+function booleanQueryFlag(defaultValue: 'true' | 'false') {
+  return z
+    .enum(['true', 'false'])
+    .default(defaultValue)
+    .transform((v) => v === 'true');
+}
+
+/**
+ * GET /customers/:id/goals?domain=&year=&granularity=&fetchHistory=
+ * `granularity` defaults to `month`; `fetchHistory=true` adds ≤100 history entries.
+ */
+export const GetGoalsQuerySchema = z.object({
+  domain: GoalDomainSchema,
+  year: z.coerce.number().pipe(YearSchema),
+  granularity: GoalGranularitySchema.default('month'),
+  fetchHistory: booleanQueryFlag('false'),
+});
+export type GetGoalsQueryDTO = z.infer<typeof GetGoalsQuerySchema>;
+
+/**
+ * Discriminator-only query for PUT / PATCH / POST import / DELETE.
+ * `domain` and `year` identify the `(customer, domain, year)` tree.
+ */
+export const GoalsTargetQuerySchema = z.object({
+  domain: GoalDomainSchema,
+  year: z.coerce.number().pipe(YearSchema),
+});
+export type GoalsTargetQueryDTO = z.infer<typeof GoalsTargetQuerySchema>;
+
+// -----------------------------------------------------------------------------
+// Bucket leaves (shared by PUT and PATCH bodies)
+//
+// A bucket carries the target `value` and an optional `sourceLevel` declaring
+// the level the operator acted on. When omitted, `sourceLevel` is inferred from
+// the position of the bucket in the tree (annual → YEAR, monthly → MONTH, etc.).
+// -----------------------------------------------------------------------------
+
+/** A single goal target leaf: the value plus an optional explicit source level. */
+export const GoalBucketSchema = z.object({
+  value: GoalValueSchema,
+  sourceLevel: GoalSourceLevelSchema.optional(),
+});
+export type GoalBucketDTO = z.infer<typeof GoalBucketSchema>;
+
+// Keys are zero-padded strings on the wire to match the GoalsPanel contract:
+//   month "01".."12", day "01".."31", hour "00".."23".
+const MonthKeySchema = z
+  .string()
+  .regex(/^(0[1-9]|1[0-2])$/, 'month key must be "01".."12"');
+
+const DayKeySchema = z
+  .string()
+  .regex(/^(0[1-9]|[12]\d|3[01])$/, 'day key must be "01".."31"');
+
+const HourKeySchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3])$/, 'hour key must be "00".."23"');
+
+// -----------------------------------------------------------------------------
+// PUT replace body — a full year tree at any granularity
+//
+// REPLACE semantics (DEC-5): the payload IS the whole year for this domain.
+// Buckets absent from the payload's scope are removed; the system distributes
+// to hours. The operator picks ONE granularity for the submission; the tree is
+// nested only down to that granularity.
+//
+// Shape mirrors the read tree:
+//   annual  → { value, sourceLevel? }
+//   monthly → { "01": <month node>, ... }
+//   each month node carries its own value/sourceLevel and optional finer nesting.
+// -----------------------------------------------------------------------------
+
+/** Hour node: leaf only (the canonical grain). */
+const ReplaceHourNodeSchema = GoalBucketSchema;
+
+/** Day node: a value, plus an optional map of hour buckets. */
+const ReplaceDayNodeSchema: z.ZodType<{
+  value: number;
+  sourceLevel?: GoalSourceLevel;
+  hourly?: Record<string, GoalBucketDTO>;
+}> = GoalBucketSchema.extend({
+  hourly: z.record(HourKeySchema, ReplaceHourNodeSchema).optional(),
+});
+
+/** Month node: a value, plus an optional map of day nodes. */
+const ReplaceMonthNodeSchema = GoalBucketSchema.extend({
+  daily: z.record(DayKeySchema, ReplaceDayNodeSchema).optional(),
+});
+
+/**
+ * Full-year replace body. At least one of `annual` / `monthly` must be present;
+ * the operator may go as deep as the hour. Day-of-month validity against the
+ * (month, year) is enforced by `validateGoalTreeCalendar` once `year` is known
+ * (the static schema cannot see the year-from-query).
+ */
+export const ReplaceGoalsBodySchema = z
+  .object({
+    annual: GoalBucketSchema.optional(),
+    monthly: z.record(MonthKeySchema, ReplaceMonthNodeSchema).optional(),
+    /** Optimistic concurrency: expected current version (omit on first write). */
+    expectedVersion: z.number().int().positive().optional(),
+  })
+  .refine(
+    (b) => b.annual !== undefined || (b.monthly !== undefined && Object.keys(b.monthly).length > 0),
+    { message: 'replace body must define at least an annual value or one month' },
+  );
+export type ReplaceGoalsBodyDTO = z.infer<typeof ReplaceGoalsBodySchema>;
+
+// -----------------------------------------------------------------------------
+// PATCH merge body — sparse buckets
+//
+// MERGE semantics (DEC-5): only the sent buckets are (re)distributed; all other
+// buckets are preserved. Each entry names its bucket explicitly via `level` +
+// `ref`, which is unambiguous and matches the history `bucket_ref` format:
+//   YEAR  → "2026"
+//   MONTH → "2026-03"
+//   DAY   → "2026-03-15"
+//   HOUR  → "2026-03-15T08"
+// -----------------------------------------------------------------------------
+
+const BUCKET_REF_PATTERNS: Record<GoalSourceLevel, RegExp> = {
+  YEAR: /^\d{4}$/,
+  MONTH: /^\d{4}-(0[1-9]|1[0-2])$/,
+  DAY: /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/,
+  HOUR: /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3])$/,
+};
+
+/** A single sparse bucket to merge: the level, its reference and the new value. */
+export const MergeGoalBucketSchema = z
+  .object({
+    level: GoalSourceLevelSchema,
+    ref: z.string().min(4).max(13),
+    value: GoalValueSchema,
+  })
+  .refine((b) => BUCKET_REF_PATTERNS[b.level].test(b.ref), {
+    message: 'ref does not match the format required for its level',
+    path: ['ref'],
+  });
+export type MergeGoalBucketDTO = z.infer<typeof MergeGoalBucketSchema>;
+
+/** PATCH body: a non-empty list of sparse buckets, plus optional optimistic version. */
+export const MergeGoalsBodySchema = z.object({
+  buckets: z.array(MergeGoalBucketSchema).min(1, 'at least one bucket is required').max(8760),
+  expectedVersion: z.number().int().positive().optional(),
+});
+export type MergeGoalsBodyDTO = z.infer<typeof MergeGoalsBodySchema>;
+
+// -----------------------------------------------------------------------------
+// Delete body (optional sub-bucket scope)
+//
+// DELETE /customers/:id/goals?domain=&year= removes the whole year by default;
+// an optional `bucket` narrows the deletion to a sub-bucket (logged + versioned).
+// -----------------------------------------------------------------------------
+
+export const DeleteGoalsBodySchema = z
+  .object({
+    bucket: z
+      .object({
+        level: GoalSourceLevelSchema,
+        ref: z.string().min(4).max(13),
+      })
+      .refine((b) => BUCKET_REF_PATTERNS[b.level].test(b.ref), {
+        message: 'ref does not match the format required for its level',
+        path: ['ref'],
+      })
+      .optional(),
+    expectedVersion: z.number().int().positive().optional(),
+  })
+  .optional();
+export type DeleteGoalsBodyDTO = z.infer<typeof DeleteGoalsBodySchema>;
+
+// -----------------------------------------------------------------------------
+// CSV import query (dry-run by default)
+//
+// POST /customers/:id/goals/import?domain=&year=&dryRun=
+// Defaults to a dry-run preview; `dryRun=false` confirms and persists.
+// -----------------------------------------------------------------------------
+
+export const ImportGoalsQuerySchema = z.object({
+  domain: GoalDomainSchema,
+  year: z.coerce.number().pipe(YearSchema),
+  dryRun: booleanQueryFlag('true'),
+});
+export type ImportGoalsQueryDTO = z.infer<typeof ImportGoalsQuerySchema>;
+
+// -----------------------------------------------------------------------------
+// Cross-field validators (need `domain` and `year` from the query, which the
+// static Zod schemas cannot see). Call these in the service/controller after the
+// body and query have both parsed.
+// -----------------------------------------------------------------------------
+
+export interface GoalValidationIssue {
+  path: string;
+  message: string;
+}
+
+/**
+ * Validates that every value in a replace tree satisfies the per-domain sign
+ * constraint. Returns an empty array when valid.
+ */
+export function validateReplaceTreeForDomain(
+  body: ReplaceGoalsBodyDTO,
+  domain: GoalDomain,
+): GoalValidationIssue[] {
+  const issues: GoalValidationIssue[] = [];
+
+  const check = (value: number, path: string) => {
+    if (!isValidValueForDomain(domain, value)) {
+      issues.push({
+        path,
+        message:
+          domain === 'TEMPERATURE'
+            ? 'value must be a finite number'
+            : 'value must be a finite number >= 0 for energy/water domains',
+      });
+    }
+  };
+
+  if (body.annual) check(body.annual.value, 'annual.value');
+
+  for (const [monthKey, month] of Object.entries(body.monthly ?? {})) {
+    check(month.value, `monthly.${monthKey}.value`);
+    for (const [dayKey, day] of Object.entries(month.daily ?? {})) {
+      check(day.value, `monthly.${monthKey}.daily.${dayKey}.value`);
+      for (const [hourKey, hour] of Object.entries(day.hourly ?? {})) {
+        check(hour.value, `monthly.${monthKey}.daily.${dayKey}.hourly.${hourKey}.value`);
+      }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Validates day-of-month validity (leap-year aware) for every day bucket in a
+ * replace tree, given the `year` from the query. Returns an empty array when
+ * valid.
+ */
+export function validateReplaceTreeCalendar(
+  body: ReplaceGoalsBodyDTO,
+  year: number,
+): GoalValidationIssue[] {
+  const issues: GoalValidationIssue[] = [];
+
+  for (const [monthKey, month] of Object.entries(body.monthly ?? {})) {
+    const monthNum = Number(monthKey);
+    const maxDay = daysInMonth(year, monthNum);
+    for (const dayKey of Object.keys(month.daily ?? {})) {
+      const dayNum = Number(dayKey);
+      if (dayNum < 1 || dayNum > maxDay) {
+        issues.push({
+          path: `monthly.${monthKey}.daily.${dayKey}`,
+          message: `day ${dayKey} is invalid for ${year}-${monthKey} (max ${maxDay})`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Validates merge buckets against the per-domain sign constraint, the target
+ * year, and day-of-month validity (leap-year aware). Returns an empty array
+ * when valid.
+ */
+export function validateMergeBucketsForDomain(
+  body: MergeGoalsBodyDTO,
+  domain: GoalDomain,
+  year: number,
+): GoalValidationIssue[] {
+  const issues: GoalValidationIssue[] = [];
+
+  body.buckets.forEach((bucket, i) => {
+    if (!isValidValueForDomain(domain, bucket.value)) {
+      issues.push({
+        path: `buckets.${i}.value`,
+        message:
+          domain === 'TEMPERATURE'
+            ? 'value must be a finite number'
+            : 'value must be a finite number >= 0 for energy/water domains',
+      });
+    }
+
+    // ref's year must match the query year, and DAY/HOUR days must be valid.
+    const refYear = Number(bucket.ref.slice(0, 4));
+    if (refYear !== year) {
+      issues.push({
+        path: `buckets.${i}.ref`,
+        message: `ref year ${refYear} does not match the target year ${year}`,
+      });
+    }
+
+    if (bucket.level === 'DAY' || bucket.level === 'HOUR') {
+      const monthNum = Number(bucket.ref.slice(5, 7));
+      const dayNum = Number(bucket.ref.slice(8, 10));
+      const maxDay = daysInMonth(refYear, monthNum);
+      if (dayNum < 1 || dayNum > maxDay) {
+        issues.push({
+          path: `buckets.${i}.ref`,
+          message: `day ${dayNum} is invalid for ${refYear}-${bucket.ref.slice(5, 7)} (max ${maxDay})`,
+        });
+      }
+    }
+  });
+
+  return issues;
+}
+
+// Re-exported leaf schemas for unit tests / reuse.
+export {
+  YearSchema,
+  MonthSchema,
+  HourSchema,
+  MonthKeySchema,
+  DayKeySchema,
+  HourKeySchema,
+  BUCKET_REF_PATTERNS,
+};

--- a/src/dto/response/GoalsResponseDTO.ts
+++ b/src/dto/response/GoalsResponseDTO.ts
@@ -86,15 +86,29 @@ export interface GoalTree {
 // returns ≤100 of these, newest first.
 // -----------------------------------------------------------------------------
 
+/** One compact bucket sample for the timeline breakdown of a history entry. */
+export interface GoalHistoryDetail {
+  /** Bucket reference: "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08". */
+  ref: string;
+  /** Value at the bucket level (null on delete). */
+  value: number | null;
+}
+
 export interface GoalHistoryEntry {
+  /** Operation that produced this version (IMPORT | REPLACE | MERGE | DELETE | EDIT). */
+  source: 'IMPORT' | 'REPLACE' | 'MERGE' | 'DELETE' | 'EDIT';
   /** Level the user touched (YEAR | MONTH | DAY | HOUR). */
   actionLevel: GoalSourceLevel;
-  /** Bucket reference: "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08". */
+  /** Representative bucket reference for the operation. */
   bucketRef: string;
   /** Value at the input level before the change (null on create). */
   oldValue: number | null;
-  /** Value at the input level after the change (null on delete). */
+  /** Value at the input level after the change (null on delete / multi-bucket op). */
   newValue: number | null;
+  /** How many operator buckets this operation carried. */
+  bucketCount: number;
+  /** Compact sample of the operation's buckets (capped server-side). */
+  details: GoalHistoryDetail[];
   /** True when the system spread the change down to hour rows. */
   distributed: boolean;
   /** Count of hour rows written by this change. */

--- a/src/dto/response/GoalsResponseDTO.ts
+++ b/src/dto/response/GoalsResponseDTO.ts
@@ -1,0 +1,201 @@
+// =============================================================================
+// RFC-0046: Customer Consumption Goals — response contracts (TypeScript types)
+//
+// The read wire shape returns the goal tree at the requested granularity,
+// derived from the canonical hourly grain, plus the optimistic `version`.
+// Each derived node declares its `method` so a temperature weighted-average is
+// never mistaken for a sum. This file defines ONLY response-side types — no
+// business logic.
+// =============================================================================
+
+import type {
+  GoalDomain,
+  GoalGranularity,
+  GoalSourceLevel,
+  GoalAggregationMethod,
+} from '../request/GoalsDTO';
+
+// -----------------------------------------------------------------------------
+// Derived tree nodes
+//
+// Every derived node carries:
+//   - value:       the rolled-up (or distributed) target at this node
+//   - method:      how children were reduced into this value (SUM | AVERAGE)
+//   - sourceLevel: the level the operator actually set for this bucket
+//   - derived:     true when the value was system-distributed/aggregated,
+//                  false when the operator set this exact bucket
+//
+// `annual` may legitimately have no `sourceLevel`/`derived` when nothing was set
+// at the year level itself (it was rolled up from finer buckets); those fields
+// are therefore optional on the annual node and required on leaf-set buckets.
+// -----------------------------------------------------------------------------
+
+/** A single derived tree node (the {value, method, sourceLevel, derived} leaf). */
+export interface GoalTreeNode {
+  value: number;
+  method: GoalAggregationMethod;
+  sourceLevel: GoalSourceLevel;
+  derived: boolean;
+}
+
+/** Annual node: source metadata is optional (it may be a pure roll-up). */
+export interface GoalAnnualNode {
+  value: number;
+  method: GoalAggregationMethod;
+  sourceLevel?: GoalSourceLevel;
+  derived?: boolean;
+}
+
+/** Map of hour key ("00".."23") → hour node. Present at `granularity=hour`. */
+export type GoalHourMap = Record<string, GoalTreeNode>;
+
+/** Day node: optional nested hourly map when the hour granularity is requested. */
+export interface GoalDayNode extends GoalTreeNode {
+  hourly?: GoalHourMap;
+}
+
+/** Map of day key ("01".."31") → day node. */
+export type GoalDayMap = Record<string, GoalDayNode>;
+
+/** Month node: optional nested daily map at `granularity=day` or finer. */
+export interface GoalMonthNode extends GoalTreeNode {
+  daily?: GoalDayMap;
+}
+
+/** Map of month key ("01".."12") → month node. */
+export type GoalMonthMap = Record<string, GoalMonthNode>;
+
+/**
+ * The derived tree. Which fields are populated depends on the requested
+ * granularity:
+ *   - year:  { annual }
+ *   - month: { annual, monthly }
+ *   - day:   { annual, monthly: { ..daily } }
+ *   - hour:  { annual, monthly: { ..daily: { ..hourly } } }
+ */
+export interface GoalTree {
+  annual: GoalAnnualNode;
+  monthly?: GoalMonthMap;
+}
+
+// -----------------------------------------------------------------------------
+// History entry
+//
+// One row per change, recording the level the user acted on and how the system
+// distributed it. Mirrors `consumption_goal_history`. `?fetchHistory=true`
+// returns ≤100 of these, newest first.
+// -----------------------------------------------------------------------------
+
+export interface GoalHistoryEntry {
+  /** Level the user touched (YEAR | MONTH | DAY | HOUR). */
+  actionLevel: GoalSourceLevel;
+  /** Bucket reference: "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08". */
+  bucketRef: string;
+  /** Value at the input level before the change (null on create). */
+  oldValue: number | null;
+  /** Value at the input level after the change (null on delete). */
+  newValue: number | null;
+  /** True when the system spread the change down to hour rows. */
+  distributed: boolean;
+  /** Count of hour rows written by this change. */
+  hoursAffected: number;
+  /** The version this change produced. */
+  version: number;
+  /** ISO-8601 timestamp of the change. */
+  changedAt: string;
+  /** Who changed it (user/actor id), or null for system changes. */
+  actor: string | null;
+}
+
+// -----------------------------------------------------------------------------
+// Top-level GET response
+//
+// GET /customers/:id/goals?domain=&year=&granularity=&fetchHistory=
+// -----------------------------------------------------------------------------
+
+export interface GetGoalsResponseDTO {
+  customerId: string;
+  domain: GoalDomain;
+  /** Unit from domain config: kWh | m3 | C. */
+  unit: string;
+  aggregationMethod: GoalAggregationMethod;
+  year: number;
+  /** Optimistic concurrency version for this (customer, domain, year). */
+  version: number;
+  /** Granularity the tree was derived at (echoes the request, default month). */
+  granularity: GoalGranularity;
+  /** The derived tree at the requested granularity. */
+  tree: GoalTree;
+  /** Present only when fetchHistory=true; ≤100 entries, newest first. */
+  history?: GoalHistoryEntry[];
+}
+
+// -----------------------------------------------------------------------------
+// GET /customers/:id/goals (no domain) — summary listing
+// -----------------------------------------------------------------------------
+
+/** One summary entry per domain that has goals for the customer. */
+export interface GoalDomainSummaryDTO {
+  domain: GoalDomain;
+  unit: string;
+  aggregationMethod: GoalAggregationMethod;
+  /** Years that have at least one goal bucket for this domain. */
+  years: number[];
+  /** Latest version across the listed years (highest), for quick display. */
+  version: number;
+}
+
+export interface ListGoalsSummaryResponseDTO {
+  customerId: string;
+  domains: GoalDomainSummaryDTO[];
+}
+
+// -----------------------------------------------------------------------------
+// Write responses (PUT / PATCH / DELETE)
+//
+// Return the new version and a compact summary of what the write did, so the
+// front-end can reconcile without an extra round-trip.
+// -----------------------------------------------------------------------------
+
+export interface GoalsWriteResponseDTO {
+  customerId: string;
+  domain: GoalDomain;
+  year: number;
+  /** New optimistic version after the write. */
+  version: number;
+  /** Count of hour rows written/affected by this write. */
+  hoursAffected: number;
+  /** The level the operator acted on for the audit event. */
+  actionLevel: GoalSourceLevel;
+}
+
+// -----------------------------------------------------------------------------
+// CSV import (dry-run preview + confirm)
+// -----------------------------------------------------------------------------
+
+/** A single line-level diagnostic from a CSV import dry-run. */
+export interface GoalImportLineDiagnostic {
+  /** 1-based source line number in the uploaded CSV. */
+  line: number;
+  status: 'OK' | 'ERROR';
+  /** Present when status = ERROR; human-readable reason. */
+  message?: string;
+  /** Resolved bucket reference for an OK line (e.g. "2026-03-15"). */
+  bucketRef?: string;
+}
+
+export interface ImportGoalsResponseDTO {
+  customerId: string;
+  domain: GoalDomain;
+  year: number;
+  /** True when this was a preview (nothing persisted). */
+  dryRun: boolean;
+  okCount: number;
+  errorCount: number;
+  /** Line-by-line diagnostics (errors always listed; OK lines may be summarised). */
+  diagnostics: GoalImportLineDiagnostic[];
+  /** The ghost tree showing how the year would look (preview) or now looks. */
+  tree: GoalTree;
+  /** New version when persisted (dryRun=false); omitted on a pure preview. */
+  version?: number;
+}

--- a/src/dto/response/index.ts
+++ b/src/dto/response/index.ts
@@ -3,3 +3,4 @@ export * from './AuthorizationResponseDTO';
 export * from './AssetResponseDTO';
 export * from './DeviceResponseDTO';
 export * from './RuleResponseDTO';
+export * from './GoalsResponseDTO';

--- a/src/infrastructure/database/drizzle/schema.ts
+++ b/src/infrastructure/database/drizzle/schema.ts
@@ -13,6 +13,7 @@ import {
   integer,
   smallint,
   bigint,
+  numeric,
   boolean,
   timestamp,
   jsonb,
@@ -2014,4 +2015,94 @@ export const workOrdersWatchers = pgTable('work_orders_watchers', {
   createdAt:   timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 }, (table) => ({
   woEmailUnique: uniqueIndex('work_orders_watchers_unique').on(table.workOrderId, table.email),
+}));
+
+// =============================================================================
+// CONSUMPTION GOALS (RFC-0046)
+// =============================================================================
+// Per-customer targets for ENERGY | WATER | TEMPERATURE, scoped by domain and
+// year, persisted at a single canonical grain — the hour. The parent row holds
+// the optimistic `version`; hours are derived-on-write / aggregated-on-read.
+
+// 1) Parent — one per (tenant, customer, domain, year); carries the version.
+export const consumptionGoals = pgTable('consumption_goals', {
+  id:         uuid('id').primaryKey().defaultRandom(),
+  tenantId:   uuid('tenant_id').notNull(),
+  customerId: uuid('customer_id').notNull().references(() => customers.id, { onDelete: 'cascade' }),
+  domain:     text('domain').notNull(),                 // ENERGY | WATER | TEMPERATURE
+  year:       smallint('year').notNull(),
+  unit:       text('unit').notNull(),                    // kWh | m3 | C (from domain config)
+  version:    integer('version').notNull().default(1),
+  createdAt:  timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  createdBy:  uuid('created_by'),
+  updatedAt:  timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedBy:  uuid('updated_by'),
+}, (table) => ({
+  uq:          uniqueIndex('consumption_goals_uq').on(table.tenantId, table.customerId, table.domain, table.year),
+  customerIdx: index('consumption_goals_customer_idx').on(table.tenantId, table.customerId),
+  domainCheck: check(
+    'consumption_goals_domain_check',
+    sql`${table.domain} IN ('ENERGY','WATER','TEMPERATURE')`
+  ),
+}));
+
+// 2) Canonical hourly grain. One row per (goal, month, day, hour).
+export const consumptionGoalHours = pgTable('consumption_goal_hours', {
+  goalId:      uuid('goal_id').notNull().references(() => consumptionGoals.id, { onDelete: 'cascade' }),
+  month:       smallint('month').notNull(),              // 1..12
+  day:         smallint('day').notNull(),                // 1..31 (valid for the month/year)
+  hour:        smallint('hour').notNull(),               // 0..23
+  value:       numeric('value').notNull(),
+  sourceLevel: text('source_level').notNull(),           // YEAR | MONTH | DAY | HOUR — level the user set
+  derived:     boolean('derived').notNull(),             // true = system-distributed
+  updatedAt:   timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedBy:   uuid('updated_by'),
+}, (table) => ({
+  uq: uniqueIndex('consumption_goal_hours_uq').on(table.goalId, table.month, table.day, table.hour),
+  monthRange:  check('consumption_goal_hours_month_check', sql`${table.month} BETWEEN 1 AND 12`),
+  dayRange:    check('consumption_goal_hours_day_check',   sql`${table.day} BETWEEN 1 AND 31`),
+  hourRange:   check('consumption_goal_hours_hour_check',  sql`${table.hour} BETWEEN 0 AND 23`),
+  sourceLevelCheck: check(
+    'consumption_goal_hours_source_level_check',
+    sql`${table.sourceLevel} IN ('YEAR','MONTH','DAY','HOUR')`
+  ),
+}));
+
+// 3) Fixed aggregation config per (tenant, domain). Seeded; operator-immutable.
+export const consumptionGoalDomains = pgTable('consumption_goal_domains', {
+  tenantId:          uuid('tenant_id').notNull(),
+  domain:            text('domain').notNull(),           // ENERGY | WATER | TEMPERATURE
+  aggregationMethod: text('aggregation_method').notNull(), // SUM | AVERAGE
+  unit:              text('unit').notNull(),             // kWh | m3 | C
+}, (table) => ({
+  pk: primaryKey({ columns: [table.tenantId, table.domain] }),
+  aggregationMethodCheck: check(
+    'consumption_goal_domains_agg_method_check',
+    sql`${table.aggregationMethod} IN ('SUM','AVERAGE')`
+  ),
+  domainCheck: check(
+    'consumption_goal_domains_domain_check',
+    sql`${table.domain} IN ('ENERGY','WATER','TEMPERATURE')`
+  ),
+}));
+
+// 4) Append-only history. Records the level the user acted on (DEC-4).
+export const consumptionGoalHistory = pgTable('consumption_goal_history', {
+  id:            uuid('id').primaryKey().defaultRandom(),
+  goalId:        uuid('goal_id').notNull(),
+  actor:         uuid('actor'),                          // who changed it
+  actionLevel:   text('action_level').notNull(),         // YEAR | MONTH | DAY | HOUR — what the user touched
+  bucketRef:     text('bucket_ref').notNull(),           // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  oldValue:      numeric('old_value'),                   // at the input level (NULL on create)
+  newValue:      numeric('new_value'),                   // at the input level (NULL on delete)
+  distributed:   boolean('distributed').notNull(),       // true = system spread to hours
+  hoursAffected: integer('hours_affected').notNull(),    // count of hour rows written by this change
+  version:       integer('version').notNull(),           // the version this change produced
+  changedAt:     timestamp('changed_at', { withTimezone: true }).notNull().defaultNow(),
+}, (table) => ({
+  goalChronoIdx: index('consumption_goal_history_idx').on(table.goalId, table.changedAt.desc()),
+  actionLevelCheck: check(
+    'consumption_goal_history_action_level_check',
+    sql`${table.actionLevel} IN ('YEAR','MONTH','DAY','HOUR')`
+  ),
 }));

--- a/src/infrastructure/database/drizzle/schema.ts
+++ b/src/infrastructure/database/drizzle/schema.ts
@@ -2091,10 +2091,13 @@ export const consumptionGoalHistory = pgTable('consumption_goal_history', {
   id:            uuid('id').primaryKey().defaultRandom(),
   goalId:        uuid('goal_id').notNull(),
   actor:         uuid('actor'),                          // who changed it
+  source:        text('source').notNull().default('EDIT'), // IMPORT | REPLACE | MERGE | DELETE | EDIT — the operation
   actionLevel:   text('action_level').notNull(),         // YEAR | MONTH | DAY | HOUR — what the user touched
   bucketRef:     text('bucket_ref').notNull(),           // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
   oldValue:      numeric('old_value'),                   // at the input level (NULL on create)
-  newValue:      numeric('new_value'),                   // at the input level (NULL on delete)
+  newValue:      numeric('new_value'),                   // at the input level (NULL on delete / multi-bucket op)
+  bucketCount:   integer('bucket_count').notNull().default(1), // operator buckets this operation carried
+  details:       jsonb('details').notNull().default([]), // compact [{ ref, value }] sample for the timeline
   distributed:   boolean('distributed').notNull(),       // true = system spread to hours
   hoursAffected: integer('hours_affected').notNull(),    // count of hour rows written by this change
   version:       integer('version').notNull(),           // the version this change produced
@@ -2104,5 +2107,9 @@ export const consumptionGoalHistory = pgTable('consumption_goal_history', {
   actionLevelCheck: check(
     'consumption_goal_history_action_level_check',
     sql`${table.actionLevel} IN ('YEAR','MONTH','DAY','HOUR')`
+  ),
+  sourceCheck: check(
+    'consumption_goal_history_source_check',
+    sql`${table.source} IN ('IMPORT','REPLACE','MERGE','DELETE','EDIT')`
   ),
 }));

--- a/src/repositories/consumptionGoalRepository.ts
+++ b/src/repositories/consumptionGoalRepository.ts
@@ -90,17 +90,28 @@ export interface GoalHourScope {
 }
 
 /** A history row to append (the version it produced is supplied by the caller). */
+/** One compact bucket sample stored in `details` for the timeline breakdown. */
+export interface GoalHistoryDetail {
+  ref: string; // "2026-03-15T08"
+  value: number | null; // value at the bucket level (null on delete)
+}
+
 export interface GoalHistoryAppend {
   goalId: string;
   actor?: string | null;
+  source: GoalHistorySource; // IMPORT | REPLACE | MERGE | DELETE | EDIT
   actionLevel: GoalSourceLevel; // YEAR | MONTH | DAY | HOUR
   bucketRef: string; // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
   oldValue?: string | null; // at the input level; NULL on create
-  newValue?: string | null; // at the input level; NULL on delete
+  newValue?: string | null; // at the input level; NULL on delete / multi-bucket op
+  bucketCount: number; // operator buckets this operation carried
+  details?: GoalHistoryDetail[]; // compact sample for the timeline
   distributed: boolean;
   hoursAffected: number;
   version: number; // the version this change produced
 }
+
+export type GoalHistorySource = 'IMPORT' | 'REPLACE' | 'MERGE' | 'DELETE' | 'EDIT';
 
 /** Default aggregation config per domain (DEC: fixed; seed if missing). */
 const DEFAULT_DOMAIN_CONFIG: Record<GoalDomain, { aggregationMethod: GoalAggregationMethod; unit: string }> = {
@@ -327,10 +338,13 @@ export class ConsumptionGoalRepository {
       .values({
         goalId: entry.goalId,
         actor: entry.actor ?? null,
+        source: entry.source,
         actionLevel: entry.actionLevel,
         bucketRef: entry.bucketRef,
         oldValue: entry.oldValue ?? null,
         newValue: entry.newValue ?? null,
+        bucketCount: entry.bucketCount,
+        details: entry.details ?? [],
         distributed: entry.distributed,
         hoursAffected: entry.hoursAffected,
         version: entry.version,

--- a/src/repositories/consumptionGoalRepository.ts
+++ b/src/repositories/consumptionGoalRepository.ts
@@ -1,0 +1,433 @@
+// =============================================================================
+// RFC-0046 — Customer Consumption Goals: repository (data access)
+//
+// Owns the four goals tables:
+//   - consumptionGoals        (parent — one per tenant+customer+domain+year)
+//   - consumptionGoalHours    (canonical hourly grain)
+//   - consumptionGoalDomains  (fixed aggregation config per tenant+domain)
+//   - consumptionGoalHistory  (append-only audit of operator-level edits)
+//
+// Conventions (matched from CustomerRepository / DeviceSyncJobRepository /
+// WorkOrderLifecycleRepository): the shared `db` client, tenant-scoped reads,
+// Drizzle `eq/and`, `db.transaction(async (tx) => ...)` for atomicity.
+//
+// Ratified storage rules this repo encodes (no business logic — that lives in
+// the service):
+//   - hour is the only stored grain (DEC-1);
+//   - `version` lives on the parent and bumps per change (DEC-4) — the bump is a
+//     guarded `UPDATE ... SET version = version + 1 WHERE id = ? AND version = ?`
+//     (optimistic concurrency); a 0-row result is a version conflict;
+//   - the hour upsert + version bump + history append run in ONE transaction —
+//     every mutating method accepts an optional `tx` so the service can compose
+//     them; `withTransaction` exposes the transaction boundary.
+//   - `aggregation_method` is fixed per domain, read from consumption_goal_domains
+//     (seeded on demand if missing).
+// =============================================================================
+
+import { and, eq, desc, sql } from 'drizzle-orm';
+import { db, schema } from '../infrastructure/database/drizzle/db';
+import type { GoalAggregationMethod, GoalDomain, GoalSourceLevel } from '../dto/request/GoalsDTO';
+
+const { consumptionGoals, consumptionGoalHours, consumptionGoalDomains, consumptionGoalHistory } = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing
+//
+// Drizzle does not export a stable transaction-client type alias, so we derive
+// it from `db.transaction`'s callback parameter. Both `db` and a `tx` satisfy
+// `GoalDbClient`, letting every method accept an optional executor.
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type GoalTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type GoalDbClient = typeof db | GoalTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type ConsumptionGoalRow = typeof consumptionGoals.$inferSelect;
+export type ConsumptionGoalHourRow = typeof consumptionGoalHours.$inferSelect;
+export type ConsumptionGoalDomainRow = typeof consumptionGoalDomains.$inferSelect;
+export type ConsumptionGoalHistoryRow = typeof consumptionGoalHistory.$inferSelect;
+
+/** Identifies the parent goal tree. */
+export interface GoalKey {
+  tenantId: string;
+  customerId: string;
+  domain: GoalDomain;
+  year: number;
+}
+
+/** Data to create the parent goal row. */
+export interface CreateGoalData extends GoalKey {
+  unit: string;
+  createdBy?: string | null;
+}
+
+/**
+ * One canonical hour to upsert. `value` is kept as a string (numeric column) to
+ * preserve precision end-to-end — the service formats numbers; the repo never
+ * rounds.
+ */
+export interface GoalHourUpsert {
+  month: number; // 1..12
+  day: number; // 1..31
+  hour: number; // 0..23
+  value: string; // numeric, as a string
+  sourceLevel: GoalSourceLevel; // YEAR | MONTH | DAY | HOUR
+  derived: boolean; // true = system-distributed
+  updatedBy?: string | null;
+}
+
+/** Scope for deleting hour rows; omit a field to leave that level unconstrained. */
+export interface GoalHourScope {
+  month?: number;
+  day?: number;
+  hour?: number;
+}
+
+/** A history row to append (the version it produced is supplied by the caller). */
+export interface GoalHistoryAppend {
+  goalId: string;
+  actor?: string | null;
+  actionLevel: GoalSourceLevel; // YEAR | MONTH | DAY | HOUR
+  bucketRef: string; // "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08"
+  oldValue?: string | null; // at the input level; NULL on create
+  newValue?: string | null; // at the input level; NULL on delete
+  distributed: boolean;
+  hoursAffected: number;
+  version: number; // the version this change produced
+}
+
+/** Default aggregation config per domain (DEC: fixed; seed if missing). */
+const DEFAULT_DOMAIN_CONFIG: Record<GoalDomain, { aggregationMethod: GoalAggregationMethod; unit: string }> = {
+  ENERGY: { aggregationMethod: 'SUM', unit: 'kWh' },
+  WATER: { aggregationMethod: 'SUM', unit: 'm3' },
+  TEMPERATURE: { aggregationMethod: 'AVERAGE', unit: 'C' },
+};
+
+export class ConsumptionGoalRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Runs `fn` inside a single DB transaction, handing it a `tx` to pass to the
+   * other methods. The service uses this to make upsert + version bump + history
+   * append atomic.
+   */
+  async withTransaction<T>(fn: (tx: GoalTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parent goal
+  // ---------------------------------------------------------------------------
+
+  /** Finds the parent goal by (tenant, customer, domain, year). */
+  async findGoal(key: GoalKey, exec: GoalDbClient = db): Promise<ConsumptionGoalRow | null> {
+    const [row] = await exec
+      .select()
+      .from(consumptionGoals)
+      .where(
+        and(
+          eq(consumptionGoals.tenantId, key.tenantId),
+          eq(consumptionGoals.customerId, key.customerId),
+          eq(consumptionGoals.domain, key.domain),
+          eq(consumptionGoals.year, key.year),
+        ),
+      )
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  /** Finds the parent goal by its id (tenant-scoped). */
+  async findGoalById(tenantId: string, goalId: string, exec: GoalDbClient = db): Promise<ConsumptionGoalRow | null> {
+    const [row] = await exec
+      .select()
+      .from(consumptionGoals)
+      .where(and(eq(consumptionGoals.tenantId, tenantId), eq(consumptionGoals.id, goalId)))
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  /** Lists every parent goal for a customer (used by the "list domains" summary). */
+  async listGoalsForCustomer(
+    tenantId: string,
+    customerId: string,
+    exec: GoalDbClient = db,
+  ): Promise<ConsumptionGoalRow[]> {
+    return exec
+      .select()
+      .from(consumptionGoals)
+      .where(and(eq(consumptionGoals.tenantId, tenantId), eq(consumptionGoals.customerId, customerId)))
+      .orderBy(consumptionGoals.domain, desc(consumptionGoals.year));
+  }
+
+  /** Inserts the parent goal row (version starts at 1 per schema default). */
+  async createGoal(data: CreateGoalData, exec: GoalDbClient = db): Promise<ConsumptionGoalRow> {
+    const [row] = await exec
+      .insert(consumptionGoals)
+      .values({
+        tenantId: data.tenantId,
+        customerId: data.customerId,
+        domain: data.domain,
+        year: data.year,
+        unit: data.unit,
+        createdBy: data.createdBy ?? null,
+        updatedBy: data.createdBy ?? null,
+      })
+      .returning();
+
+    return row;
+  }
+
+  /**
+   * Finds the parent goal, creating it if absent. Convenience for the write path
+   * (PUT/PATCH/import-confirm) where a `(domain, year)` may be brand new.
+   */
+  async findOrCreateGoal(data: CreateGoalData, exec: GoalDbClient = db): Promise<ConsumptionGoalRow> {
+    const existing = await this.findGoal(data, exec);
+    if (existing) return existing;
+    return this.createGoal(data, exec);
+  }
+
+  /**
+   * Optimistic version bump. Atomically does
+   *   `UPDATE ... SET version = version + 1, updated_at = now() WHERE id = ? AND version = ?`
+   * Returns the updated row when the guard matched, or `null` when it did not
+   * (i.e. a version conflict — the service maps `null` to a 409 / ConflictError
+   * carrying the current version).
+   *
+   * Pass `expectedVersion` as `undefined` to force-write (skip the optimistic
+   * guard); the bump then matches on id alone.
+   */
+  async bumpVersion(
+    goalId: string,
+    expectedVersion: number | undefined,
+    updatedBy: string | null | undefined,
+    exec: GoalDbClient = db,
+  ): Promise<ConsumptionGoalRow | null> {
+    const guard =
+      expectedVersion === undefined
+        ? eq(consumptionGoals.id, goalId)
+        : and(eq(consumptionGoals.id, goalId), eq(consumptionGoals.version, expectedVersion));
+
+    const [row] = await exec
+      .update(consumptionGoals)
+      .set({
+        version: sqlIncrement(),
+        updatedAt: new Date(),
+        updatedBy: updatedBy ?? null,
+      })
+      .where(guard)
+      .returning();
+
+    return row ?? null;
+  }
+
+  /** Deletes the parent goal (cascades to its hours via FK). Returns rows removed. */
+  async deleteGoal(goalId: string, exec: GoalDbClient = db): Promise<number> {
+    const rows = await exec.delete(consumptionGoals).where(eq(consumptionGoals.id, goalId)).returning({
+      id: consumptionGoals.id,
+    });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hours (canonical grain)
+  // ---------------------------------------------------------------------------
+
+  /** Reads all hour rows for a goal (ordered for deterministic roll-up on read). */
+  async findHours(goalId: string, exec: GoalDbClient = db): Promise<ConsumptionGoalHourRow[]> {
+    return exec
+      .select()
+      .from(consumptionGoalHours)
+      .where(eq(consumptionGoalHours.goalId, goalId))
+      .orderBy(consumptionGoalHours.month, consumptionGoalHours.day, consumptionGoalHours.hour);
+  }
+
+  /**
+   * Bulk upsert of hour rows. Conflict target is the unique
+   * `(goal_id, month, day, hour)` — on conflict the value/sourceLevel/derived
+   * are overwritten (the service decides which hours to send; the repo writes
+   * exactly what it is given). No-op on an empty array.
+   */
+  async upsertHours(goalId: string, hours: GoalHourUpsert[], exec: GoalDbClient = db): Promise<number> {
+    if (hours.length === 0) return 0;
+
+    const now = new Date();
+    const values = hours.map((h) => ({
+      goalId,
+      month: h.month,
+      day: h.day,
+      hour: h.hour,
+      value: h.value,
+      sourceLevel: h.sourceLevel,
+      derived: h.derived,
+      updatedAt: now,
+      updatedBy: h.updatedBy ?? null,
+    }));
+
+    const rows = await exec
+      .insert(consumptionGoalHours)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [
+          consumptionGoalHours.goalId,
+          consumptionGoalHours.month,
+          consumptionGoalHours.day,
+          consumptionGoalHours.hour,
+        ],
+        set: {
+          value: sqlExcluded('value'),
+          sourceLevel: sqlExcluded('source_level'),
+          derived: sqlExcluded('derived'),
+          updatedAt: now,
+          updatedBy: sqlExcluded('updated_by'),
+        },
+      })
+      .returning({ goalId: consumptionGoalHours.goalId });
+
+    return rows.length;
+  }
+
+  /**
+   * Deletes hour rows for a goal. With no `scope` it removes every hour (used by
+   * PUT-replace before re-writing, and by a whole-year delete). A `scope`
+   * narrows to a month / day / hour bucket (sub-bucket delete).
+   */
+  async deleteHours(goalId: string, scope: GoalHourScope = {}, exec: GoalDbClient = db): Promise<number> {
+    const conditions = [eq(consumptionGoalHours.goalId, goalId)];
+    if (scope.month !== undefined) conditions.push(eq(consumptionGoalHours.month, scope.month));
+    if (scope.day !== undefined) conditions.push(eq(consumptionGoalHours.day, scope.day));
+    if (scope.hour !== undefined) conditions.push(eq(consumptionGoalHours.hour, scope.hour));
+
+    const rows = await exec
+      .delete(consumptionGoalHours)
+      .where(and(...conditions))
+      .returning({ goalId: consumptionGoalHours.goalId });
+
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // History (append-only)
+  // ---------------------------------------------------------------------------
+
+  /** Appends a single history row. */
+  async appendHistory(entry: GoalHistoryAppend, exec: GoalDbClient = db): Promise<ConsumptionGoalHistoryRow> {
+    const [row] = await exec
+      .insert(consumptionGoalHistory)
+      .values({
+        goalId: entry.goalId,
+        actor: entry.actor ?? null,
+        actionLevel: entry.actionLevel,
+        bucketRef: entry.bucketRef,
+        oldValue: entry.oldValue ?? null,
+        newValue: entry.newValue ?? null,
+        distributed: entry.distributed,
+        hoursAffected: entry.hoursAffected,
+        version: entry.version,
+      })
+      .returning();
+
+    return row;
+  }
+
+  /** Reads history for a goal, newest-first, capped at `limit` (default 100). */
+  async findHistory(goalId: string, limit = 100, exec: GoalDbClient = db): Promise<ConsumptionGoalHistoryRow[]> {
+    return exec
+      .select()
+      .from(consumptionGoalHistory)
+      .where(eq(consumptionGoalHistory.goalId, goalId))
+      .orderBy(desc(consumptionGoalHistory.changedAt))
+      .limit(limit);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Domain aggregation config (fixed per domain; seeded on demand)
+  // ---------------------------------------------------------------------------
+
+  /** Reads the aggregation config for a (tenant, domain), or null if unseeded. */
+  async findDomainConfig(
+    tenantId: string,
+    domain: GoalDomain,
+    exec: GoalDbClient = db,
+  ): Promise<ConsumptionGoalDomainRow | null> {
+    const [row] = await exec
+      .select()
+      .from(consumptionGoalDomains)
+      .where(and(eq(consumptionGoalDomains.tenantId, tenantId), eq(consumptionGoalDomains.domain, domain)))
+      .limit(1);
+
+    return row ?? null;
+  }
+
+  /** Lists every aggregation config for a tenant. */
+  async listDomainConfigs(tenantId: string, exec: GoalDbClient = db): Promise<ConsumptionGoalDomainRow[]> {
+    return exec
+      .select()
+      .from(consumptionGoalDomains)
+      .where(eq(consumptionGoalDomains.tenantId, tenantId));
+  }
+
+  /**
+   * Reads the aggregation config for a (tenant, domain), seeding the ratified
+   * default (ENERGY/WATER=SUM, TEMPERATURE=AVERAGE) when the tenant has no row
+   * yet. Idempotent — a concurrent seed is absorbed by `onConflictDoNothing`,
+   * after which the existing row is returned.
+   */
+  async getOrSeedDomainConfig(
+    tenantId: string,
+    domain: GoalDomain,
+    exec: GoalDbClient = db,
+  ): Promise<ConsumptionGoalDomainRow> {
+    const existing = await this.findDomainConfig(tenantId, domain, exec);
+    if (existing) return existing;
+
+    const def = DEFAULT_DOMAIN_CONFIG[domain];
+    const [seeded] = await exec
+      .insert(consumptionGoalDomains)
+      .values({
+        tenantId,
+        domain,
+        aggregationMethod: def.aggregationMethod,
+        unit: def.unit,
+      })
+      .onConflictDoNothing({ target: [consumptionGoalDomains.tenantId, consumptionGoalDomains.domain] })
+      .returning();
+
+    if (seeded) return seeded;
+
+    // Lost the race — another writer seeded it first; read it back.
+    const row = await this.findDomainConfig(tenantId, domain, exec);
+    if (!row) {
+      // Should be unreachable: the row exists after a conflict-do-nothing.
+      throw new Error(`Failed to seed consumption goal domain config for ${domain}`);
+    }
+    return row;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Small SQL helpers (kept local so the call sites read cleanly).
+// -----------------------------------------------------------------------------
+
+/** `version = version + 1` increment expression for the parent bump. */
+function sqlIncrement() {
+  return sql`${consumptionGoals.version} + 1`;
+}
+
+/** References an `excluded.<column>` value inside an upsert's update set. */
+function sqlExcluded(column: string) {
+  return sql.raw(`excluded.${column}`);
+}
+
+// Singleton, mirroring `deviceSyncJobRepository`.
+export const consumptionGoalRepository = new ConsumptionGoalRepository();

--- a/src/services/consumptionGoalService.ts
+++ b/src/services/consumptionGoalService.ts
@@ -32,6 +32,8 @@ import {
   type ConsumptionGoalHourRow,
   type ConsumptionGoalHistoryRow,
   type GoalHourUpsert,
+  type GoalHistorySource,
+  type GoalHistoryDetail,
   type GoalKey,
   type GoalTx,
 } from '../repositories/consumptionGoalRepository';
@@ -90,10 +92,13 @@ export interface GoalTree {
 }
 
 export interface GoalHistoryEntry {
+  source: GoalHistorySource;
   actionLevel: GoalSourceLevel;
   bucketRef: string;
   oldValue: number | null;
   newValue: number | null;
+  bucketCount: number;
+  details: GoalHistoryDetail[];
   distributed: boolean;
   hoursAffected: number;
   version: number;
@@ -177,6 +182,9 @@ interface ValueBucket {
 }
 
 const SUM_AGG: GoalAggregationMethod = 'SUM';
+
+/** Max bucket samples persisted in a history row's `details` (timeline breakdown). */
+const HISTORY_DETAIL_CAP = 50;
 
 // =============================================================================
 // Service
@@ -450,7 +458,7 @@ export class ConsumptionGoalService {
 
       const final = await this.commitVersion(goal, created, body.expectedVersion, actor, key, tx);
 
-      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+      await this.appendOperation(goal.id, 'REPLACE', buckets, final.version, actor, tx);
 
       return { goal: final, hoursWritten, actionLevel };
     });
@@ -493,7 +501,7 @@ export class ConsumptionGoalService {
 
       const final = await this.commitVersion(goal, created, body.expectedVersion, actor, key, tx);
 
-      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+      await this.appendOperation(goal.id, 'MERGE', buckets, final.version, actor, tx);
 
       return { goal: final, hoursWritten, actionLevel };
     });
@@ -561,7 +569,7 @@ export class ConsumptionGoalService {
       await this.repo.upsertHours(goal.id, hours, tx);
 
       const final = await this.commitVersion(goal, created, expectedVersion, actor, key, tx);
-      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+      await this.appendOperation(goal.id, 'IMPORT', buckets, final.version, actor, tx);
 
       const rows = await this.repo.findHours(goal.id, tx);
       return { goal: final, rows };
@@ -633,10 +641,13 @@ export class ConsumptionGoalService {
         {
           goalId: goal.id,
           actor,
+          source: 'DELETE',
           actionLevel: bucket.level,
           bucketRef: bucket.ref,
           oldValue: null,
           newValue: null,
+          bucketCount: 1,
+          details: [{ ref: bucket.ref, value: null }],
           distributed: true,
           hoursAffected: hoursRemoved,
           version: bumped.version,
@@ -810,31 +821,50 @@ export class ConsumptionGoalService {
     return rows.length === 0 ? {} : this.buildTree(rows, granularity, method);
   }
 
-  /** Appends one history row per distinct operator bucket of this change. */
-  private async appendHistoryForBuckets(
+  /**
+   * Appends ONE audit row per operation (a mutation = a version = one entry),
+   * so the UI timeline reads clean, human entries and a large import does not
+   * flood the ≤100-row history window. The row records the operation `source`,
+   * the coarsest level touched, the bucket count, the total hours affected, and
+   * a compact `details` sample ([{ ref, value }], capped) for the breakdown.
+   */
+  private async appendOperation(
     goalId: string,
+    source: GoalHistorySource,
     buckets: ValueBucket[],
     version: number,
     actor: string | null,
     tx: GoalTx,
   ): Promise<void> {
-    for (const b of buckets) {
+    if (buckets.length === 0) return;
+
+    const actionLevel = coarsestLevel(buckets.map((b) => b.level));
+    const hoursAffected = buckets.reduce((sum, b) => {
       const year = Number(b.ref.slice(0, 4));
-      await this.repo.appendHistory(
-        {
-          goalId,
-          actor,
-          actionLevel: b.level,
-          bucketRef: b.ref,
-          oldValue: null,
-          newValue: formatNumeric(b.value),
-          distributed: true,
-          hoursAffected: this.hoursInScope(b.level, year, b.month, b.day),
-          version,
-        },
-        tx,
-      );
-    }
+      return sum + this.hoursInScope(b.level, year, b.month, b.day);
+    }, 0);
+    const details: GoalHistoryDetail[] = buckets
+      .slice(0, HISTORY_DETAIL_CAP)
+      .map((b) => ({ ref: b.ref, value: b.value }));
+
+    await this.repo.appendHistory(
+      {
+        goalId,
+        actor,
+        source,
+        actionLevel,
+        // Representative ref: the single bucket's ref, or the coarsest scope.
+        bucketRef: buckets.length === 1 ? buckets[0].ref : String(Number(buckets[0].ref.slice(0, 4))),
+        oldValue: null,
+        newValue: buckets.length === 1 ? formatNumeric(buckets[0].value) : null,
+        bucketCount: buckets.length,
+        details,
+        distributed: true,
+        hoursAffected,
+        version,
+      },
+      tx,
+    );
   }
 
   // ===========================================================================
@@ -1138,10 +1168,13 @@ function stripAggMeta(node: GoalTreeNode): GoalTreeNode {
 
 function mapHistoryRow(row: ConsumptionGoalHistoryRow): GoalHistoryEntry {
   return {
+    source: (row.source ?? 'EDIT') as GoalHistorySource,
     actionLevel: row.actionLevel as GoalSourceLevel,
     bucketRef: row.bucketRef,
     oldValue: row.oldValue === null ? null : Number(row.oldValue),
     newValue: row.newValue === null ? null : Number(row.newValue),
+    bucketCount: row.bucketCount ?? 1,
+    details: Array.isArray(row.details) ? (row.details as GoalHistoryDetail[]) : [],
     distributed: row.distributed,
     hoursAffected: row.hoursAffected,
     version: row.version,

--- a/src/services/consumptionGoalService.ts
+++ b/src/services/consumptionGoalService.ts
@@ -1,0 +1,1153 @@
+// =============================================================================
+// RFC-0046 — Customer Consumption Goals: service (business logic)
+//
+// Owns the ratified storage rules on top of `consumptionGoalRepository`:
+//
+//   DEC-1  Always-hourly canonical storage. The hour is the only stored grain;
+//          coarser views are derived on read, never materialised.
+//   DEC-2  Roll-up on read = SUM(hours) (SUM domains) or weighted AVG by hour
+//          count (AVERAGE/TEMPERATURE).
+//   DEC-3  Distribution on write: SUM → even split (parent / hoursInScope);
+//          AVERAGE → copy parent to every hour in scope.
+//   DEC-4  Optimistic `version` on the parent, bumped per change; the hour
+//          upsert + version bump + history append run in ONE transaction.
+//          A version mismatch raises VersionConflictError (409) carrying the
+//          current version.
+//   DEC-5  PUT = replace the whole (year, domain); PATCH = merge sent buckets.
+//   DEC-6  aggregation_method is fixed per domain, read from
+//          consumption_goal_domains (seeded on demand).
+//
+// Re-distribution on a coarser edit overwrites only system-distributed
+// (derived=true) hours by default; operator-confirmed (derived=false) hours are
+// preserved.
+//
+// Numbers: hour values are kept as strings end-to-end through the repository to
+// preserve numeric precision; the service formats on the boundary only.
+// =============================================================================
+
+import {
+  consumptionGoalRepository,
+  type ConsumptionGoalRepository,
+  type ConsumptionGoalRow,
+  type ConsumptionGoalHourRow,
+  type ConsumptionGoalHistoryRow,
+  type GoalHourUpsert,
+  type GoalKey,
+  type GoalTx,
+} from '../repositories/consumptionGoalRepository';
+import {
+  daysInMonth,
+  isValidValueForDomain,
+  type GoalAggregationMethod,
+  type GoalDomain,
+  type GoalGranularity,
+  type GoalSourceLevel,
+  type ReplaceGoalsBodyDTO,
+  type MergeGoalsBodyDTO,
+  type DeleteGoalsBodyDTO,
+} from '../dto/request/GoalsDTO';
+import { ValidationError, NotFoundError, AppError } from '../shared/errors/AppError';
+
+// -----------------------------------------------------------------------------
+// 409 — optimistic version conflict
+//
+// The project ships a generic `ConflictError` (code CONFLICT). RFC-0046 §4.4
+// requires code `VERSION_CONFLICT` with `currentVersion` in the body, so the
+// service raises this richer subclass; the controller serialises its `details`
+// and `currentVersion` directly (the global error handler only emits
+// message+code for a bare AppError).
+// -----------------------------------------------------------------------------
+
+export class VersionConflictError extends AppError {
+  public readonly currentVersion: number;
+  public readonly details: Record<string, unknown>;
+
+  constructor(currentVersion: number, expectedVersion: number | undefined, domain: GoalDomain, year: number) {
+    super('VERSION_CONFLICT', 'Version conflict: goal was modified by another change', 409);
+    this.currentVersion = currentVersion;
+    this.details = { expectedVersion, currentVersion, domain, year };
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Derived-tree response shapes (mirrors RFC-0046-Goals-API §3.2)
+// -----------------------------------------------------------------------------
+
+export interface GoalTreeNode {
+  value: number;
+  method: GoalAggregationMethod;
+  /** Finest level the operator set within the node; absent on the pure annual root. */
+  sourceLevel?: GoalSourceLevel;
+  /** true = every contributing hour was system-distributed. */
+  derived?: boolean;
+}
+
+export interface GoalTree {
+  annual?: GoalTreeNode;
+  monthly?: Record<string, GoalTreeNode>;
+  daily?: Record<string, GoalTreeNode>;
+  hourly?: Record<string, GoalTreeNode>;
+}
+
+export interface GoalHistoryEntry {
+  actionLevel: GoalSourceLevel;
+  bucketRef: string;
+  oldValue: number | null;
+  newValue: number | null;
+  distributed: boolean;
+  hoursAffected: number;
+  version: number;
+  actor: string | null;
+  changedAt: string;
+}
+
+export interface GoalGetResult {
+  customerId: string;
+  domain: GoalDomain;
+  unit: string;
+  aggregationMethod: GoalAggregationMethod;
+  year: number;
+  version: number;
+  tree: GoalTree;
+  history?: GoalHistoryEntry[];
+}
+
+export interface GoalWriteResult extends GoalGetResult {
+  distribution: { hoursWritten: number; actionLevel: GoalSourceLevel };
+}
+
+export interface GoalDomainSummary {
+  domain: GoalDomain;
+  unit: string;
+  aggregationMethod: GoalAggregationMethod;
+  years: Array<{ year: number; version: number }>;
+}
+
+export interface GoalListResult {
+  customerId: string;
+  domains: GoalDomainSummary[];
+}
+
+export interface GoalDeleteResult {
+  customerId: string;
+  domain: GoalDomain;
+  year: number;
+  deleted: { bucket: string | null; hoursRemoved: number; actionLevel: GoalSourceLevel };
+  version: number;
+}
+
+// Import (stateless dryRun — DEC e)
+export interface ImportDiagnostic {
+  line: number;
+  bucket?: string;
+  value?: number;
+  reason: string;
+}
+
+export interface ImportResult {
+  dryRun: boolean;
+  preview: GoalTree;
+  diagnostics: ImportDiagnostic[];
+  okCount: number;
+  errorCount: number;
+  /** present on persist (dryRun=false) */
+  version?: number;
+  /** present on persist (dryRun=false) — human-readable per-bucket log lines */
+  log?: string[];
+}
+
+// -----------------------------------------------------------------------------
+// Internal value-bucket model used by every write path
+//
+// A "bucket" is one operator-set value at a declared level. The service expands
+// each bucket to the canonical hour rows it covers.
+// -----------------------------------------------------------------------------
+
+interface ValueBucket {
+  level: GoalSourceLevel;
+  /** month 1..12 (undefined for YEAR). */
+  month?: number;
+  /** day 1..31 (undefined for YEAR/MONTH). */
+  day?: number;
+  /** hour 0..23 (undefined for YEAR/MONTH/DAY). */
+  hour?: number;
+  value: number;
+  /** bucketRef for history, e.g. "2026" | "2026-03" | "2026-03-15" | "2026-03-15T08". */
+  ref: string;
+}
+
+const SUM_AGG: GoalAggregationMethod = 'SUM';
+
+// =============================================================================
+// Service
+// =============================================================================
+
+export class ConsumptionGoalService {
+  constructor(private readonly repo: ConsumptionGoalRepository = consumptionGoalRepository) {}
+
+  // ---------------------------------------------------------------------------
+  // Calendar helpers (leap-year aware)
+  // ---------------------------------------------------------------------------
+
+  /** Hours covered by a bucket scope of the given level, for a (year). */
+  private hoursInScope(level: GoalSourceLevel, year: number, month?: number, _day?: number): number {
+    switch (level) {
+      case 'HOUR':
+        return 1;
+      case 'DAY':
+        return 24;
+      case 'MONTH': {
+        if (month === undefined) throw new ValidationError('month required for MONTH scope');
+        return daysInMonth(year, month) * 24;
+      }
+      case 'YEAR': {
+        let total = 0;
+        for (let m = 1; m <= 12; m++) total += daysInMonth(year, m);
+        return total * 24;
+      }
+      default:
+        throw new ValidationError(`Unknown level: ${level}`);
+    }
+  }
+
+  /** Iterates every (month, day, hour) in scope, calling `fn` for each. */
+  private forEachHourInScope(
+    level: GoalSourceLevel,
+    year: number,
+    scope: { month?: number; day?: number; hour?: number },
+    fn: (month: number, day: number, hour: number) => void,
+  ): void {
+    const months = level === 'YEAR' ? range(1, 12) : [scope.month!];
+    for (const m of months) {
+      const days =
+        level === 'YEAR' || level === 'MONTH' ? range(1, daysInMonth(year, m)) : [scope.day!];
+      for (const d of days) {
+        const hours = level === 'HOUR' ? [scope.hour!] : range(0, 23);
+        for (const h of hours) fn(m, d, h);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Distribution (bucket → canonical hour rows) — DEC-3
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Expands one value bucket into the hour upserts it covers.
+   *   SUM     → even split: each hour = value / hoursInScope
+   *   AVERAGE → copy: each hour = value
+   * Generated hours carry `sourceLevel` = the bucket's level and `derived` =
+   * true for every hour except the exact HOUR a HOUR-level bucket names.
+   */
+  private distributeBucket(
+    bucket: ValueBucket,
+    year: number,
+    method: GoalAggregationMethod,
+    updatedBy: string | null,
+  ): GoalHourUpsert[] {
+    const hours: GoalHourUpsert[] = [];
+    const scope = { month: bucket.month, day: bucket.day, hour: bucket.hour };
+    const count = this.hoursInScope(bucket.level, year, bucket.month, bucket.day);
+    const perHour = method === SUM_AGG ? bucket.value / count : bucket.value;
+    // A HOUR-level bucket is operator-confirmed for the exact hour it names.
+    const derived = bucket.level !== 'HOUR';
+
+    this.forEachHourInScope(bucket.level, year, scope, (m, d, h) => {
+      hours.push({
+        month: m,
+        day: d,
+        hour: h,
+        value: formatNumeric(perHour),
+        sourceLevel: bucket.level,
+        derived,
+        updatedBy,
+      });
+    });
+
+    return hours;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Roll-up (hour rows → derived tree) — DEC-2
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reduces hour rows to a node value at the requested method:
+   *   SUM     → sum of hour values
+   *   AVERAGE → weighted average by hour count (= simple mean of equal-weight hours)
+   * Also computes the aggregated `sourceLevel`/`derived`:
+   *   derived = true only when EVERY contributing hour is derived; the reported
+   *   sourceLevel is the finest level any contributing hour was set at.
+   */
+  private reduceHours(rows: ConsumptionGoalHourRow[], method: GoalAggregationMethod): GoalTreeNode {
+    let acc = 0;
+    let anyConfirmed = false;
+    let finestLevel: GoalSourceLevel | undefined;
+
+    for (const r of rows) {
+      acc += Number(r.value);
+      if (!r.derived) anyConfirmed = true;
+      finestLevel = finerLevel(finestLevel, r.sourceLevel as GoalSourceLevel);
+    }
+
+    const value = method === SUM_AGG ? acc : rows.length > 0 ? acc / rows.length : 0;
+
+    return {
+      value: roundOut(value),
+      method,
+      sourceLevel: finestLevel,
+      derived: rows.length > 0 ? !anyConfirmed : undefined,
+    };
+  }
+
+  /** Builds the derived tree at the requested granularity from all hour rows. */
+  private buildTree(
+    rows: ConsumptionGoalHourRow[],
+    granularity: GoalGranularity,
+    method: GoalAggregationMethod,
+  ): GoalTree {
+    const tree: GoalTree = {};
+
+    // annual is always present when there are any hours
+    tree.annual = stripAggMeta(this.reduceHours(rows, method));
+
+    if (granularity === 'year') return tree;
+
+    // monthly
+    const byMonth = groupBy(rows, (r) => pad2(r.month));
+    tree.monthly = {};
+    for (const [mKey, mRows] of Object.entries(byMonth)) {
+      tree.monthly[mKey] = this.reduceHours(mRows, method);
+    }
+
+    if (granularity === 'month') return tree;
+
+    // daily keyed MM-DD
+    const byDay = groupBy(rows, (r) => `${pad2(r.month)}-${pad2(r.day)}`);
+    tree.daily = {};
+    for (const [dKey, dRows] of Object.entries(byDay)) {
+      tree.daily[dKey] = this.reduceHours(dRows, method);
+    }
+
+    if (granularity === 'day') return tree;
+
+    // hourly keyed MM-DDThh
+    tree.hourly = {};
+    for (const r of rows) {
+      const key = `${pad2(r.month)}-${pad2(r.day)}T${pad2(r.hour)}`;
+      tree.hourly[key] = this.reduceHours([r], method);
+    }
+
+    return tree;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Domain config (fixed per domain; seeded on demand) — DEC-6
+  // ---------------------------------------------------------------------------
+
+  private async resolveDomainConfig(tenantId: string, domain: GoalDomain) {
+    const cfg = await this.repo.getOrSeedDomainConfig(tenantId, domain);
+    return { aggregationMethod: cfg.aggregationMethod as GoalAggregationMethod, unit: cfg.unit };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET — list domains with goals (RFC §3.1)
+  // ---------------------------------------------------------------------------
+
+  async list(tenantId: string, customerId: string): Promise<GoalListResult> {
+    const goals = await this.repo.listGoalsForCustomer(tenantId, customerId);
+
+    // Group years per domain.
+    const byDomain = new Map<GoalDomain, Array<{ year: number; version: number }>>();
+    for (const g of goals) {
+      const d = g.domain as GoalDomain;
+      if (!byDomain.has(d)) byDomain.set(d, []);
+      byDomain.get(d)!.push({ year: g.year, version: g.version });
+    }
+
+    // Emit a summary per domain that has any goals, with its fixed config.
+    const domains: GoalDomainSummary[] = [];
+    for (const [domain, years] of byDomain.entries()) {
+      const cfg = await this.resolveDomainConfig(tenantId, domain);
+      years.sort((a, b) => b.year - a.year);
+      domains.push({ domain, unit: cfg.unit, aggregationMethod: cfg.aggregationMethod, years });
+    }
+    domains.sort((a, b) => a.domain.localeCompare(b.domain));
+
+    return { customerId, domains };
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET — derived tree (RFC §3.2)
+  // ---------------------------------------------------------------------------
+
+  async get(
+    key: GoalKey,
+    granularity: GoalGranularity,
+    fetchHistory: boolean,
+  ): Promise<GoalGetResult> {
+    const cfg = await this.resolveDomainConfig(key.tenantId, key.domain);
+    const goal = await this.repo.findGoal(key);
+
+    // No goal yet → version 0, empty tree (RFC §3.2).
+    if (!goal) {
+      return {
+        customerId: key.customerId,
+        domain: key.domain,
+        unit: cfg.unit,
+        aggregationMethod: cfg.aggregationMethod,
+        year: key.year,
+        version: 0,
+        tree: {},
+        ...(fetchHistory ? { history: [] } : {}),
+      };
+    }
+
+    const rows = await this.repo.findHours(goal.id);
+    const tree = rows.length === 0 ? {} : this.buildTree(rows, granularity, cfg.aggregationMethod);
+
+    const result: GoalGetResult = {
+      customerId: key.customerId,
+      domain: key.domain,
+      unit: goal.unit,
+      aggregationMethod: cfg.aggregationMethod,
+      year: key.year,
+      version: goal.version,
+      tree,
+    };
+
+    if (fetchHistory) {
+      const hist = await this.repo.findHistory(goal.id, 100);
+      result.history = hist.map(mapHistoryRow);
+    }
+
+    return result;
+  }
+
+  // ---------------------------------------------------------------------------
+  // PUT — replace whole (year, domain) (RFC §3.3, DEC-5)
+  // ---------------------------------------------------------------------------
+
+  async replace(
+    key: GoalKey,
+    body: ReplaceGoalsBodyDTO,
+    actor: string | null,
+  ): Promise<GoalWriteResult> {
+    const cfg = await this.resolveDomainConfig(key.tenantId, key.domain);
+    const buckets = this.flattenReplaceBody(body, key.domain, key.year);
+
+    // The action level recorded in history = the coarsest level the operator set.
+    const actionLevel = coarsestLevel(buckets.map((b) => b.level));
+
+    const result = await this.repo.withTransaction(async (tx) => {
+      const { goal, created } = await this.openGoalForWrite(key, cfg.unit, body.expectedVersion, actor, tx);
+
+      // REPLACE: wipe every hour, then write exactly the submitted scope.
+      await this.repo.deleteHours(goal.id, {}, tx);
+
+      const hours = this.materialiseBuckets(buckets, key.year, cfg.aggregationMethod, actor);
+      const hoursWritten = await this.repo.upsertHours(goal.id, hours, tx);
+
+      const final = await this.commitVersion(goal, created, body.expectedVersion, actor, key, tx);
+
+      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+
+      return { goal: final, hoursWritten, actionLevel };
+    });
+
+    const tree = await this.readTreeAt(result.goal.id, granularityOf(actionLevel), cfg.aggregationMethod);
+    return {
+      customerId: key.customerId,
+      domain: key.domain,
+      unit: cfg.unit,
+      aggregationMethod: cfg.aggregationMethod,
+      year: key.year,
+      version: result.goal.version,
+      tree,
+      distribution: { hoursWritten: result.hoursWritten, actionLevel: result.actionLevel },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // PATCH — merge sent buckets (RFC §3.4, DEC-5)
+  // ---------------------------------------------------------------------------
+
+  async merge(
+    key: GoalKey,
+    body: MergeGoalsBodyDTO,
+    actor: string | null,
+  ): Promise<GoalWriteResult> {
+    const cfg = await this.resolveDomainConfig(key.tenantId, key.domain);
+    const buckets = this.parseMergeBuckets(body, key.domain, key.year);
+    const actionLevel = coarsestLevel(buckets.map((b) => b.level));
+
+    const result = await this.repo.withTransaction(async (tx) => {
+      const { goal, created } = await this.openGoalForWrite(key, cfg.unit, body.expectedVersion, actor, tx);
+
+      // MERGE: re-distribute only the sent buckets. For each bucket we overwrite
+      // its derived hours; operator-confirmed hours are preserved by re-applying
+      // them on top (read existing scope, keep derived=false ones unchanged).
+      const existing = await this.repo.findHours(goal.id, tx);
+      const hours = this.mergeBuckets(existing, buckets, key.year, cfg.aggregationMethod, actor);
+      const hoursWritten = await this.repo.upsertHours(goal.id, hours, tx);
+
+      const final = await this.commitVersion(goal, created, body.expectedVersion, actor, key, tx);
+
+      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+
+      return { goal: final, hoursWritten, actionLevel };
+    });
+
+    const tree = await this.readTreeAt(result.goal.id, granularityOf(actionLevel), cfg.aggregationMethod);
+    return {
+      customerId: key.customerId,
+      domain: key.domain,
+      unit: cfg.unit,
+      aggregationMethod: cfg.aggregationMethod,
+      year: key.year,
+      version: result.goal.version,
+      tree,
+      distribution: { hoursWritten: result.hoursWritten, actionLevel: result.actionLevel },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // IMPORT — stateless dryRun (DEC e)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Parses pipe/CSV `content` into buckets.
+   *   dryRun=true  → returns { preview, diagnostics, okCount, errorCount } WITHOUT
+   *                  persisting.
+   *   dryRun=false → applies via MERGE semantics and returns the same plus a log.
+   * There is NO previewToken — the same payload is re-sent with dryRun:false.
+   */
+  async importData(
+    key: GoalKey,
+    content: string,
+    dryRun: boolean,
+    expectedVersion: number | undefined,
+    actor: string | null,
+  ): Promise<ImportResult> {
+    const cfg = await this.resolveDomainConfig(key.tenantId, key.domain);
+    const { buckets, diagnostics } = this.parseImport(content, key.domain, key.year);
+    const okCount = buckets.length;
+    const errorCount = diagnostics.length;
+
+    if (dryRun) {
+      // Build a preview tree WITHOUT touching the DB: merge the parsed buckets on
+      // top of the current hours and roll up.
+      const goal = await this.repo.findGoal(key);
+      const existing = goal ? await this.repo.findHours(goal.id) : [];
+      const merged = this.mergeBuckets(existing, buckets, key.year, cfg.aggregationMethod, actor);
+      const previewRows = this.simulateRows(existing, merged);
+      const preview =
+        previewRows.length === 0 ? {} : this.buildTree(previewRows, 'month', cfg.aggregationMethod);
+      return { dryRun: true, preview, diagnostics, okCount, errorCount };
+    }
+
+    // Persist via merge semantics.
+    if (buckets.length === 0) {
+      throw new ValidationError('Import has no valid lines to apply', {
+        csv: ['every line was invalid or empty'],
+      });
+    }
+
+    const persisted = await this.repo.withTransaction(async (tx) => {
+      const { goal, created } = await this.openGoalForWrite(key, cfg.unit, expectedVersion, actor, tx);
+
+      const existing = await this.repo.findHours(goal.id, tx);
+      const hours = this.mergeBuckets(existing, buckets, key.year, cfg.aggregationMethod, actor);
+      await this.repo.upsertHours(goal.id, hours, tx);
+
+      const final = await this.commitVersion(goal, created, expectedVersion, actor, key, tx);
+      await this.appendHistoryForBuckets(goal.id, buckets, final.version, actor, tx);
+
+      const rows = await this.repo.findHours(goal.id, tx);
+      return { goal: final, rows };
+    });
+
+    const preview =
+      persisted.rows.length === 0 ? {} : this.buildTree(persisted.rows, 'month', cfg.aggregationMethod);
+    const log = buckets.map((b) => `applied ${b.level} ${b.ref} = ${b.value}`);
+
+    return {
+      dryRun: false,
+      preview,
+      diagnostics,
+      okCount,
+      errorCount,
+      version: persisted.goal.version,
+      log,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // DELETE — year or sub-bucket (RFC §3.6)
+  // ---------------------------------------------------------------------------
+
+  async remove(
+    key: GoalKey,
+    body: DeleteGoalsBodyDTO,
+    actor: string | null,
+  ): Promise<GoalDeleteResult | null> {
+    const goal = await this.repo.findGoal(key);
+    if (!goal) {
+      throw new NotFoundError(`No ${key.domain} goal for year ${key.year}`);
+    }
+
+    const bucket = body?.bucket;
+    const expectedVersion = body?.expectedVersion;
+
+    // Whole-year delete with no sub-bucket → remove parent (cascade) entirely.
+    if (!bucket) {
+      this.assertVersion(goal, expectedVersion, key);
+      // bump-guard first so an expectedVersion mismatch 409s before we delete.
+      if (expectedVersion !== undefined) {
+        const guarded = await this.repo.bumpVersion(goal.id, expectedVersion, actor);
+        if (!guarded) {
+          const cur = await this.repo.findGoalById(key.tenantId, goal.id);
+          throw new VersionConflictError(cur?.version ?? goal.version, expectedVersion, key.domain, key.year);
+        }
+      }
+      const removed = await this.repo.deleteHours(goal.id);
+      await this.repo.deleteGoal(goal.id);
+      return {
+        customerId: key.customerId,
+        domain: key.domain,
+        year: key.year,
+        deleted: { bucket: null, hoursRemoved: removed, actionLevel: 'YEAR' },
+        version: 0,
+      };
+    }
+
+    // Sub-bucket delete: remove its hours, bump version, append history.
+    const parsed = this.parseBucketRef(bucket.level, bucket.ref, key.year);
+    const scope = { month: parsed.month, day: parsed.day, hour: parsed.hour };
+
+    const result = await this.repo.withTransaction(async (tx) => {
+      this.assertVersion(goal, expectedVersion, key);
+      const hoursRemoved = await this.repo.deleteHours(goal.id, scope, tx);
+      const bumped = await this.bumpOrConflict(goal, expectedVersion, actor, key, tx);
+      await this.repo.appendHistory(
+        {
+          goalId: goal.id,
+          actor,
+          actionLevel: bucket.level,
+          bucketRef: bucket.ref,
+          oldValue: null,
+          newValue: null,
+          distributed: true,
+          hoursAffected: hoursRemoved,
+          version: bumped.version,
+        },
+        tx,
+      );
+      return { version: bumped.version, hoursRemoved };
+    });
+
+    return {
+      customerId: key.customerId,
+      domain: key.domain,
+      year: key.year,
+      deleted: { bucket: bucket.ref, hoursRemoved: result.hoursRemoved, actionLevel: bucket.level },
+      version: result.version,
+    };
+  }
+
+  // ===========================================================================
+  // Internal write helpers
+  // ===========================================================================
+
+  /**
+   * Opens (find-or-create) the parent goal for a write and applies the early
+   * optimistic guard. Reports `created` so the caller can skip the version bump
+   * on a brand-new goal — a first write lands on version 1, matching the RFC
+   * worked example (0 → 1), not 2.
+   */
+  private async openGoalForWrite(
+    key: GoalKey,
+    unit: string,
+    expected: number | undefined,
+    actor: string | null,
+    tx: GoalTx,
+  ): Promise<{ goal: ConsumptionGoalRow; created: boolean }> {
+    const existing = await this.repo.findGoal(key, tx);
+    if (existing) {
+      this.assertVersion(existing, expected, key);
+      return { goal: existing, created: false };
+    }
+    const goal = await this.repo.createGoal({ ...key, unit, createdBy: actor }, tx);
+    return { goal, created: true };
+  }
+
+  /**
+   * Settles the parent version after the hour write:
+   *   - a freshly-created goal keeps its initial version 1 (the create IS the
+   *     first change);
+   *   - an existing goal is bumped under the optimistic guard (409 on mismatch).
+   */
+  private async commitVersion(
+    goal: ConsumptionGoalRow,
+    created: boolean,
+    expected: number | undefined,
+    actor: string | null,
+    key: GoalKey,
+    tx: GoalTx,
+  ): Promise<ConsumptionGoalRow> {
+    if (created) return goal;
+    return this.bumpOrConflict(goal, expected, actor, key, tx);
+  }
+
+  /** Optimistic guard: throws VersionConflictError when expectedVersion mismatches. */
+  private assertVersion(goal: ConsumptionGoalRow, expected: number | undefined, key: GoalKey): void {
+    if (expected !== undefined && goal.version !== expected) {
+      throw new VersionConflictError(goal.version, expected, key.domain, key.year);
+    }
+  }
+
+  /**
+   * Bumps the parent version inside `tx`, mapping a guard miss to a 409. Re-reads
+   * the current version for the conflict body.
+   */
+  private async bumpOrConflict(
+    goal: ConsumptionGoalRow,
+    expected: number | undefined,
+    actor: string | null,
+    key: GoalKey,
+    tx: GoalTx,
+  ): Promise<ConsumptionGoalRow> {
+    const bumped = await this.repo.bumpVersion(goal.id, expected, actor, tx);
+    if (!bumped) {
+      const cur = await this.repo.findGoalById(key.tenantId, goal.id, tx);
+      throw new VersionConflictError(cur?.version ?? goal.version, expected, key.domain, key.year);
+    }
+    return bumped;
+  }
+
+  /** Materialises a set of disjoint buckets into hour upserts (replace path). */
+  private materialiseBuckets(
+    buckets: ValueBucket[],
+    year: number,
+    method: GoalAggregationMethod,
+    actor: string | null,
+  ): GoalHourUpsert[] {
+    // Finest-wins: a later, finer bucket overrides a coarser one for the same hour.
+    const map = new Map<string, GoalHourUpsert>();
+    const ordered = [...buckets].sort((a, b) => levelRank(a.level) - levelRank(b.level));
+    for (const b of ordered) {
+      for (const h of this.distributeBucket(b, year, method, actor)) {
+        map.set(hourKey(h.month, h.day, h.hour), h);
+      }
+    }
+    return [...map.values()];
+  }
+
+  /**
+   * Merge path: start from existing hours, then for each sent bucket re-distribute
+   * over its scope — but preserve operator-confirmed (derived=false) hours that the
+   * bucket would have touched, unless the bucket itself is HOUR-level (explicit).
+   */
+  private mergeBuckets(
+    existing: ConsumptionGoalHourRow[],
+    buckets: ValueBucket[],
+    year: number,
+    method: GoalAggregationMethod,
+    actor: string | null,
+  ): GoalHourUpsert[] {
+    const confirmed = new Set<string>();
+    for (const r of existing) {
+      if (!r.derived) confirmed.add(hourKey(r.month, r.day, r.hour));
+    }
+
+    const out = new Map<string, GoalHourUpsert>();
+    const ordered = [...buckets].sort((a, b) => levelRank(a.level) - levelRank(b.level));
+    for (const b of ordered) {
+      for (const h of this.distributeBucket(b, year, method, actor)) {
+        const k = hourKey(h.month, h.day, h.hour);
+        // Preserve operator-confirmed hours on a coarser re-distribution.
+        if (b.level !== 'HOUR' && confirmed.has(k)) continue;
+        out.set(k, h);
+      }
+    }
+    return [...out.values()];
+  }
+
+  /** Overlays the upsert set onto the existing rows to simulate a post-write state. */
+  private simulateRows(
+    existing: ConsumptionGoalHourRow[],
+    upserts: GoalHourUpsert[],
+  ): ConsumptionGoalHourRow[] {
+    const map = new Map<string, ConsumptionGoalHourRow>();
+    for (const r of existing) map.set(hourKey(r.month, r.day, r.hour), r);
+    for (const u of upserts) {
+      const k = hourKey(u.month, u.day, u.hour);
+      map.set(k, {
+        ...(map.get(k) ?? ({} as ConsumptionGoalHourRow)),
+        goalId: '',
+        month: u.month,
+        day: u.day,
+        hour: u.hour,
+        value: u.value,
+        sourceLevel: u.sourceLevel,
+        derived: u.derived,
+        updatedAt: new Date(),
+        updatedBy: u.updatedBy ?? null,
+      } as ConsumptionGoalHourRow);
+    }
+    return [...map.values()].sort(
+      (a, b) => a.month - b.month || a.day - b.day || a.hour - b.hour,
+    );
+  }
+
+  /** Re-reads the goal's hours and rolls them into a tree (post-write response). */
+  private async readTreeAt(
+    goalId: string,
+    granularity: GoalGranularity,
+    method: GoalAggregationMethod,
+  ): Promise<GoalTree> {
+    const rows = await this.repo.findHours(goalId);
+    return rows.length === 0 ? {} : this.buildTree(rows, granularity, method);
+  }
+
+  /** Appends one history row per distinct operator bucket of this change. */
+  private async appendHistoryForBuckets(
+    goalId: string,
+    buckets: ValueBucket[],
+    version: number,
+    actor: string | null,
+    tx: GoalTx,
+  ): Promise<void> {
+    for (const b of buckets) {
+      const year = Number(b.ref.slice(0, 4));
+      await this.repo.appendHistory(
+        {
+          goalId,
+          actor,
+          actionLevel: b.level,
+          bucketRef: b.ref,
+          oldValue: null,
+          newValue: formatNumeric(b.value),
+          distributed: true,
+          hoursAffected: this.hoursInScope(b.level, year, b.month, b.day),
+          version,
+        },
+        tx,
+      );
+    }
+  }
+
+  // ===========================================================================
+  // Body / CSV parsing → ValueBucket[]
+  // ===========================================================================
+
+  /** Flattens a PUT replace tree into disjoint value buckets (refs are year-aware). */
+  private flattenReplaceBody(body: ReplaceGoalsBodyDTO, domain: GoalDomain, year: number): ValueBucket[] {
+    const buckets: ValueBucket[] = [];
+
+    const pushCheck = (value: number, path: string) => {
+      if (!isValidValueForDomain(domain, value)) {
+        throw new ValidationError('Invalid goal value', {
+          [path]: [
+            domain === 'TEMPERATURE'
+              ? 'value must be a finite number'
+              : 'value must be a finite number >= 0 for energy/water domains',
+          ],
+        });
+      }
+    };
+
+    const push = (b: Omit<ValueBucket, 'ref'>) => {
+      buckets.push({ ...b, ref: bucketRefOf(b as ValueBucket, year) });
+    };
+
+    if (body.annual) {
+      pushCheck(body.annual.value, 'annual.value');
+      push({ level: 'YEAR', value: body.annual.value });
+    }
+
+    for (const [mKey, month] of Object.entries(body.monthly ?? {})) {
+      const m = Number(mKey);
+      pushCheck(month.value, `monthly.${mKey}.value`);
+      const hasDaily = month.daily && Object.keys(month.daily).length > 0;
+      // A month node contributes a MONTH bucket only when it has no finer children;
+      // otherwise the finer DAY/HOUR buckets fully describe it (finest-wins).
+      if (!hasDaily) {
+        push({ level: 'MONTH', month: m, value: month.value });
+      }
+
+      for (const [dKey, day] of Object.entries(month.daily ?? {})) {
+        const d = Number(dKey);
+        pushCheck(day.value, `monthly.${mKey}.daily.${dKey}.value`);
+        const hasHourly = day.hourly && Object.keys(day.hourly).length > 0;
+        if (!hasHourly) {
+          push({ level: 'DAY', month: m, day: d, value: day.value });
+        }
+        for (const [hKey, hour] of Object.entries(day.hourly ?? {})) {
+          const h = Number(hKey);
+          pushCheck(hour.value, `monthly.${mKey}.daily.${dKey}.hourly.${hKey}.value`);
+          push({ level: 'HOUR', month: m, day: d, hour: h, value: hour.value });
+        }
+      }
+    }
+
+    return buckets;
+  }
+
+  /** Parses PATCH merge buckets (level + ref) into value buckets. */
+  private parseMergeBuckets(body: MergeGoalsBodyDTO, domain: GoalDomain, year: number): ValueBucket[] {
+    return body.buckets.map((b, i) => {
+      if (!isValidValueForDomain(domain, b.value)) {
+        throw new ValidationError('Invalid goal value', {
+          [`buckets.${i}.value`]: [
+            domain === 'TEMPERATURE'
+              ? 'value must be a finite number'
+              : 'value must be a finite number >= 0 for energy/water domains',
+          ],
+        });
+      }
+      const parsed = this.parseBucketRef(b.level, b.ref, year);
+      return {
+        level: b.level,
+        month: parsed.month,
+        day: parsed.day,
+        hour: parsed.hour,
+        value: b.value,
+        ref: b.ref,
+      };
+    });
+  }
+
+  /**
+   * Parses a CSV/pipe import into value buckets + line diagnostics.
+   * Accepts a header line `bucket,value` (or pipe-separated). Each data line is
+   * `<bucketRef><sep><value>` where bucketRef ∈ YYYY | YYYY-MM | YYYY-MM-DD |
+   * YYYY-MM-DDThh. Finest-granularity wins on duplicate refs.
+   */
+  private parseImport(
+    content: string,
+    domain: GoalDomain,
+    year: number,
+  ): { buckets: ValueBucket[]; diagnostics: ImportDiagnostic[] } {
+    const diagnostics: ImportDiagnostic[] = [];
+    const buckets: ValueBucket[] = [];
+
+    const lines = content.split(/\r?\n/);
+    let dataStarted = false;
+
+    lines.forEach((raw, idx) => {
+      const lineNo = idx + 1;
+      const line = raw.trim();
+      if (line === '') return;
+
+      const sep = line.includes('|') ? '|' : ',';
+      const parts = line.split(sep).map((p) => p.trim());
+
+      // Skip a header row (`bucket,value`).
+      if (!dataStarted && /bucket/i.test(parts[0]) && /value/i.test(parts[1] ?? '')) {
+        dataStarted = true;
+        return;
+      }
+      dataStarted = true;
+
+      if (parts.length < 2) {
+        diagnostics.push({ line: lineNo, reason: 'expected "<bucket><sep><value>"' });
+        return;
+      }
+
+      const ref = parts[0];
+      const valueRaw = parts[1];
+      const value = Number(valueRaw);
+
+      const level = levelFromRef(ref);
+      if (!level) {
+        diagnostics.push({ line: lineNo, bucket: ref, reason: 'unrecognised bucket format' });
+        return;
+      }
+
+      if (!Number.isFinite(value)) {
+        diagnostics.push({ line: lineNo, bucket: ref, reason: 'value is not a finite number' });
+        return;
+      }
+      if (!isValidValueForDomain(domain, value)) {
+        diagnostics.push({
+          line: lineNo,
+          bucket: ref,
+          value,
+          reason:
+            domain === 'TEMPERATURE'
+              ? 'value must be finite'
+              : 'value must be >= 0 for energy/water domains',
+        });
+        return;
+      }
+
+      let parsed;
+      try {
+        parsed = this.parseBucketRef(level, ref, year);
+      } catch (e) {
+        diagnostics.push({
+          line: lineNo,
+          bucket: ref,
+          value,
+          reason: e instanceof Error ? e.message : 'invalid bucket reference',
+        });
+        return;
+      }
+
+      buckets.push({ level, month: parsed.month, day: parsed.day, hour: parsed.hour, value, ref });
+    });
+
+    return { buckets, diagnostics };
+  }
+
+  /**
+   * Parses a bucketRef into (month, day, hour) and validates it against the year
+   * (leap-year aware). Throws ValidationError on mismatch.
+   */
+  private parseBucketRef(
+    level: GoalSourceLevel,
+    ref: string,
+    year: number,
+  ): { month?: number; day?: number; hour?: number } {
+    const refYear = Number(ref.slice(0, 4));
+    if (refYear !== year) {
+      throw new ValidationError(`ref year ${refYear} does not match target year ${year}`);
+    }
+
+    if (level === 'YEAR') return {};
+
+    const month = Number(ref.slice(5, 7));
+    if (!(month >= 1 && month <= 12)) {
+      throw new ValidationError(`month must be 1..12 in "${ref}"`);
+    }
+    if (level === 'MONTH') return { month };
+
+    const day = Number(ref.slice(8, 10));
+    const maxDay = daysInMonth(year, month);
+    if (!(day >= 1 && day <= maxDay)) {
+      throw new ValidationError(`day ${day} is invalid for ${year}-${pad2(month)} (max ${maxDay})`);
+    }
+    if (level === 'DAY') return { month, day };
+
+    const hour = Number(ref.slice(11, 13));
+    if (!(hour >= 0 && hour <= 23)) {
+      throw new ValidationError(`hour must be 0..23 in "${ref}"`);
+    }
+    return { month, day, hour };
+  }
+}
+
+// =============================================================================
+// Pure helpers
+// =============================================================================
+
+function bucketRefOf(b: ValueBucket, year: number): string {
+  switch (b.level) {
+    case 'YEAR':
+      return `${year}`;
+    case 'MONTH':
+      return `${year}-${pad2(b.month!)}`;
+    case 'DAY':
+      return `${year}-${pad2(b.month!)}-${pad2(b.day!)}`;
+    case 'HOUR':
+      return `${year}-${pad2(b.month!)}-${pad2(b.day!)}T${pad2(b.hour!)}`;
+  }
+}
+
+function range(from: number, to: number): number[] {
+  const out: number[] = [];
+  for (let i = from; i <= to; i++) out.push(i);
+  return out;
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function hourKey(month: number, day: number, hour: number): string {
+  return `${month}-${day}-${hour}`;
+}
+
+function groupBy<T>(rows: T[], keyFn: (r: T) => string): Record<string, T[]> {
+  const out: Record<string, T[]> = {};
+  for (const r of rows) {
+    const k = keyFn(r);
+    (out[k] ??= []).push(r);
+  }
+  return out;
+}
+
+/** numeric column formatting — fixed precision string, trimmed of trailing zeros. */
+function formatNumeric(value: number): string {
+  // 10 dp keeps hour-split precision (e.g. 100000/744) without float noise.
+  return value.toFixed(10);
+}
+
+/** Output rounding for derived tree values (avoids 99999.99999997 artefacts). */
+function roundOut(value: number): number {
+  return Math.round((value + Number.EPSILON) * 1e6) / 1e6;
+}
+
+const LEVEL_RANK: Record<GoalSourceLevel, number> = { YEAR: 0, MONTH: 1, DAY: 2, HOUR: 3 };
+
+function levelRank(level: GoalSourceLevel): number {
+  return LEVEL_RANK[level];
+}
+
+/** The finer (deeper) of two levels; used to report a node's sourceLevel. */
+function finerLevel(a: GoalSourceLevel | undefined, b: GoalSourceLevel): GoalSourceLevel {
+  if (a === undefined) return b;
+  return levelRank(a) >= levelRank(b) ? a : b;
+}
+
+/** The coarsest (shallowest) level among a set — the history action level. */
+function coarsestLevel(levels: GoalSourceLevel[]): GoalSourceLevel {
+  let best: GoalSourceLevel = 'HOUR';
+  for (const l of levels) if (levelRank(l) < levelRank(best)) best = l;
+  return best;
+}
+
+/** Maps an action level to the read granularity used in the write response tree. */
+function granularityOf(level: GoalSourceLevel): GoalGranularity {
+  switch (level) {
+    case 'YEAR':
+      return 'year';
+    case 'MONTH':
+      return 'month';
+    case 'DAY':
+      return 'day';
+    case 'HOUR':
+      return 'hour';
+  }
+}
+
+/** Detects the level implied by a bucketRef string. */
+function levelFromRef(ref: string): GoalSourceLevel | null {
+  if (/^\d{4}$/.test(ref)) return 'YEAR';
+  if (/^\d{4}-\d{2}$/.test(ref)) return 'MONTH';
+  if (/^\d{4}-\d{2}-\d{2}$/.test(ref)) return 'DAY';
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}$/.test(ref)) return 'HOUR';
+  return null;
+}
+
+/** annual root reports no per-node sourceLevel/derived (it is the whole-year reduction). */
+function stripAggMeta(node: GoalTreeNode): GoalTreeNode {
+  return { value: node.value, method: node.method };
+}
+
+function mapHistoryRow(row: ConsumptionGoalHistoryRow): GoalHistoryEntry {
+  return {
+    actionLevel: row.actionLevel as GoalSourceLevel,
+    bucketRef: row.bucketRef,
+    oldValue: row.oldValue === null ? null : Number(row.oldValue),
+    newValue: row.newValue === null ? null : Number(row.newValue),
+    distributed: row.distributed,
+    hoursAffected: row.hoursAffected,
+    version: row.version,
+    actor: row.actor,
+    changedAt: (row.changedAt instanceof Date ? row.changedAt : new Date(row.changedAt)).toISOString(),
+  };
+}
+
+export const consumptionGoalService = new ConsumptionGoalService();


### PR DESCRIPTION
## RFC-0046 — Customer Consumption Goals (backend)

Per-customer consumption targets (ENERGY / WATER / TEMPERATURE) by domain and year, stored at an always-hourly canonical grain with coarser views derived on read. See `docs/RFC-0046-Customer-Consumption-Goals.md` and `docs/RFC-0046-Goals-API.md`.

### What's included
- **Schema + migration 0047**: four tables (`consumption_goals`, `consumption_goal_hours`, `consumption_goal_domains`, `consumption_goal_history`) + per-tenant domain seed; new `goals:read` / `goals:write` api-key scopes.
- **Contracts**: Zod request DTOs (nested-tree PUT, `buckets[]` PATCH, stateless `?dryRun` import, delete body) + response DTOs.
- **Repository + service + controller + route mount** under `/customers/:id/goals` (hybrid auth): distribute-on-write, roll-up-on-read (SUM / weighted-average), optimistic `version` with 409 `VERSION_CONFLICT`.
- **Operation-level audit + migration 0048**: history is one row per operation (`source` IMPORT/REPLACE/MERGE/DELETE/EDIT, `bucket_count`, `details`) instead of one per bucket.
- **Local test seed** (`scripts/db/seeds/rfc0046-goals-test.sql`) and **dev:debug** scripts + VS Code attach config.
- Docs reconciled with the implemented contract (main / API / schema).

### Migrations
`0047_consumption_goals.sql` + `0048_consumption_goals_history_ops.sql` — applied to local Docker; **pending prod**.

### Notes
- Whole-year DELETE cascades away the goal and its history (no audit row); only sub-bucket deletes append a DELETE entry. A global `CUSTOMER_GOALS_UPDATED` event is designed but not yet emitted.
- `npm run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
