### PR TITLE
fix(rfc-0047): reject un-parenting a type that requires a parent

### DIFF
--- a/src/services/EntityService.ts
+++ b/src/services/EntityService.ts
@@ -311,39 +311,12 @@ export class EntityService {
       this.validateMetadata(current.entityType, effective);
     }
 
-    // Re-parent guards: cycle + allowed parent type. Runs on ANY parent change,
-    // including un-parenting (-> null): a type that requires a parent (e.g.
-    // PROFILE) must not be silently turned into a root. Without this an edit that
-    // sent parentEntityId=null orphaned the node (it then had no valid parent and
-    // disappeared from the tree).
+    // Re-parent guard (cycle + allowed-parent-type, incl. un-parenting -> null).
     if (
       dto.parentEntityId !== undefined &&
       dto.parentEntityId !== current.parentEntityId
     ) {
-      if (dto.parentEntityId) {
-        // Moving under a new parent: no cycle + the parent's type must be allowed.
-        const cycles = await this.repository.wouldCreateCycle(tenantId, id, dto.parentEntityId);
-        if (cycles) {
-          throw new AppError('ENTITY_CYCLE', 'Re-parenting would create a cycle', 400);
-        }
-        const parent = await this.repository.getById(tenantId, dto.parentEntityId);
-        if (!parent) {
-          throw new NotFoundError(`Parent entity ${dto.parentEntityId} not found`);
-        }
-        const type = await this.repository.getEntityType(tenantId, current.entityType);
-        if (type) this.assertAllowedParentType(type, parent.entityType);
-      } else {
-        // Un-parenting (-> root): only allowed if the type may be a root, i.e.
-        // its allowedParentTypes is empty OR carries the '' root marker.
-        const type = await this.repository.getEntityType(tenantId, current.entityType);
-        if (type && type.allowedParentTypes.length > 0 && !type.allowedParentTypes.includes('')) {
-          throw new AppError(
-            'INVALID_PARENT_TYPE',
-            `Type ${current.entityType} requires a parent of: ${type.allowedParentTypes.join(', ')}`,
-            400,
-          );
-        }
-      }
+      await this.assertReparentAllowed(tenantId, current, dto.parentEntityId ?? null);
     }
 
     try {
@@ -513,6 +486,41 @@ export class EntityService {
   // ---------------------------------------------------------------------------
   // internal helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Validate a parent change for an existing entity: moving under a new parent
+   * checks cycle + allowed-parent-type; un-parenting (`null`) is only allowed for
+   * a root-eligible type (empty `allowedParentTypes` or the `''` root marker).
+   * Extracted from `update` to keep that method's complexity in check.
+   */
+  private async assertReparentAllowed(
+    tenantId: string,
+    current: RegistryEntity,
+    newParentId: string | null,
+  ): Promise<void> {
+    if (newParentId) {
+      const cycles = await this.repository.wouldCreateCycle(tenantId, current.id, newParentId);
+      if (cycles) {
+        throw new AppError('ENTITY_CYCLE', 'Re-parenting would create a cycle', 400);
+      }
+      const parent = await this.repository.getById(tenantId, newParentId);
+      if (!parent) {
+        throw new NotFoundError(`Parent entity ${newParentId} not found`);
+      }
+      const type = await this.repository.getEntityType(tenantId, current.entityType);
+      if (type) this.assertAllowedParentType(type, parent.entityType);
+      return;
+    }
+    // Un-parenting (-> root): only allowed if the type may be a root.
+    const type = await this.repository.getEntityType(tenantId, current.entityType);
+    if (type && type.allowedParentTypes.length > 0 && !type.allowedParentTypes.includes('')) {
+      throw new AppError(
+        'INVALID_PARENT_TYPE',
+        `Type ${current.entityType} requires a parent of: ${type.allowedParentTypes.join(', ')}`,
+        400,
+      );
+    }
+  }
 
   /** Throw 400 INVALID_PARENT_TYPE if `parentType` is not allowed for `type`. */
   private assertAllowedParentType(type: EntityType, parentType: string): void {

--- a/src/services/EntityService.ts
+++ b/src/services/EntityService.ts
@@ -311,22 +311,39 @@ export class EntityService {
       this.validateMetadata(current.entityType, effective);
     }
 
-    // Re-parent guards: cycle + allowed parent type.
+    // Re-parent guards: cycle + allowed parent type. Runs on ANY parent change,
+    // including un-parenting (-> null): a type that requires a parent (e.g.
+    // PROFILE) must not be silently turned into a root. Without this an edit that
+    // sent parentEntityId=null orphaned the node (it then had no valid parent and
+    // disappeared from the tree).
     if (
       dto.parentEntityId !== undefined &&
-      dto.parentEntityId !== current.parentEntityId &&
-      dto.parentEntityId
+      dto.parentEntityId !== current.parentEntityId
     ) {
-      const cycles = await this.repository.wouldCreateCycle(tenantId, id, dto.parentEntityId);
-      if (cycles) {
-        throw new AppError('ENTITY_CYCLE', 'Re-parenting would create a cycle', 400);
+      if (dto.parentEntityId) {
+        // Moving under a new parent: no cycle + the parent's type must be allowed.
+        const cycles = await this.repository.wouldCreateCycle(tenantId, id, dto.parentEntityId);
+        if (cycles) {
+          throw new AppError('ENTITY_CYCLE', 'Re-parenting would create a cycle', 400);
+        }
+        const parent = await this.repository.getById(tenantId, dto.parentEntityId);
+        if (!parent) {
+          throw new NotFoundError(`Parent entity ${dto.parentEntityId} not found`);
+        }
+        const type = await this.repository.getEntityType(tenantId, current.entityType);
+        if (type) this.assertAllowedParentType(type, parent.entityType);
+      } else {
+        // Un-parenting (-> root): only allowed if the type may be a root, i.e.
+        // its allowedParentTypes is empty OR carries the '' root marker.
+        const type = await this.repository.getEntityType(tenantId, current.entityType);
+        if (type && type.allowedParentTypes.length > 0 && !type.allowedParentTypes.includes('')) {
+          throw new AppError(
+            'INVALID_PARENT_TYPE',
+            `Type ${current.entityType} requires a parent of: ${type.allowedParentTypes.join(', ')}`,
+            400,
+          );
+        }
       }
-      const parent = await this.repository.getById(tenantId, dto.parentEntityId);
-      if (!parent) {
-        throw new NotFoundError(`Parent entity ${dto.parentEntityId} not found`);
-      }
-      const type = await this.repository.getEntityType(tenantId, current.entityType);
-      if (type) this.assertAllowedParentType(type, parent.entityType);
     }
 
     try {

--- a/tests/unit/services/EntityService.crud.test.ts
+++ b/tests/unit/services/EntityService.crud.test.ts
@@ -289,6 +289,29 @@ describe('EntityService — CRUD + entity_types', () => {
       );
     });
 
+    it('rejects INVALID_PARENT_TYPE when un-parenting a type that requires a parent', async () => {
+      // The orphaning bug: an edit that sent parentEntityId=null turned a PROFILE
+      // (allowedParentTypes ['GROUP']) into a root with no valid parent.
+      repo.getById.mockResolvedValue(makeEntity({ entityType: 'PROFILE', parentEntityId: 'g-1' }));
+      repo.getEntityType.mockResolvedValue(makeType({ entityType: 'PROFILE', allowedParentTypes: ['GROUP'] }));
+
+      await expectErrorWithCode(
+        service.update(tenantId, 'ent-1', { parentEntityId: null }, userId, { isAdmin: true }),
+        'INVALID_PARENT_TYPE',
+      );
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('allows un-parenting a root-eligible type (GROUP carries the "" root marker)', async () => {
+      repo.getById.mockResolvedValue(makeEntity({ entityType: 'GROUP', parentEntityId: 'g-0' }));
+      repo.getEntityType.mockResolvedValue(makeType({ entityType: 'GROUP', allowedParentTypes: ['GROUP', ''] }));
+      repo.update.mockResolvedValue(makeEntity({ entityType: 'GROUP', parentEntityId: null, version: 2 }));
+
+      const got = await service.update(tenantId, 'ent-1', { parentEntityId: null }, userId, { isAdmin: true });
+      expect(got.version).toBe(2);
+      expect(repo.update).toHaveBeenCalled();
+    });
+
     it('updates and validates merged metadata for free-form types', async () => {
       repo.getById.mockResolvedValue(makeEntity({ metadata: { a: 1 } }));
       repo.update.mockResolvedValue(makeEntity({ metadata: { a: 1, b: 2 }, version: 2 }));


### PR DESCRIPTION
Backend half of the entity-orphaning fix. `EntityService.update` now validates parent-type on **un-parenting** (parentEntityId -> null), not only when a new parent is set — so a PROFILE can no longer be silently turned into a root (which orphaned it and removed it from the tree). Rejected with `INVALID_PARENT_TYPE` unless the type is root-eligible (empty allowedParentTypes or the `''` root marker). +2 unit tests; 35/35 green. Pairs with gh-myio/gcdr-frontend fix/entity-form-parent-race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)