### PR TITLE
test(bundle): campinas_g0_nova bundle-fetch scripts

### DIFF
--- a/tests/get_bundles/campinas_g0_nova/fetch-simple-bundle-central.sh
+++ b/tests/get_bundles/campinas_g0_nova/fetch-simple-bundle-central.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Fetch simplified alarm bundle — Campinas G0 Nova / Central principal.
+# Customer: Campinas G0 Nova (3a3edfe0-b3e0-11ef-9d80-0f53bf3519bb)
+# Central:  401230d1-e7d6-46dd-9bb1-059387683303
+
+#API_URL="http://localhost:3015"
+API_URL="https://gcdr-api.a.myio-bas.com"
+CUSTOMER_ID="3a3edfe0-b3e0-11ef-9d80-0f53bf3519bb"
+API_KEY="gcdr_75068349fe19e144b5743c7fd42eb48c5268f6640ca24c2f910f822ff0641393"
+CENTRAL_ID="401230d1-e7d6-46dd-9bb1-059387683303"
+OUTPUT_FILE="$(dirname "$0")/simple_bundle_central.json"
+
+echo "Fetching simplified bundle — Campinas G0 Nova Central..."
+echo "Customer: $CUSTOMER_ID"
+echo "Central:  $CENTRAL_ID"
+echo ""
+
+curl -s "${API_URL}/api/v1/customers/${CUSTOMER_ID}/alarm-rules/bundle/simple" \
+  -H "X-API-Key: ${API_KEY}" \
+  -H "X-Central-Id: ${CENTRAL_ID}" \
+  -H "Accept: application/json" \
+  -o "$OUTPUT_FILE"
+
+if [ $? -eq 0 ] && [ -s "$OUTPUT_FILE" ]; then
+  echo "Bundle saved to: $OUTPUT_FILE"
+  echo ""
+  echo "=== meta ==="
+  jq '.data.meta' "$OUTPUT_FILE" 2>/dev/null || head -30 "$OUTPUT_FILE"
+  echo ""
+  echo "=== deviceIndex keys ==="
+  jq '.data.deviceIndex | keys' "$OUTPUT_FILE" 2>/dev/null
+  echo ""
+  echo "=== rules keys ==="
+  jq '.data.rules | keys' "$OUTPUT_FILE" 2>/dev/null
+else
+  echo "Error fetching bundle"
+  exit 1
+fi

--- a/tests/get_bundles/campinas_g0_nova/fetch-simple-bundle.sh
+++ b/tests/get_bundles/campinas_g0_nova/fetch-simple-bundle.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Fetch simplified alarm bundle for Campinas G0 Nova and save to JSON file.
+# Central: sem filtro — retorna todos os devices do customer.
+# Para filtrar por central use: fetch-simple-bundle-central.sh
+
+#API_URL="http://localhost:3015"
+API_URL="https://gcdr-api.a.myio-bas.com"
+CUSTOMER_ID="3a3edfe0-b3e0-11ef-9d80-0f53bf3519bb"
+API_KEY="gcdr_75068349fe19e144b5743c7fd42eb48c5268f6640ca24c2f910f822ff0641393"
+CENTRAL_ID=""
+OUTPUT_FILE="$(dirname "$0")/simple_bundle_output.json"
+
+echo "Fetching simplified bundle — Campinas G0 Nova..."
+echo "Customer: $CUSTOMER_ID"
+echo "Central:  ${CENTRAL_ID:-<todos>}"
+echo ""
+
+curl -s "${API_URL}/api/v1/customers/${CUSTOMER_ID}/alarm-rules/bundle/simple" \
+  -H "X-API-Key: ${API_KEY}" \
+  ${CENTRAL_ID:+-H "X-Central-Id: ${CENTRAL_ID}"} \
+  -H "Accept: application/json" \
+  -o "$OUTPUT_FILE"
+
+if [ $? -eq 0 ] && [ -s "$OUTPUT_FILE" ]; then
+  echo "Bundle saved to: $OUTPUT_FILE"
+  echo ""
+  echo "=== meta ==="
+  jq '.data.meta' "$OUTPUT_FILE" 2>/dev/null || head -30 "$OUTPUT_FILE"
+  echo ""
+  echo "=== deviceIndex keys ==="
+  jq '.data.deviceIndex | keys' "$OUTPUT_FILE" 2>/dev/null
+  echo ""
+  echo "=== rules keys ==="
+  jq '.data.rules | keys' "$OUTPUT_FILE" 2>/dev/null
+else
+  echo "Error fetching bundle"
+  exit 1
+fi

--- a/tests/get_bundles/campinas_g0_nova/fetch-with-version-check.sh
+++ b/tests/get_bundles/campinas_g0_nova/fetch-with-version-check.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Fetch simplified alarm bundle for Campinas G0 Nova with version check (304 cache validation)
+# Step 1: Fetch without version → get full bundle + capture version
+# Step 2: Fetch again with captured version → expect 304 (no changes)
+# Step 3: Fetch with fake version → expect 200 (full bundle)
+
+#API_URL="http://localhost:3015"
+API_URL="https://gcdr-api.a.myio-bas.com"
+CUSTOMER_ID="3a3edfe0-b3e0-11ef-9d80-0f53bf3519bb"
+API_KEY="gcdr_75068349fe19e144b5743c7fd42eb48c5268f6640ca24c2f910f822ff0641393"
+# Central Campinas G0 Nova: 401230d1-e7d6-46dd-9bb1-059387683303
+# Deixe vazio para todos os devices do customer
+CENTRAL_ID="401230d1-e7d6-46dd-9bb1-059387683303"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+ENDPOINT="${API_URL}/api/v1/customers/${CUSTOMER_ID}/alarm-rules/bundle/simple"
+LOG_FILE="$(dirname "$0")/version-check-$(date +%Y%m%d_%H%M%S).log"
+
+exec > >(tee >(sed 's/\x1b\[[0-9;]*m//g' >> "$LOG_FILE")) 2>&1
+
+echo "=== Bundle Version Check — Campinas G0 Nova ==="
+echo "Log: $LOG_FILE"
+echo "Customer: $CUSTOMER_ID"
+echo "Central:  ${CENTRAL_ID:-<todos>}"
+echo ""
+
+# ─────────────────────────────────────────────────────────────
+# Step 1: First request — no version header
+# ─────────────────────────────────────────────────────────────
+echo "1. First request (sem X-Version-Id)..."
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  "$ENDPOINT" \
+  -H "X-API-Key: ${API_KEY}" \
+  ${CENTRAL_ID:+-H "X-Central-Id: ${CENTRAL_ID}"} \
+  -H "Accept: application/json")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "   Status: $HTTP_CODE"
+
+if [ "$HTTP_CODE" = "200" ]; then
+  if command -v jq &>/dev/null; then
+    VERSION_ID=$(echo "$BODY" | jq -r '.data.meta.version // .data.version // "N/A"')
+    RULES_COUNT=$(echo "$BODY" | jq '(.data.meta.rulesCount // .data.rules | length // 0)')
+    DEVICES_COUNT=$(echo "$BODY" | jq '(.data.meta.devicesCount // (.data.deviceIndex | length // 0))')
+    DEVICE_KEYS=$(echo "$BODY" | jq -r '.data.deviceIndex | keys | join(", ")' 2>/dev/null)
+    SKIP_VERSION=$(echo "$BODY" | jq -r '.data.meta.skipVersionCheck // false')
+  else
+    VERSION_ID=$(echo "$BODY" | grep -o '"version": *"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+    RULES_COUNT="?"
+    DEVICES_COUNT="?"
+    DEVICE_KEYS="(install jq for details)"
+    SKIP_VERSION="?"
+  fi
+
+  echo -e "   ${GREEN}Bundle recebido OK${NC}"
+  echo "   Version:          $VERSION_ID"
+  echo "   Rules:            $RULES_COUNT"
+  echo "   Devices:          $DEVICES_COUNT"
+  echo "   skipVersionCheck: $SKIP_VERSION"
+  echo "   Device keys:      $DEVICE_KEYS"
+  echo "   Payload size:     $(echo "$BODY" | wc -c) bytes"
+  echo ""
+  echo "   --- meta completo ---"
+  echo "$BODY" | jq '.data.meta'
+  echo "   ---------------------"
+else
+  echo -e "   ${RED}Erro na requisição${NC}"
+  echo "   Response: $BODY"
+  exit 1
+fi
+
+echo ""
+
+# ─────────────────────────────────────────────────────────────
+# Step 2: Second request — with captured version (expect 304)
+# ─────────────────────────────────────────────────────────────
+echo "2. Second request (X-Version-Id: $VERSION_ID)..."
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  "$ENDPOINT" \
+  -H "X-API-Key: ${API_KEY}" \
+  ${CENTRAL_ID:+-H "X-Central-Id: ${CENTRAL_ID}"} \
+  -H "X-Version-Id: ${VERSION_ID}" \
+  -H "Accept: application/json")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "   Status: $HTTP_CODE"
+
+if [ "$HTTP_CODE" = "304" ]; then
+  echo -e "   ${GREEN}✓ Cache HIT — 304 correto (bundle não mudou)${NC}"
+elif [ "$HTTP_CODE" = "200" ]; then
+  echo -e "   ${YELLOW}⚠ Cache MISS — bundle mudou (ou VERSION_ID vazio — instale jq)${NC}"
+  if command -v jq &>/dev/null; then
+    NEW_VERSION=$(echo "$BODY" | jq -r '.data.meta.version // empty')
+    echo "   Nova version: $NEW_VERSION"
+  fi
+else
+  echo -e "   ${RED}Erro inesperado${NC}"
+  echo "   Response: $BODY"
+fi
+
+echo ""
+
+# ─────────────────────────────────────────────────────────────
+# Step 3: Third request — with wrong version (expect 200)
+# ─────────────────────────────────────────────────────────────
+echo "3. Third request (X-Version-Id: v0-fake)..."
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  "$ENDPOINT" \
+  -H "X-API-Key: ${API_KEY}" \
+  ${CENTRAL_ID:+-H "X-Central-Id: ${CENTRAL_ID}"} \
+  -H "X-Version-Id: v0-fake" \
+  -H "Accept: application/json")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+echo "   Status: $HTTP_CODE"
+
+if [ "$HTTP_CODE" = "200" ]; then
+  echo -e "   ${GREEN}✓ Bundle completo retornado (version mismatch esperado)${NC}"
+  echo "   Payload size: $(echo "$BODY" | wc -c) bytes"
+elif [ "$HTTP_CODE" = "304" ]; then
+  echo -e "   ${RED}✗ 304 inesperado com version falsa${NC}"
+fi
+
+echo ""
+echo "=== Done ==="
+echo "Log salvo em: $LOG_FILE"


### PR DESCRIPTION
Mirror of `tests/get_bundles/montserrat_test` for Campinas G0 Nova (customer `3a3edfe0-…`, central `401230d1-…`). Three scripts (simple / central / version-check). Validated against prod (7 devices, 1 rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)