### PR TITLE
feat(rfc-0053): Single Dashboard aggregation endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5145,6 +5145,43 @@ components:
         actor:         { type: string, format: uuid, nullable: true }
         changedAt:     { type: string, format: date-time }
 
+    SingleDashboard:
+      type: object
+      description: |
+        RFC-0053 aggregated snapshot. `groups[].devices[].telemetry` and
+        `goals[].monthConsumption` stay null while the ingestion read-through
+        is pending; consumers must treat every telemetry-derived field as
+        optional. See docs/rfcs/RFC-0053-One-Store-Dashboard.md for the full
+        contract.
+      additionalProperties: true
+      properties:
+        customerId:   { type: string, format: uuid }
+        customerName: { type: string }
+        groups:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+            properties:
+              key:         { type: string, enum: [energy, water, temperature, tanks] }
+              deviceCount: { type: integer }
+              online:      { type: integer }
+              offline:     { type: integer }
+              telemetry:
+                type: object
+                properties:
+                  available: { type: boolean }
+                  reason:    { type: string }
+        unassigned: { type: array, items: { type: object, additionalProperties: true } }
+        health:
+          type: object
+          properties:
+            score:      { type: integer, minimum: 0, maximum: 100 }
+            components: { type: array, items: { type: object, additionalProperties: true } }
+        goals:    { type: array, items: { type: object, additionalProperties: true } }
+        insights: { type: array, items: { type: object, additionalProperties: true } }
+        errors:   { type: array, items: { type: object, properties: { section: { type: string }, message: { type: string } } } }
+
     GoalTree:
       type: object
       description: |
@@ -6459,6 +6496,44 @@ paths:
           content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } }
         '409':
           description: VERSION_CONFLICT
+          content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } }
+
+  /customers/{customerId}/single-dashboard:
+    parameters:
+      - $ref: '#/components/parameters/TenantId'
+      - name: customerId
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+    get:
+      tags: [Single Dashboard]
+      summary: Single Dashboard aggregated snapshot (RFC-0053)
+      description: |
+        Read-only composition for the single-customer operational dashboard (Single Dashboard):
+        device groups (energy | water | temperature | tanks, mapped by
+        profile/type with per-customer overrides in
+        `customer.settings.singleDashboard.groupOverrides`), an explainable
+        health score, goal progress (RFC-0046 targets + RFC-0052
+        `adjustedValue`), heuristic insights and per-section soft errors.
+        Telemetry fields degrade to `available:false` while the ingestion
+        read-through contract is pending (RFC-0053 Q1). Scope `customers:read`.
+      operationId: getSingleDashboard
+      parameters:
+        - { name: from, in: query, required: false, schema: { type: string, format: date }, description: 'Range start (ISO date/datetime); forwarded to the telemetry read-through.' }
+        - { name: to, in: query, required: false, schema: { type: string, format: date } }
+      responses:
+        '200':
+          description: Aggregated store snapshot
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - type: object
+                    properties:
+                      data: { $ref: '#/components/schemas/SingleDashboard' }
+        '404':
+          description: Customer not found
           content: { application/json: { schema: { $ref: '#/components/schemas/ErrorResponse' } } }
 
   /customers/{customerId}/goals/import:

--- a/docs/rfcs/RFC-0053-One-Store-Dashboard.md
+++ b/docs/rfcs/RFC-0053-One-Store-Dashboard.md
@@ -1,0 +1,302 @@
+# RFC-0053 — Single Dashboard: single-customer operational dashboard
+
+> **Naming update (2026-07-13):** the feature shipped as **"Single Dashboard"**
+> (menu label), route `/single-customer(/:customerId)`, backend endpoint
+> `GET /customers/:customerId/single-dashboard`, config block
+> `customer.settings.singleDashboard`. Occurrences of "One-Store Dash" /
+> "store-dash" below are the original working name.
+
+- **Feature Name:** `single-dashboard` (né `one-store-dashboard`)
+- **Start Date:** 2026-07-10
+- **RFC PR:** (leave this empty until the PR is created)
+- **Tracking Issue:** (leave this empty until an issue is created)
+- **Status:** Draft
+- **Authors:** Rodrigo Lago (rplago@gmail.com), MYIO Platform Team
+- **Domain:** New frontend module + backend aggregation endpoint
+- **Depends on:** [RFC-0046](./RFC-0046-Customer-Consumption-Goals.md) (goals), [RFC-0052](./RFC-0052-Goal-Margin-Adjustment.md) (goal margin / adjusted targets), RFC-0016 (ThingsBoard entity mapping), device taxonomy (customer Taxonomia)
+- **Product spec:** [RFC-0053-OneStoreDashboard.draft.md](./RFC-0053-OneStoreDashboard.draft.md) — the product/UX draft this RFC engineers; kept as the canonical wireframe/copy reference
+- **Migration:** next free runner slot (`0060_store_dashboard.sql` as of authoring; only needed for Phase 2 — see §4.6)
+- **Stakeholders:** Store Operations (restaurants, supermarkets, gyms, pharmacies), Platform Backend, Platform Frontend, Data/AI
+
+---
+
+## 1. Summary
+
+Add **One-Store Dash**: a new top-level menu in the GCDR UI that opens a
+single-store operational dashboard — "is my store operating efficiently right
+now?" — for restaurant/supermarket/gym-style customers (one `customer` = one
+store). The screen composes four operational groups (**Energy ⚡ purple, Water
+💧 blue, Temperature 🌡️ green, Reservoirs/Tanks 🛢️ cyan**), a right sidebar
+(health score, active alerts, top consumers, goal progress), and an
+**Insights** feed of rule-based recommendations.
+
+GCDR is a registry — it stores *which* devices exist, not their live values.
+The dashboard therefore ships with a new backend **aggregation endpoint**
+(`GET /customers/:customerId/store-dashboard`) that joins GCDR registry data
+(devices, taxonomy, goals + margin, rules) with live telemetry read through
+the existing ingestion references (`device.ingestionId` /
+`device.externalId`), server-side and cached.
+
+The MVP target from the product spec: a store manager answers in ≤30 seconds —
+*Is everything working? Where am I spending money? Is there any risk? Can I
+save money? What requires attention now?*
+
+## 2. Motivation
+
+The existing GCDR "Painel"/"Dashboard" pages are **platform-wide registry
+views** (105 customers, 3657 devices) tuned for the MYIO operations team.
+Shopping-center dashboards focus on distribution across tenants. A single
+store needs the opposite: one customer, all its devices, grouped by utility,
+with cost/goal/alert context on one screen.
+
+Everything required already half-exists in the platform — devices with
+profiles (CHILLER, FANCOIL, HIDR., 3F_MEDIDOR…), consumption goals with a
+margin overlay (RFC-0046/0052), an alarm rules engine, and per-device
+ingestion identities. What is missing is (a) a **composition layer** that
+turns those into one store-shaped payload and (b) a **UI surface** designed
+for the store manager persona rather than the platform operator.
+
+### Non-goals (MVP)
+
+- Multi-store benchmarking, carbon footprint, digital twin, occupancy/weather
+  correlation — listed as Future Possibilities (§8), mirroring draft §11.
+- ML-based insights. MVP insights are **deterministic heuristics** (§4.5);
+  the AI layer plugs in later behind the same contract.
+- Writing telemetry or commanding equipment. Read-only.
+- The draft's **Reports / Performance / Settings** sub-pages ship as stubs
+  (route + empty state) — content is follow-up work.
+
+## 3. Guide-Level Explanation
+
+### 3.1 Navigation
+
+A new sidebar item **"One-Store Dash"** (icon: `Store` / 🏪) between
+"Dashboard" and "Clientes":
+
+- `/store-dash` — store picker: customers the user can read, searchable
+  (skipped automatically when the user's scope resolves to exactly one store).
+- `/store-dash/:customerId` — the dashboard itself, with an internal
+  left sub-nav per draft §4: **Dashboard**, **Insights**, **Alerts**,
+  Reports*, Performance*, Settings* (*stub in MVP).
+
+### 3.2 Screen anatomy (draft §3/§5/§6/§9)
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ Header: store selector · date range · notifications · user│
+├──────────────┬───────────────────────────────┬────────────┤
+│ Sub-nav      │ 4 operational groups          │ Insights   │
+│ (Dashboard,  │  ⚡ Energy   💧 Water          │ sidebar:   │
+│  Insights,   │  🌡️ Temp    🛢️ Tanks          │ health 92  │
+│  Alerts, …)  │  summary card + device cards  │ alerts     │
+│              │                               │ top consum.│
+│              │                               │ goal 78%   │
+└──────────────┴───────────────────────────────┴────────────┘
+```
+
+- **Date range**: Today · Yesterday · Last 7 · Last 30 · Current month ·
+  Custom (reuses `LibDateRangePicker`).
+- **Group summary cards** (draft §6): current demand/flow, daily & monthly
+  consumption, cost estimate, sensors online / out-of-range, fill level and
+  autonomy for tanks.
+- **Device cards**: one per device in the group — live value, today/monthly
+  figures, sparkline, alarm badge; actions (real-time graph, history,
+  reports, alarms, config, maintenance) deep-link to the existing
+  DeviceDetail tabs rather than re-implementing them.
+- **Right sidebar** (draft §9): Operational Health Score (0–100), active
+  alerts, top consumers, **monthly goal progress** — consumption vs. the
+  RFC-0052 **`adjustedValue`** (the margin-adjusted target), insight counter.
+- **Visual language**: existing MYIO dashboard look (white, rounded cards,
+  purple `#6C3CF0` accent, soft shadows, sparklines, dense layout).
+
+### 3.3 How devices land in groups
+
+Grouping is **registry-driven, not hard-coded**: each device maps to a group
+via its profile/taxonomy (e.g. `3F_MEDIDOR → energy`, `HIDR. → water`,
+`TERMOMETRO → temperature`, `CAIXA_DAGUA/BOMBA → tanks`). A per-customer
+override lives in `customer.settings.storeDashboard` (§4.4) so a store can
+re-bucket devices without a deploy. Devices with no mapping appear in an
+"Unassigned" drawer so nothing is silently hidden.
+
+## 4. Reference-Level Explanation
+
+### 4.1 Backend — aggregation endpoint
+
+```
+GET /api/v1/customers/:customerId/store-dashboard?from=&to=&sections=
+```
+
+- **Auth**: standard hybrid (`goals:read`-style read scope — final scope name
+  in §7); rate-limited like the goals router.
+- **Composes** (per section, so the UI can lazy-load):
+  - `groups[]` — energy/water/temperature/tanks: summary + device cards
+    (registry fields from GCDR; live/period values from the telemetry
+    read-through, §4.2);
+  - `health` — score + component breakdown (§4.3);
+  - `alerts[]` — active alarms for the store's devices (source: alarm
+    orchestrator API — Unresolved Q2);
+  - `goals` — per domain: consumption-to-date vs. `value` and
+    `adjustedValue` from RFC-0046/0052 (`GET /goals` internals reused);
+  - `insights[]` — §4.5.
+- **New controller** `store-dashboard.controller.ts` + service
+  `StoreDashboardService` (composition only; no new tables in Phase 1).
+
+### 4.2 Telemetry read-through
+
+GCDR stores identities, not values. `StoreDashboardService` resolves each
+device's `ingestionId` (fallback `externalId`/tbId per RFC-0016) and queries
+the **MYIO Ingestion API** server-side for: instantaneous value, period
+totals, and a small sparkline series. Rules:
+
+- **Batched + cached** — one upstream query per (customer, range) with a
+  short TTL (30–60 s) keyed in-memory; the dashboard never fans out N
+  browser→upstream calls, and GCDR credentials to the ingestion API stay
+  server-side.
+- **Degrade, don't fail** — devices whose telemetry is unavailable render
+  their registry card with a "no data" state; the endpoint returns partial
+  data with per-section `errors[]` instead of a 5xx.
+- Cost estimates = consumption × tariff from `customer.settings.storeDashboard.tariffs`
+  (flat per-kWh/m³ in MVP; utility-bill modeling is future work).
+
+### 4.3 Operational Health Score
+
+Deterministic and explainable (0–100), recomputed per request:
+
+```
+score = 100
+  − 15 × critical_active_alarms   (cap 45)
+  −  5 × warning_active_alarms    (cap 20)
+  − 10 × (offline_sensors / total_sensors) × 10   (cap 20)
+  −  5 × out_of_range_temperature_sensors          (cap 15)
+```
+
+The response carries the breakdown (`components[]`) so the UI can explain
+the number — no magic scores.
+
+### 4.4 Configuration (no new tables in Phase 1)
+
+`customer.settings.storeDashboard` (JSONB already exists on `customers`):
+
+```jsonc
+{
+  "enabled": true,
+  "groupOverrides": { "<deviceId>": "tanks" },
+  "tariffs": { "ENERGY": 0.92, "WATER": 11.5 },      // R$/kWh, R$/m³
+  "tankCapacities": { "<deviceId>": 20000 }           // litres, for autonomy calc
+}
+```
+
+The Settings sub-page (stub in MVP) will edit this block later; until then it
+is set via the existing customer edit/API.
+
+### 4.5 Insights (MVP heuristics)
+
+Computed on demand inside `StoreDashboardService` from the same telemetry
+window — **no storage, no ML** in Phase 1:
+
+| key | rule (draft §7 examples) |
+|---|---|
+| `night-flow-leak` | water flow > 0 sustained during configured closed hours ("continuous flow 02:00–05:00") |
+| `baseline-deviation` | group/device consumption > X% above the trailing 4-week same-weekday baseline ("HVAC 18% above baseline") |
+| `temp-out-of-range` | temperature sensor outside its rule-engine min/max for > N minutes |
+| `runtime-increase` | compressor/pump duty-cycle up > X% vs. baseline ("Freezer #2 runtime +35%") |
+| `refill-frequency` | tank refill cycles/day up > X% vs. baseline |
+| `goal-pace` | month-to-date consumption pace exceeds the **adjusted** (RFC-0052) monthly goal |
+
+Each insight: `{ key, severity, title, description, deviceId?, groupKey,
+estimatedImpact?, detectedAt }`. The contract is the extension point — the
+future AI generator emits the same shape.
+
+### 4.6 Phase 2 (separate migration `0060_store_dashboard.sql`, out of MVP)
+
+Persisted insights (dismiss/acknowledge/history), insight audit, and a
+scheduled evaluator (so insights exist before the first page load and can
+notify). Deliberately deferred: MVP proves the read model first.
+
+### 4.7 Frontend
+
+| Piece | Detail |
+|---|---|
+| Sidebar | new item `One-Store Dash` → `/store-dash` (i18n `nav.storeDash`) |
+| Routes | `/store-dash` (picker) · `/store-dash/:customerId` (+ `?view=insights\|alerts\|…` for the sub-nav) |
+| Pages | `src/pages/store-dash/StoreDashPicker.tsx`, `StoreDashboard.tsx`, `StoreInsights.tsx`, `StoreAlerts.tsx` + stubs |
+| Components | `GroupSummaryCard`, `DeviceMiniCard` (sparkline via existing chart lib), `HealthScoreGauge`, `GoalProgressBar` (raw vs. adjusted), `InsightCard` |
+| Service/hook | `storeDashboardService.get(customerId, params)` + `useStoreDashboard` (per-section loading, 30 s polling for the live column) |
+| Deep links | device card actions → `/devices/:id` tabs (graphs/alarms/reports/config) — no duplication |
+| i18n | `store-dash` namespace, pt-BR + en |
+
+### 4.8 Files to Modify
+
+**Backend (`gcdr.git`)**
+- `src/controllers/store-dashboard.controller.ts` (new) + mount in `app.ts`
+- `src/services/StoreDashboardService.ts` (new; composition, health, insights)
+- `src/services/IngestionTelemetryClient.ts` (new; batched, cached read-through)
+- `src/dto/request/StoreDashboardDTO.ts` (new)
+- `docs/openapi.yaml` — new path + schemas (`StoreDashboard*`)
+- `tests/unit/services/StoreDashboardService.test.ts` (health score, grouping, insights heuristics — telemetry client mocked)
+
+**Frontend (`gcdr-frontend.git`)**
+- `src/components/layout/Sidebar.tsx` — menu item
+- `src/App.tsx`/router — routes
+- `src/pages/store-dash/**` (new module), `src/services/api/storeDashboardService.ts`, `src/hooks/useStoreDashboard.ts`
+- `src/i18n/locales/{pt-BR,en}/store-dash.json` (new namespace)
+
+**Documentation**
+- `docs/api/STORE-DASHBOARD-API-GUIDE.md` (consumer guide, same format as GOALS/ANNOTATIONS guides)
+- `docs/BACKLOG-RFCS.md` — register RFC-0053
+- Draft spec stays as the UX annex (link in header)
+
+## 5. Drawbacks
+
+- GCDR takes on a **read-through dependency** on the ingestion API; a slow
+  upstream degrades the dashboard (mitigated by cache + partial responses,
+  §4.2) and couples deploys operationally.
+- Heuristic insights can be noisy until thresholds are tuned per vertical;
+  a bad first impression undermines the differentiating feature.
+- One more dashboard surface to keep visually in sync with the design system.
+
+## 6. Rationale and Alternatives
+
+- **Server-side aggregation vs. browser composition** — the browser could call
+  N existing endpoints + ingestion directly, but that leaks ingestion
+  credentials, multiplies latency by device count, and makes the health/insight
+  logic unimplementable consistently (mobile, reports reuse). One composed
+  endpoint is the only shape that keeps secrets server-side.
+- **`customer.settings` JSONB vs. new config tables** — MVP config is small,
+  per-customer and low-churn; JSONB avoids a migration until the Settings page
+  ships (Phase 2 revisits).
+- **Heuristics-first vs. AI-first insights** — deterministic rules are
+  debuggable, explainable to the store manager, and define the contract the
+  AI generator later fills. Shipping "AI insights" without a baseline would be
+  unverifiable.
+- **New module vs. extending `/dashboard`** — the platform dashboard serves a
+  different persona (MYIO ops, cross-customer); mixing both would compromise
+  each. The draft explicitly calls for a distinct surface.
+
+## 7. Unresolved Questions
+
+1. **Ingestion API contract** — exact endpoints/auth for instantaneous +
+   period + series queries by `ingestionId` (needs confirmation with the
+   ingestion team before `IngestionTelemetryClient` is coded); ThingsBoard
+   fallback for devices without `ingestionId`?
+2. **Active alerts source** — alarm orchestrator REST
+   (`docs/alarm-orsquestrador-backend`) vs. GCDR-local rule state: which is
+   authoritative for "active now", and does the orchestrator expose a
+   per-customer active-alarm listing with the needed latency?
+3. **RBAC** — new scope (`store-dash:read`) or ride on existing read scopes?
+   Store-manager users likely need a role that sees ONLY this module.
+4. **Closed-hours schedule** for the leak heuristic — per-customer setting
+   (where in `settings`?) or derived from an operating-hours registry that
+   does not exist yet?
+5. Which **verticals** pilot the MVP (draft lists restaurant examples —
+   Steak House Prime) and therefore which device-profile→group mappings must
+   exist on day one?
+
+## 8. Future Possibilities
+
+Draft §11, unchanged in intent: carbon footprint, utility-billing prediction,
+occupancy & weather correlation, multi-store benchmarking, digital-twin mode,
+equipment health score, AI assistant integration. Plus, from this design:
+persisted/acknowledgeable insights with notification fan-out (Phase 2, §4.6),
+tariff modeling beyond flat rates, and reuse of `StoreDashboardService` as the
+data source for scheduled PDF/email reports.

--- a/docs/rfcs/RFC-0053-OneStoreDashboard.draft.md
+++ b/docs/rfcs/RFC-0053-OneStoreDashboard.draft.md
@@ -1,0 +1,415 @@
+MYIO Store Dashboard MVP Specification
+Version 1.0
+Document Type: Product Requirement + UI/UX Specification
+Language: English
+1. Overview
+
+The purpose of this dashboard is to provide a single-store operational view for restaurants, supermarkets, gyms, pharmacies, hospitals, retail stores, and similar environments.
+
+Unlike shopping center dashboards, where the objective is to understand consumption distribution across tenants and infrastructure, this dashboard focuses on:
+
+Operational health
+Utility consumption
+Equipment performance
+Predictive insights
+Cost optimization
+
+The platform must answer a simple question:
+
+"Is my store operating efficiently right now?"
+
+2. Design Philosophy
+
+The design language should remain visually aligned with the existing MYIO Shopping Center dashboard:
+
+White background
+Rounded cards
+Purple as primary accent color (#6C3CF0)
+Soft shadows
+Small sparkline charts
+Light gray separators
+Dense information layout
+Operational control room feeling
+
+Visual inspiration:
+
+Tesla Energy
+Google Nest
+Datadog Infrastructure
+Apple Home
+Stripe Dashboard
+3. Layout Structure
+┌───────────────────────────────────────────────────────────┐
+│ Header                                                    │
+├──────────────┬───────────────────────────────┬────────────┤
+│ Left Menu    │ Main Operational Area         │ Insights   │
+│              │                               │ Sidebar    │
+│              │                               │            │
+└──────────────┴───────────────────────────────┴────────────┘
+4. Left Navigation Menu
+Fixed Menu Items
+Dashboard
+
+Main operational overview.
+
+Icon:
+
+🏠
+Insights
+
+AI generated recommendations and opportunities.
+
+Icon:
+
+✨
+
+Examples:
+
+HVAC consuming 18% above expected baseline.
+Water leak suspected during closed hours.
+Freezer operating outside recommended range.
+Energy cost can be reduced by changing startup sequence.
+Alerts
+
+Operational alarms.
+
+Icon:
+
+🚨
+
+Examples:
+
+Freezer temperature high.
+Tank level low.
+Excessive water consumption.
+Sensor communication failure.
+Reports
+
+Historical reports and exports.
+
+Icon:
+
+📊
+Performance
+
+KPIs and benchmarking.
+
+Icon:
+
+📈
+Settings
+
+Store configuration.
+
+Icon:
+
+⚙️
+5. Header Area
+Components
+Store selector
+
+Example:
+
+Steak House Prime
+Store 001 · Leblon · RJ
+Date Range Selector
+
+Examples:
+
+Today
+Yesterday
+Last 7 Days
+Last 30 Days
+Current Month
+Custom Range
+Notification Center
+
+Badge counter.
+
+User Avatar
+6. Main Dashboard Area
+
+The center of the dashboard contains four major operational groups.
+
+Group 1 — Energy
+
+Color:
+
+Purple
+
+Icon:
+
+⚡
+
+Purpose:
+
+Electrical consumption and distribution.
+
+Summary Card
+
+Displays:
+
+Current demand
+Daily consumption
+Monthly consumption
+Peak demand
+Cost estimate
+Equipment Cards Examples
+Main Panel
+
+Fields:
+
+Current Power
+Consumption Today
+Status
+Alarm Count
+Kitchen Circuit
+
+Fields:
+
+Current Load
+Consumption Today
+Percentage of total
+HVAC
+
+Fields:
+
+Current Demand
+Runtime
+Consumption
+Lighting
+
+Fields:
+
+Current Consumption
+Estimated Cost
+Refrigeration
+
+Fields:
+
+Compressor status
+Consumption
+Group 2 — Water
+
+Color:
+
+Blue
+
+Icon:
+
+💧
+
+Purpose:
+
+Water monitoring.
+
+Summary Card
+
+Displays:
+
+Current flow
+Daily consumption
+Monthly consumption
+Estimated cost
+Device Cards Examples
+Main Meter
+Kitchen Water
+Restrooms
+Irrigation
+Cleaning Area
+
+Each card displays:
+
+Flow rate
+Daily volume
+Monthly volume
+Alarm status
+Group 3 — Temperature
+
+Color:
+
+Green
+
+Icon:
+
+🌡️
+
+Purpose:
+
+Environmental and equipment temperatures.
+
+Summary Card
+
+Displays:
+
+Average temperature
+Number of sensors online
+Out-of-range sensors
+Device Cards Examples
+Dining Room
+Kitchen
+Freezer
+Cold Chamber
+Wine Cellar
+HVAC Supply Air
+
+Each card displays:
+
+Current temperature
+Min/Max range
+Trend
+Alarm state
+Group 4 — Reservoirs and Water Tanks
+
+Color:
+
+Cyan
+
+Icon:
+
+🛢️
+
+Purpose:
+
+Water storage management.
+
+Summary Card
+
+Displays:
+
+Average fill level
+Estimated autonomy
+Pumps online
+Device Cards Examples
+Upper Tank
+Lower Tank
+Kitchen Tank
+Fire Reserve Tank
+Pressure System
+
+Fields:
+
+Current level
+Capacity
+Percentage
+Estimated remaining hours
+Pump state
+7. Insights Module
+
+This is the feature that creates differentiation.
+
+The menu item should exist independently.
+
+Insight Types
+Energy Optimization
+
+Example:
+
+HVAC startup can be delayed by 20 minutes and save 8%.
+
+Water Leak Detection
+
+Example:
+
+Continuous flow detected between 02:00 and 05:00.
+
+Refrigeration Efficiency
+
+Example:
+
+Freezer #2 compressor runtime increased by 35%.
+
+Tank Management
+
+Example:
+
+Upper tank refill cycle frequency increased by 28%.
+
+Predictive Maintenance
+
+Example:
+
+HVAC compressor vibration pattern indicates possible maintenance requirement within 30 days.
+
+Operational Recommendations
+
+Example:
+
+Kitchen equipment startup sequence could reduce peak demand charges.
+
+8. Insights Page Layout
+┌──────────────────────────────┐
+│ Savings Opportunities        │
+├──────────────────────────────┤
+│ Predictive Maintenance        │
+├──────────────────────────────┤
+│ Consumption Anomalies         │
+├──────────────────────────────┤
+│ Benchmark Comparison          │
+└──────────────────────────────┘
+9. Right Sidebar
+Operational Health Score
+
+Example:
+
+92/100
+Active Alerts
+
+Examples:
+
+Freezer High Temperature
+Low Water Level
+Top Consumers
+
+Examples:
+
+HVAC
+Kitchen Circuit
+Refrigeration
+Monthly Goal Progress
+
+Example:
+
+Energy Goal:
+78%
+AI Recommendation Counter
+
+Example:
+
+5 recommendations available
+10. Card Actions
+
+Every device card supports:
+
+Real Time Graph
+Historical Graph
+Reports
+Alarms
+Configuration
+Maintenance History
+
+Icons:
+
+📈
+📋
+🚨
+⚙️
+🔧
+11. Future Features
+Carbon footprint tracking
+Utility billing prediction
+Occupancy correlation
+Weather correlation
+Multi-store benchmarking
+Digital Twin Mode
+Equipment health score
+AI assistant integration
+12. MVP Goal
+
+The MVP should make a store manager able to answer within 30 seconds:
+
+Is everything working?
+Where am I spending money?
+Is there any risk?
+Can I save money?
+What requires attention now?

--- a/src/app.ts
+++ b/src/app.ts
@@ -270,13 +270,16 @@ apiV1Router.get('/customers/:customerId/themes', authMiddleware, themesListByCus
 // RFC-0024: User notification contacts (nested — must come before general /users router)
 apiV1Router.use('/users/:userId/contacts', authMiddleware, userContactsController);
 
+// Scope required by hybridAuthByMethod for mutating customer-scoped routes.
+const SCOPE_CUSTOMERS_WRITE = 'customers:write';
+
 // RFC-0024: Customer dispatch channels (nested — must come before general /customers router)
 // hybridAuth: supports JWT + API Key (alarm-orchestrator M2M)
-apiV1Router.use('/customers/:customerId/channels', hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'), customerChannelsController);
+apiV1Router.use('/customers/:customerId/channels', hybridAuthByMethod(PERM_CUSTOMERS_READ, SCOPE_CUSTOMERS_WRITE), customerChannelsController);
 
 // RFC-0033: Customer integration sync state (nested — must come before general /customers router)
 // hybridAuth: GET requires customers:read; POST/PATCH/DELETE require customers:write.
-apiV1Router.use('/customers/:customerId/integrations', hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'), customerIntegrationsController);
+apiV1Router.use('/customers/:customerId/integrations', hybridAuthByMethod(PERM_CUSTOMERS_READ, SCOPE_CUSTOMERS_WRITE), customerIntegrationsController);
 
 // RFC-0046: Customer consumption goals (nested — must come before general /customers router)
 // hybridAuth: GET requires goals:read; PUT/PATCH/POST/DELETE require goals:write.
@@ -309,13 +312,13 @@ apiV1Router.use(
 // Read-only composition of devices/goals/health/insights for the store dashboard.
 apiV1Router.use(
   '/customers/:customerId/single-dashboard',
-  hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'),
+  hybridAuthByMethod(PERM_CUSTOMERS_READ, SCOPE_CUSTOMERS_WRITE),
   singleDashboardController,
 );
 
 // Customers (general router - must come after specific nested routes)
 // hybridAuth: supports JWT + API Key for ThingsBoard integration (RFC-0016)
-apiV1Router.use('/customers', hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'), customersController);
+apiV1Router.use('/customers', hybridAuthByMethod(PERM_CUSTOMERS_READ, SCOPE_CUSTOMERS_WRITE), customersController);
 
 // Devices (hybridAuth for ThingsBoard integration)
 apiV1Router.use('/devices', hybridAuthByMethod('devices:read', 'devices:write'), devicesController);
@@ -415,7 +418,7 @@ apiV1Router.use('/partners', authMiddleware, partnersController);
 
 // RFC-0024: Group dispatch matrix (nested — must come before general /groups router)
 // hybridAuth: supports JWT + API Key (alarm-orchestrator M2M)
-apiV1Router.use('/groups/:groupId/dispatch', hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'), groupDispatchController);
+apiV1Router.use('/groups/:groupId/dispatch', hybridAuthByMethod(PERM_CUSTOMERS_READ, SCOPE_CUSTOMERS_WRITE), groupDispatchController);
 
 // RFC-0024: Group channel targets (nested — must come before general /groups router)
 apiV1Router.use('/groups/:groupId/channels', authMiddleware, groupChannelsController);

--- a/src/app.ts
+++ b/src/app.ts
@@ -97,6 +97,7 @@ import {
 } from './controllers';
 
 import { simulatorAdminController } from './controllers/admin/simulator-admin.controller';
+import { singleDashboardController } from './controllers/single-dashboard.controller';
 import { userAdminController } from './controllers/admin/user-admin.controller';
 
 import { centralAuthMiddleware } from './middleware/centralAuth';
@@ -302,6 +303,14 @@ apiV1Router.use(
   goalsRateLimiter,
   hybridAuthByMethod('goals:read', 'goals:write'),
   consumptionGoalsController,
+);
+
+// RFC-0053: One-Store Dash aggregation (nested — must come before general /customers router).
+// Read-only composition of devices/goals/health/insights for the store dashboard.
+apiV1Router.use(
+  '/customers/:customerId/single-dashboard',
+  hybridAuthByMethod(PERM_CUSTOMERS_READ, 'customers:write'),
+  singleDashboardController,
 );
 
 // Customers (general router - must come after specific nested routes)

--- a/src/controllers/admin/db-admin.controller.ts
+++ b/src/controllers/admin/db-admin.controller.ts
@@ -6,7 +6,6 @@
 // =============================================================================
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { db, executeRawScript } from '../../infrastructure/database/drizzle/db';
@@ -34,8 +33,6 @@ const router = Router();
 // =============================================================================
 
 const SEEDS_DIR = path.join(process.cwd(), 'scripts', 'db', 'seeds');
-const DB_USER = process.env.DB_USER || 'postgres';
-const DB_NAME = process.env.DB_NAME || 'db_gcdr';
 
 // In-memory log storage
 const executionLogs: Array<{
@@ -49,31 +46,36 @@ const executionLogs: Array<{
  * Extract meaningful PostgreSQL error from Drizzle error object.
  * Drizzle wraps errors and includes the full query in message, making it unreadable.
  */
-function extractPgError(error: any): string {
+function extractPgError(error: unknown): string {
+  const err = (error ?? {}) as {
+    cause?: { message?: string };
+    detail?: string;
+    column?: string;
+    constraint?: string;
+    message?: string;
+  };
+
   // Try to get the underlying PostgreSQL error details
-  if (error.cause) {
+  if (err.cause?.message) {
     // Drizzle often wraps the real error in cause
-    const cause = error.cause;
-    if (cause.message) {
-      return cause.message;
-    }
+    return err.cause.message;
   }
 
   // Check for PostgreSQL-specific error properties
-  if (error.detail) {
-    return `${error.message?.split('\n')[0] || 'Error'}: ${error.detail}`;
+  if (err.detail) {
+    return `${err.message?.split('\n')[0] || 'Error'}: ${err.detail}`;
   }
 
   // Check for constraint/column info
-  if (error.column || error.constraint) {
+  if (err.column || err.constraint) {
     const parts = [];
-    if (error.column) parts.push(`column: ${error.column}`);
-    if (error.constraint) parts.push(`constraint: ${error.constraint}`);
-    return `${error.message?.split('\n')[0] || 'Error'} (${parts.join(', ')})`;
+    if (err.column) parts.push(`column: ${err.column}`);
+    if (err.constraint) parts.push(`constraint: ${err.constraint}`);
+    return `${err.message?.split('\n')[0] || 'Error'} (${parts.join(', ')})`;
   }
 
   // If message starts with "Failed query:", try to extract the actual error
-  const msg = error.message || String(error);
+  const msg = err.message || String(error);
   if (msg.includes('Failed query:')) {
     // The actual PostgreSQL error is usually at the end or in a separate property
     // Try to find common PostgreSQL error patterns
@@ -156,7 +158,7 @@ router.get('/api/stats', async (req: Request, res: Response) => {
     for (const table of tables) {
       try {
         const result = await db.execute(sql`SELECT COUNT(*)::int as count FROM ${sql.identifier(table)}`);
-        const count = Array.isArray(result) && result[0] ? (result[0] as any).count : 0;
+        const count = Array.isArray(result) && result[0] ? (result[0] as { count: number }).count : 0;
         tableCounts.push({ table_name: table, count });
       } catch {
         tableCounts.push({ table_name: table, count: 0 });
@@ -172,7 +174,7 @@ router.get('/api/stats', async (req: Request, res: Response) => {
         GROUP BY status
         ORDER BY status
       `);
-      usersByStatus = Array.isArray(result) ? result as any : [];
+      usersByStatus = Array.isArray(result) ? (result as unknown as Array<{ status: string; count: number }>) : [];
     } catch {
       // Table might not exist
     }
@@ -186,7 +188,7 @@ router.get('/api/stats', async (req: Request, res: Response) => {
         GROUP BY type
         ORDER BY type
       `);
-      customersByType = Array.isArray(result) ? result as any : [];
+      customersByType = Array.isArray(result) ? (result as unknown as Array<{ type: string; count: number }>) : [];
     } catch {
       // Table might not exist
     }
@@ -200,7 +202,7 @@ router.get('/api/stats', async (req: Request, res: Response) => {
         GROUP BY status
         ORDER BY status
       `);
-      devicesByStatus = Array.isArray(result) ? result as any : [];
+      devicesByStatus = Array.isArray(result) ? (result as unknown as Array<{ status: string; count: number }>) : [];
     } catch {
       // Table might not exist
     }
@@ -212,8 +214,8 @@ router.get('/api/stats', async (req: Request, res: Response) => {
       devicesByStatus,
       timestamp: new Date().toISOString(),
     });
-  } catch (error: any) {
-    res.status(500).json({ error: error.message });
+  } catch (error) {
+    res.status(500).json({ error: extractPgError(error) });
   }
 });
 
@@ -236,8 +238,8 @@ router.get('/api/scripts', (req: Request, res: Response) => {
         };
       });
     res.json({ scripts: files });
-  } catch (error: any) {
-    res.status(500).json({ error: error.message });
+  } catch (error) {
+    res.status(500).json({ error: extractPgError(error) });
   }
 });
 
@@ -268,7 +270,7 @@ router.post('/api/scripts/:name/run', async (req: Request, res: Response) => {
       duration,
       output: 'Script executed successfully',
     });
-  } catch (error: any) {
+  } catch (error) {
     const duration = Date.now() - startTime;
     const errorMsg = extractPgError(error);
     addLog('error', `${name} - Failed (${duration}ms)`, errorMsg);
@@ -307,7 +309,7 @@ router.post('/api/seed-all', async (req: Request, res: Response) => {
         const duration = Date.now() - scriptStart;
         addLog('success', `${file} - Done (${duration}ms)`);
         results.push({ script: file, success: true, duration });
-      } catch (error: any) {
+      } catch (error) {
         const duration = Date.now() - scriptStart;
         const errorMsg = extractPgError(error);
         addLog('error', `${file} - Failed (${duration}ms)`, errorMsg);
@@ -328,7 +330,7 @@ router.post('/api/seed-all', async (req: Request, res: Response) => {
       failCount,
       results,
     });
-  } catch (error: any) {
+  } catch (error) {
     addLog('error', 'Seed failed', extractPgError(error));
     res.status(500).json({ error: extractPgError(error) });
   }
@@ -350,7 +352,7 @@ router.post('/api/clear', async (req: Request, res: Response) => {
     addLog('success', `Data cleared (${duration}ms)`);
 
     res.json({ success: true, duration, output: 'Data cleared successfully' });
-  } catch (error: any) {
+  } catch (error) {
     const duration = Date.now() - startTime;
     addLog('error', `Clear failed (${duration}ms)`, extractPgError(error));
     res.status(500).json({ success: false, error: extractPgError(error) });
@@ -373,7 +375,7 @@ router.post('/api/verify', async (req: Request, res: Response) => {
     addLog('success', `Verification complete (${duration}ms)`);
 
     res.json({ success: true, duration, output: JSON.stringify(result, null, 2) });
-  } catch (error: any) {
+  } catch (error) {
     const duration = Date.now() - startTime;
     addLog('error', `Verification failed (${duration}ms)`, extractPgError(error));
     res.status(500).json({ success: false, error: extractPgError(error) });
@@ -431,7 +433,7 @@ router.post('/api/query', async (req: Request, res: Response) => {
       rows,
       columns: rows.length > 0 ? Object.keys(rows[0]) : [],
     });
-  } catch (error: any) {
+  } catch (error) {
     const duration = Date.now() - startTime;
     addLog('error', `Query failed (${duration}ms)`, extractPgError(error));
     res.status(500).json({
@@ -632,7 +634,8 @@ function sqlLit(val: unknown, colType?: { dataType: string; udtName: string }): 
         ? 'NULL'
         : `"${String(e).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`))
       .join(',');
-    return `'${`{${elems}}`.replace(/'/g, "''")}'::${cast}`;
+    const arrayBody = `{${elems}}`.replace(/'/g, "''");
+    return `'${arrayBody}'::${cast}`;
   }
   if (typeof val === 'object') {
     return `'${JSON.stringify(val).replace(/'/g, "''")}'::jsonb`;
@@ -670,6 +673,41 @@ const CUSTOMER_EXPORT_TABLES: string[] = [
   'annotations', 'annotation_responses',
 ];
 
+/** One exportable table: a WHERE (or full custom query) joined up to the
+ * customer footprint, with optional ordering/limit/note and columns to strip. */
+interface ExportSpec {
+  table: string; where: string; order?: string; limit?: number; note?: string;
+  query?: string; strip?: string[];
+}
+
+/** Emit the INSERTs for one spec into `lines`. Tables absent from this DB are
+ * skipped via the to_regclass guard (safe against schemas where a recent RFC
+ * table is not deployed yet). */
+async function appendSpecInserts(spec: ExportSpec, lines: string[]): Promise<void> {
+  const guard = await db.execute(sql.raw(`SELECT to_regclass('public.${spec.table}') IS NOT NULL AS present`));
+  const present = Array.isArray(guard) && guard.length > 0 && (guard[0] as { present?: boolean }).present === true;
+  if (!present) return;
+
+  let q = spec.query ?? `SELECT * FROM ${spec.table} WHERE ${spec.where}`;
+  if (!spec.query) {
+    if (spec.order) q += ` ORDER BY ${spec.order}`;
+    if (spec.limit) q += ` LIMIT ${spec.limit}`;
+  }
+  const rows = await db.execute(sql.raw(q));
+  const arr = Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+  if (arr.length === 0) return;
+
+  lines.push(`  -- ----- ${spec.table} (${arr.length}) -----`);
+  if (spec.note) lines.push(`  -- NOTE: ${spec.note}`);
+  for (const row of arr) {
+    const clean = spec.strip
+      ? Object.fromEntries(Object.entries(row).filter(([k]) => !spec.strip!.includes(k)))
+      : row;
+    lines.push(`  ${buildInsert(spec.table, clean)}`);
+  }
+  lines.push('');
+}
+
 /** Generate a SQL seed script for a specific customer (and optional descendants) */
 async function generateSeedExport(
   customerId: string,
@@ -704,132 +742,28 @@ async function generateSeedExport(
       )
       SELECT id FROM descendants
     `);
-    customerIds = (Array.isArray(descRows) ? descRows : []).map((r: any) => r.id as string);
+    customerIds = (Array.isArray(descRows) ? (descRows as unknown as Array<{ id: string }>) : []).map((r) => r.id);
   }
 
   const idList = customerIds.map(id => `'${id}'`).join(', ');
+  const idIn = `(${idList})`;
 
-  // ── 2. CUSTOMERS ─────────────────────────────────────────────────────────
-  if (tables.includes('customers')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM customers WHERE id IN (${idList}) ORDER BY depth, name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- customers (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('customers', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 3. ASSETS ─────────────────────────────────────────────────────────────
-  if (tables.includes('assets')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM assets WHERE customer_id IN (${idList}) ORDER BY depth, name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- assets (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('assets', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 4. DEVICES ────────────────────────────────────────────────────────────
-  if (tables.includes('devices')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM devices WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- devices (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('devices', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 5. CENTRALS ───────────────────────────────────────────────────────────
-  if (tables.includes('centrals')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM centrals WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- centrals (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('centrals', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 6. RULES ──────────────────────────────────────────────────────────────
-  if (tables.includes('rules')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM rules WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- rules (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('rules', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 7. CUSTOMER API KEYS ──────────────────────────────────────────────────
-  if (tables.includes('customer_api_keys')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM customer_api_keys WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- customer_api_keys (${rows.length}) -----`);
-      lines.push(`  -- NOTE: key_hash values are hashed — keys are NOT recoverable from this export`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('customer_api_keys', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 8. GROUPS ─────────────────────────────────────────────────────────────
-  if (tables.includes('groups')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM groups WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- groups (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('groups', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 9. LOOK AND FEELS (themes) ────────────────────────────────────────────
-  if (tables.includes('look_and_feels')) {
-    const rows = await db.execute(sql.raw(`SELECT * FROM look_and_feels WHERE customer_id IN (${idList}) ORDER BY name`));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- look_and_feels (${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('look_and_feels', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 10. ALARM BUNDLE VERSIONS (last 10 per customer) ─────────────────────
-  if (tables.includes('alarm_bundle_versions')) {
-    const rows = await db.execute(sql.raw(
-      `SELECT * FROM alarm_bundle_versions WHERE customer_id IN (${idList})
-       ORDER BY created_at DESC LIMIT 50`
-    ));
-    if (Array.isArray(rows) && rows.length > 0) {
-      lines.push(`  -- ----- alarm_bundle_versions (last ${rows.length}) -----`);
-      for (const row of rows as Record<string, unknown>[]) {
-        lines.push(`  ${buildInsert('alarm_bundle_versions', row)}`);
-      }
-      lines.push('');
-    }
-  }
-
-  // ── 11+. Evolved customer-scoped tables (declarative, FK-ordered) ─────────
+  // ── 2. Whole footprint (declarative, FK-ordered — parents before children).
   // Each spec is exported only if (a) requested in `tables` and (b) the table
   // exists in this DB (to_regclass guard → safe against schemas where a recent
   // RFC table is not deployed yet). Indirect relations join up to the customer.
-  const idIn = `(${idList})`;
-  const extraSpecs: Array<{
-    table: string; where: string; order?: string; limit?: number; note?: string;
-    query?: string; strip?: string[];
-  }> = [
+  const specs: ExportSpec[] = [
+    { table: 'customers',                    where: `id IN ${idIn}`, order: 'depth, name' },
+    { table: 'assets',                       where: `customer_id IN ${idIn}`, order: 'depth, name' },
+    { table: 'devices',                      where: `customer_id IN ${idIn}`, order: 'name' },
+    { table: 'centrals',                     where: `customer_id IN ${idIn}`, order: 'name' },
+    { table: 'rules',                        where: `customer_id IN ${idIn}`, order: 'name' },
+    { table: 'customer_api_keys',            where: `customer_id IN ${idIn}`, order: 'name',
+      note: 'key_hash values are hashed — keys are NOT recoverable from this export' },
+    { table: 'groups',                       where: `customer_id IN ${idIn}`, order: 'name' },
+    { table: 'look_and_feels',               where: `customer_id IN ${idIn}`, order: 'name' },
+    { table: 'alarm_bundle_versions',        where: `customer_id IN ${idIn}`, order: 'created_at DESC', limit: 50,
+      note: 'most recent bundle versions only' },
     { table: 'maintenance_groups',           where: `customer_id IN ${idIn}` },
     { table: 'group_channels',               where: `group_id IN (SELECT id FROM groups WHERE customer_id IN ${idIn})` },
     { table: 'group_dispatch_configs',       where: `group_id IN (SELECT id FROM groups WHERE customer_id IN ${idIn})` },
@@ -861,30 +795,9 @@ async function generateSeedExport(
     { table: 'annotation_responses',         where: `annotation_id IN (SELECT id FROM annotations WHERE customer_id IN ${idIn})` },
   ];
 
-  for (const spec of extraSpecs) {
+  for (const spec of specs) {
     if (!tables.includes(spec.table)) continue;
-    const guard = await db.execute(sql.raw(`SELECT to_regclass('public.${spec.table}') IS NOT NULL AS present`));
-    const present = Array.isArray(guard) && guard.length > 0 && (guard[0] as { present?: boolean }).present === true;
-    if (!present) continue;
-
-    let q = spec.query ?? `SELECT * FROM ${spec.table} WHERE ${spec.where}`;
-    if (!spec.query) {
-      if (spec.order) q += ` ORDER BY ${spec.order}`;
-      if (spec.limit) q += ` LIMIT ${spec.limit}`;
-    }
-    const rows = await db.execute(sql.raw(q));
-    const arr = Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
-    if (arr.length === 0) continue;
-
-    lines.push(`  -- ----- ${spec.table} (${arr.length}) -----`);
-    if (spec.note) lines.push(`  -- NOTE: ${spec.note}`);
-    for (const row of arr) {
-      const clean = spec.strip
-        ? Object.fromEntries(Object.entries(row).filter(([k]) => !spec.strip!.includes(k)))
-        : row;
-      lines.push(`  ${buildInsert(spec.table, clean)}`);
-    }
-    lines.push('');
+    await appendSpecInserts(spec, lines);
   }
 
   lines.push('END $$;');
@@ -904,8 +817,8 @@ router.get('/api/seed-export/customers', async (req: Request, res: Response) => 
       LIMIT 500
     `);
     res.json({ customers: Array.isArray(rows) ? rows : [] });
-  } catch (error: any) {
-    res.status(500).json({ error: error.message });
+  } catch (error) {
+    res.status(500).json({ error: extractPgError(error) });
   }
 });
 
@@ -931,7 +844,7 @@ router.post('/api/seed-export', async (req: Request, res: Response) => {
     // Get customer name for filename
     const nameRows = await db.execute(sql`SELECT name FROM customers WHERE id = ${customerId}`);
     const customerName = Array.isArray(nameRows) && nameRows[0]
-      ? String((nameRows[0] as any).name).toLowerCase().replace(/[^a-z0-9]/g, '-')
+      ? String((nameRows[0] as { name: unknown }).name).toLowerCase().replace(/[^a-z0-9]/g, '-')
       : customerId.substring(0, 8);
 
     const filename = `seed-export-${customerName}-${new Date().toISOString().slice(0, 10)}.sql`;
@@ -941,7 +854,7 @@ router.post('/api/seed-export', async (req: Request, res: Response) => {
     res.send(sqlContent);
 
     addLog('success', `Seed export generated: ${filename} (${(sqlContent.length / 1024).toFixed(1)} KB)`);
-  } catch (error: any) {
+  } catch (error) {
     addLog('error', `Seed export failed: ${extractPgError(error)}`);
     res.status(500).json({ error: extractPgError(error) });
   }

--- a/src/controllers/admin/db-admin.controller.ts
+++ b/src/controllers/admin/db-admin.controller.ts
@@ -5,12 +5,27 @@
 // Access: http://localhost:3015/admin/db
 // =============================================================================
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { db } from '../../infrastructure/database/drizzle/db';
+import { db, executeRawScript } from '../../infrastructure/database/drizzle/db';
 import { sql } from 'drizzle-orm';
+
+/**
+ * Normalizes a postgres.js unsafe() result for the console UI: a single
+ * statement yields its row array; a multi-statement script yields an array of
+ * per-statement results — display the LAST non-empty one (matches the mental
+ * model of "the final SELECT of my script").
+ */
+function normalizeScriptResult(result: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(result)) return [];
+  if (result.length > 0 && Array.isArray(result[0])) {
+    const nonEmpty = (result as unknown[][]).filter((r) => Array.isArray(r) && r.length > 0);
+    return (nonEmpty.length > 0 ? nonEmpty[nonEmpty.length - 1] : []) as Record<string, unknown>[];
+  }
+  return result as Record<string, unknown>[];
+}
 
 const router = Router();
 
@@ -111,7 +126,7 @@ const ADMIN_PASSWORD = process.env.DB_ADMIN_PASSWORD || 'myio2026';
 // Middleware: Password Verification for API routes
 // =============================================================================
 
-function verifyPasswordMiddleware(req: Request, res: Response, next: Function) {
+function verifyPasswordMiddleware(req: Request, res: Response, next: NextFunction) {
   const authHeader = req.headers['x-admin-password'];
   if (authHeader !== ADMIN_PASSWORD) {
     return res.status(401).json({ error: 'Unauthorized. Invalid admin password.' });
@@ -242,7 +257,7 @@ router.post('/api/scripts/:name/run', async (req: Request, res: Response) => {
     const sqlContent = fs.readFileSync(filepath, 'utf-8');
 
     // Execute SQL directly using database connection
-    await db.execute(sql.raw(sqlContent));
+    await executeRawScript(sqlContent);
 
     const duration = Date.now() - startTime;
     addLog('success', `${name} - Done (${duration}ms)`);
@@ -287,7 +302,7 @@ router.post('/api/seed-all', async (req: Request, res: Response) => {
         const sqlContent = fs.readFileSync(filepath, 'utf-8');
 
         // Execute SQL directly using database connection
-        await db.execute(sql.raw(sqlContent));
+        await executeRawScript(sqlContent);
 
         const duration = Date.now() - scriptStart;
         addLog('success', `${file} - Done (${duration}ms)`);
@@ -329,7 +344,7 @@ router.post('/api/clear', async (req: Request, res: Response) => {
     const sqlContent = fs.readFileSync(filepath, 'utf-8');
 
     // Execute SQL directly using database connection
-    await db.execute(sql.raw(sqlContent));
+    await executeRawScript(sqlContent);
 
     const duration = Date.now() - startTime;
     addLog('success', `Data cleared (${duration}ms)`);
@@ -352,7 +367,7 @@ router.post('/api/verify', async (req: Request, res: Response) => {
     const sqlContent = fs.readFileSync(filepath, 'utf-8');
 
     // Execute SQL directly using database connection
-    const result = await db.execute(sql.raw(sqlContent));
+    const result = await executeRawScript(sqlContent);
 
     const duration = Date.now() - startTime;
     addLog('success', `Verification complete (${duration}ms)`);
@@ -386,8 +401,10 @@ router.post('/api/query', async (req: Request, res: Response) => {
   }
 
   // Security: block write operations unless explicitly allowed
-  const upperQuery = query.toUpperCase().trim();
-  const isWriteOperation = /^(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE)\b/.test(upperQuery);
+  // Scans the WHOLE script with word boundaries — the previous ^-anchored
+  // check let any script starting with a comment or BEGIN bypass the gate.
+  const upperQuery = query.toUpperCase();
+  const isWriteOperation = /\b(INSERT|UPDATE|DELETE|DROP|TRUNCATE|ALTER|CREATE|GRANT|REVOKE)\b/.test(upperQuery);
 
   if (isWriteOperation && !allowWrite) {
     return res.status(403).json({
@@ -401,17 +418,18 @@ router.post('/api/query', async (req: Request, res: Response) => {
   const startTime = Date.now();
 
   try {
-    const result = await db.execute(sql.raw(query));
+    const result = await executeRawScript(query);
+    const rows = normalizeScriptResult(result);
     const duration = Date.now() - startTime;
 
-    addLog('success', `Query executed (${duration}ms, ${Array.isArray(result) ? result.length : 0} rows)`);
+    addLog('success', `Query executed (${duration}ms, ${rows.length} rows)`);
 
     res.json({
       success: true,
       duration,
-      rowCount: Array.isArray(result) ? result.length : 0,
-      rows: result,
-      columns: Array.isArray(result) && result.length > 0 ? Object.keys(result[0]) : [],
+      rowCount: rows.length,
+      rows,
+      columns: rows.length > 0 ? Object.keys(rows[0]) : [],
     });
   } catch (error: any) {
     const duration = Date.now() - startTime;

--- a/src/controllers/single-dashboard.controller.ts
+++ b/src/controllers/single-dashboard.controller.ts
@@ -1,0 +1,44 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { singleDashboardService } from '../services/SingleDashboardService';
+import { sendSuccess } from '../middleware';
+import { ValidationError } from '../shared/errors/AppError';
+
+// =============================================================================
+// RFC-0053 — One-Store Dash (controller)
+//
+// GET /customers/:customerId/single-dashboard?from=&to=
+// One composed, read-only snapshot for the single-store operational dashboard:
+// device groups (energy/water/temperature/tanks), health score, goal progress
+// (RFC-0046 + RFC-0052 adjusted targets), insights and per-section errors.
+// Mounted with the standard hybrid auth (customers:read) in app.ts.
+// =============================================================================
+
+const router = Router({ mergeParams: true });
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Optional ISO date/datetime window; forwarded to the telemetry read-through. */
+const SingleDashboardQuerySchema = z.object({
+  from: z.string().regex(/^\d{4}-\d{2}-\d{2}(T[\d:.Z+-]+)?$/, 'from must be an ISO date').optional(),
+  to: z.string().regex(/^\d{4}-\d{2}-\d{2}(T[\d:.Z+-]+)?$/, 'to must be an ISO date').optional(),
+});
+
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { customerId } = req.params;
+
+    if (!customerId || !UUID_REGEX.test(customerId)) {
+      throw new ValidationError(`Invalid customerId: "${customerId ?? ''}"`);
+    }
+
+    const { from, to } = SingleDashboardQuerySchema.parse(req.query);
+    const result = await singleDashboardService.get(tenantId, customerId, { from, to });
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export { router as singleDashboardController };

--- a/src/infrastructure/database/drizzle/db.ts
+++ b/src/infrastructure/database/drizzle/db.ts
@@ -20,6 +20,37 @@ const queryClient = postgres(connectionString);
 // Create Drizzle instance with schema
 export const db = drizzle(queryClient, { schema });
 
+/**
+ * Executes a raw (possibly multi-statement, possibly transactional) SQL script
+ * on a RESERVED connection from the pool. postgres.js forbids explicit
+ * BEGIN/COMMIT on pooled connections (UNSAFE_TRANSACTION) because statements
+ * could land on different sockets; a reserved connection pins the whole script
+ * to ONE socket, so ops scripts with BEGIN/COMMIT + temp tables run with real
+ * transactional semantics (same class of fix as the {max: 1} one-liners used
+ * during incident response).
+ *
+ * Returns: for a single statement, its rows; for multi-statement scripts, an
+ * array with each statement's result (postgres.js semantics).
+ */
+export async function executeRawScript(sqlText: string): Promise<unknown> {
+  const reserved = await queryClient.reserve();
+  try {
+    return await reserved.unsafe(sqlText);
+  } finally {
+    // The reserved socket goes BACK TO THE POOL: if the script failed mid-
+    // transaction (or did BEGIN without COMMIT), the open aborted transaction
+    // would poison every later query on this connection ("current transaction
+    // is aborted..."). Defensive ROLLBACK — a no-op warning when there is no
+    // transaction — guarantees the connection is returned clean.
+    try {
+      await reserved.unsafe('ROLLBACK');
+    } catch {
+      // connection-level failure; the pool will recycle the socket.
+    }
+    reserved.release();
+  }
+}
+
 // Export schema for use in queries
 export { schema };
 

--- a/src/services/IngestionTelemetryClient.ts
+++ b/src/services/IngestionTelemetryClient.ts
@@ -1,0 +1,62 @@
+// =============================================================================
+// RFC-0053 — One-Store Dash: telemetry read-through client (interface + stub)
+//
+// GCDR is a registry: it stores each device's ingestion identity
+// (`device.ingestionId` / `device.externalId`) but NOT live values. The store
+// dashboard reads telemetry through this client, server-side, so ingestion
+// credentials never reach the browser (RFC-0053 §4.2).
+//
+// The concrete HTTP client is BLOCKED on RFC-0053 Unresolved Question 1 (the
+// ingestion API contract for instantaneous + period + series queries). Until
+// that lands, the Null client makes the dashboard degrade gracefully: every
+// group renders its registry data with an explicit "telemetry unavailable"
+// reason instead of failing the whole endpoint.
+// =============================================================================
+
+/** Date window requested by the dashboard (ISO strings, inclusive). */
+export interface TelemetryRange {
+  from?: string;
+  to?: string;
+}
+
+/** Per-device period figures the dashboard cards render. */
+export interface DeviceTelemetry {
+  /** Latest instantaneous reading (kW, m³/h, °C, % level — unit per group). */
+  instant?: number;
+  /** Total for the requested range (kWh, m³). */
+  periodTotal?: number;
+  /** Current-month total. */
+  monthTotal?: number;
+  /** Small series for the card sparkline (newest-last). */
+  sparkline?: number[];
+}
+
+export interface GroupTelemetryResult {
+  available: boolean;
+  /** Machine-readable reason when unavailable. */
+  reason?: 'INGESTION_CONTRACT_PENDING' | 'UPSTREAM_ERROR' | 'NO_INGESTION_ID';
+  /** Keyed by GCDR device id. */
+  byDevice: Record<string, DeviceTelemetry>;
+}
+
+export interface IngestionTelemetryClient {
+  /**
+   * Fetches telemetry for a batch of devices in one upstream round-trip.
+   * `ingestionIds` maps GCDR device id → ingestion identity (devices without
+   * one are simply absent from the result).
+   */
+  fetchBatch(ingestionIds: Record<string, string>, range: TelemetryRange): Promise<GroupTelemetryResult>;
+}
+
+/**
+ * Stub used until the ingestion API contract is ratified (RFC-0053 Q1).
+ * Always reports telemetry as unavailable — the dashboard renders registry
+ * data with per-card "no data" states.
+ */
+export class NullIngestionTelemetryClient implements IngestionTelemetryClient {
+  async fetchBatch(): Promise<GroupTelemetryResult> {
+    return { available: false, reason: 'INGESTION_CONTRACT_PENDING', byDevice: {} };
+  }
+}
+
+export const ingestionTelemetryClient: IngestionTelemetryClient = new NullIngestionTelemetryClient();

--- a/src/services/SingleDashboardService.ts
+++ b/src/services/SingleDashboardService.ts
@@ -1,0 +1,429 @@
+// =============================================================================
+// RFC-0053 — One-Store Dash: aggregation service
+//
+// Composes the single-store operational snapshot from what GCDR already owns:
+//   - devices (grouped energy/water/temperature/tanks by profile/type, with
+//     per-customer overrides in customer.settings.singleDashboard);
+//   - consumption goals with the RFC-0052 margin overlay (raw + adjusted);
+//   - connectivity-derived health score (explainable breakdown, §4.3);
+//   - live telemetry through IngestionTelemetryClient (§4.2) — currently the
+//     Null stub (RFC-0053 Q1), so groups degrade to registry-only cards.
+//
+// Insights (§4.5) are heuristics over the telemetry window; with the Null
+// telemetry client none of them can fire, so the evaluator returns an empty
+// list with the contract in place for the real client.
+// =============================================================================
+
+import { Device } from '../domain/entities/Device';
+import { deviceService } from './DeviceService';
+import { customerService } from './CustomerService';
+import { ruleService } from './RuleService';
+import { annotationService } from './AnnotationService';
+import { consumptionGoalService, GoalGetResult } from './ConsumptionGoalService';
+import {
+  IngestionTelemetryClient,
+  ingestionTelemetryClient,
+  GroupTelemetryResult,
+  TelemetryRange,
+} from './IngestionTelemetryClient';
+import type { GoalDomain } from '../dto/request/GoalsDTO';
+
+// -----------------------------------------------------------------------------
+// Response shapes (mirrored 1:1 by the frontend types)
+// -----------------------------------------------------------------------------
+
+export type SingleDashGroupKey = 'energy' | 'water' | 'temperature' | 'tanks';
+
+export const SINGLE_DASH_GROUP_KEYS: SingleDashGroupKey[] = ['energy', 'water', 'temperature', 'tanks'];
+
+export interface SingleDashDeviceCard {
+  id: string;
+  name: string;
+  label?: string;
+  identifier?: string;
+  deviceType?: string;
+  deviceProfile?: string;
+  connectivityStatus: string;
+  lastActivityTime?: string;
+  /** Period figures from the telemetry read-through; null while unavailable. */
+  telemetry: {
+    instant?: number;
+    periodTotal?: number;
+    monthTotal?: number;
+    sparkline?: number[];
+  } | null;
+}
+
+export interface SingleDashGroup {
+  key: SingleDashGroupKey;
+  deviceCount: number;
+  online: number;
+  offline: number;
+  unknown: number;
+  devices: SingleDashDeviceCard[];
+  telemetry: { available: boolean; reason?: string };
+}
+
+export interface SingleDashHealthComponent {
+  key: 'activeAlarms' | 'offlineSensors' | 'outOfRange';
+  penalty: number;
+  detail: string;
+}
+
+export interface SingleDashHealth {
+  score: number;
+  components: SingleDashHealthComponent[];
+}
+
+export interface SingleDashGoalProgress {
+  domain: GoalDomain;
+  unit: string;
+  year: number;
+  version: number;
+  goalMarginPct: number | null;
+  monthRef: string; // "2026-07"
+  monthTarget: number | null;
+  monthTargetAdjusted: number | null;
+  annualTarget: number | null;
+  annualTargetAdjusted: number | null;
+  /** Month-to-date consumption — needs telemetry; null until Q1 lands. */
+  monthConsumption: number | null;
+}
+
+export interface SingleDashInsight {
+  key: string;
+  severity: 'info' | 'warning' | 'critical';
+  title: string;
+  description: string;
+  groupKey?: SingleDashGroupKey;
+  deviceId?: string;
+  estimatedImpact?: string;
+  detectedAt: string;
+}
+
+/** Consolidated alarms card: rule inventory today; ACTIVE alarms pend Q2. */
+export interface SingleDashAlarmsSummary {
+  rulesTotal: number;
+  rulesEnabled: number;
+  /** Enabled rules by priority (CRITICAL | HIGH | MEDIUM | LOW). */
+  byPriority: Record<string, number>;
+  /** Active-alarm count — null until the orchestrator integration (RFC-0053 Q2). */
+  active: number | null;
+}
+
+/** Consolidated annotations card for the customer (RFC-0036 aggregate). */
+export interface SingleDashAnnotationsSummary {
+  total: number;
+  /** Non-archived annotations by type (observation | pending | maintenance | activity). */
+  byType: Record<string, number>;
+  recent: Array<{
+    id: string;
+    text: string;
+    type: string;
+    importance: number;
+    status: string;
+    createdAt: string;
+    createdByName: string | null;
+  }>;
+}
+
+export interface SingleDashboardResult {
+  customerId: string;
+  customerName: string;
+  range: TelemetryRange;
+  groups: SingleDashGroup[];
+  /** Devices no rule or override could place — surfaced, never hidden (§3.3). */
+  unassigned: SingleDashDeviceCard[];
+  health: SingleDashHealth;
+  goals: SingleDashGoalProgress[];
+  insights: SingleDashInsight[];
+  alarms: SingleDashAlarmsSummary | null;
+  annotations: SingleDashAnnotationsSummary | null;
+  /** Per-section soft failures (partial responses instead of 5xx, §4.2). */
+  errors: Array<{ section: string; message: string }>;
+}
+
+/** Per-customer overrides block (customer.settings.singleDashboard, §4.4). */
+interface SingleDashboardSettings {
+  groupOverrides?: Record<string, SingleDashGroupKey>;
+}
+
+// -----------------------------------------------------------------------------
+// Default device → group mapping (§3.3). First matching rule wins; matching is
+// case-insensitive over deviceProfile, deviceType and name. Overrides from
+// customer.settings.singleDashboard.groupOverrides take precedence.
+// -----------------------------------------------------------------------------
+
+const GROUP_RULES: Array<{ group: SingleDashGroupKey; pattern: RegExp }> = [
+  // Tanks first: pump/level/tank names would otherwise leak into water/energy.
+  { group: 'tanks', pattern: /CAIXA|TANQUE|TANK|RESERVAT|NIVEL|N[IÍ]VEL|BOMBA|PRESSURIZA/i },
+  // Solenoid valves belong to the water panel (MAIN_BAS convention).
+  { group: 'water', pattern: /HIDR|WATER|[AÁ]GUA|SOLEN/i },
+  { group: 'temperature', pattern: /TERM|TEMP|FREEZER|CAMARA|C[AÂ]MARA|GELADEIRA|ADEGA/i },
+  {
+    group: 'energy',
+    pattern: /MEDIDOR|3F|RELOGIO|REL[OÓ]GIO|QGBT|ENERG|CHILLER|FANCOIL|HVAC|AR[_ ]?COND|ILUMINA|LAMP|TOMADA|COMPRESSOR/i,
+  },
+];
+
+const GOAL_DOMAINS: GoalDomain[] = ['ENERGY', 'WATER'];
+
+const MAX_STORE_DEVICES = 1000;
+
+export class SingleDashboardService {
+  constructor(private readonly telemetry: IngestionTelemetryClient = ingestionTelemetryClient) {}
+
+  async get(tenantId: string, customerId: string, range: TelemetryRange): Promise<SingleDashboardResult> {
+    const errors: SingleDashboardResult['errors'] = [];
+
+    // 404s propagate: a dashboard for a missing customer is a client error.
+    const customer = await customerService.getById(tenantId, customerId);
+    const settings = this.settingsOf(customer.settings);
+
+    const page = await deviceService.listByCustomer(tenantId, customerId, { limit: MAX_STORE_DEVICES });
+    const devices = page.items.filter((d) => !d.deletedAt);
+
+    // ── Grouping ──────────────────────────────────────────────────────────────
+    const grouped = new Map<SingleDashGroupKey, Device[]>(SINGLE_DASH_GROUP_KEYS.map((k) => [k, []]));
+    const unassigned: Device[] = [];
+    for (const device of devices) {
+      const group = this.groupOf(device, settings);
+      if (group) grouped.get(group)!.push(device);
+      else unassigned.push(device);
+    }
+
+    // ── Telemetry read-through (one batch; degrades to unavailable) ──────────
+    let telemetryResult: GroupTelemetryResult;
+    try {
+      const ingestionIds: Record<string, string> = {};
+      for (const d of devices) {
+        if (d.ingestionId) ingestionIds[d.id] = d.ingestionId;
+      }
+      telemetryResult = await this.telemetry.fetchBatch(ingestionIds, range);
+    } catch (err) {
+      telemetryResult = { available: false, reason: 'UPSTREAM_ERROR', byDevice: {} };
+      errors.push({ section: 'telemetry', message: err instanceof Error ? err.message : String(err) });
+    }
+
+    const groups: SingleDashGroup[] = SINGLE_DASH_GROUP_KEYS.map((key) =>
+      this.buildGroup(key, grouped.get(key)!, telemetryResult),
+    );
+
+    // ── Goals (raw + RFC-0052 adjusted) ───────────────────────────────────────
+    const goals: SingleDashGoalProgress[] = [];
+    const now = new Date();
+    for (const domain of GOAL_DOMAINS) {
+      try {
+        const result = await consumptionGoalService.get(
+          { tenantId, customerId, domain, year: now.getFullYear() },
+          'month',
+          false,
+        );
+        goals.push(this.buildGoalProgress(domain, result, now));
+      } catch (err) {
+        errors.push({ section: `goals:${domain}`, message: err instanceof Error ? err.message : String(err) });
+      }
+    }
+
+    const health = this.buildHealth(devices);
+    const insights = this.evaluateInsights(telemetryResult);
+
+    // ── Consolidated alarms (rule inventory; active alarms pend Q2) ───────────
+    let alarms: SingleDashAlarmsSummary | null = null;
+    try {
+      alarms = await this.buildAlarmsSummary(tenantId, customerId);
+    } catch (err) {
+      errors.push({ section: 'alarms', message: err instanceof Error ? err.message : String(err) });
+    }
+
+    // ── Consolidated annotations (RFC-0036, customer-wide) ────────────────────
+    let annotations: SingleDashAnnotationsSummary | null = null;
+    try {
+      annotations = await this.buildAnnotationsSummary(tenantId, customerId);
+    } catch (err) {
+      errors.push({ section: 'annotations', message: err instanceof Error ? err.message : String(err) });
+    }
+
+    return {
+      customerId,
+      customerName: customer.displayName || customer.name,
+      range,
+      groups,
+      unassigned: unassigned.map((d) => this.buildDeviceCard(d, telemetryResult)),
+      health,
+      goals,
+      insights,
+      alarms,
+      annotations,
+      errors,
+    };
+  }
+
+  /** Rule inventory grouped by priority; `active` stays null until RFC-0053 Q2. */
+  private async buildAlarmsSummary(tenantId: string, customerId: string): Promise<SingleDashAlarmsSummary> {
+    const rules = await ruleService.getByCustomerId(tenantId, customerId);
+    const enabled = rules.filter((r) => r.enabled);
+    const byPriority: Record<string, number> = {};
+    for (const r of enabled) {
+      const p = String(r.priority || 'MEDIUM').toUpperCase();
+      byPriority[p] = (byPriority[p] ?? 0) + 1;
+    }
+    return { rulesTotal: rules.length, rulesEnabled: enabled.length, byPriority, active: null };
+  }
+
+  /** Customer-wide annotation roll-up: counts by type + the 5 most recent. */
+  private async buildAnnotationsSummary(
+    tenantId: string,
+    customerId: string,
+  ): Promise<SingleDashAnnotationsSummary> {
+    const page = await annotationService.list(tenantId, { customerId, limit: 100 });
+    const items = page.items ?? [];
+    const byType: Record<string, number> = {};
+    for (const a of items) {
+      byType[a.type] = (byType[a.type] ?? 0) + 1;
+    }
+    const recent = items.slice(0, 5).map((a) => ({
+      id: a.id,
+      text: a.text,
+      type: a.type,
+      importance: a.importance,
+      status: a.status,
+      createdAt: a.createdAt,
+      createdByName: a.createdBy?.name ?? a.createdBy?.email ?? null,
+    }));
+    return { total: page.pagination?.total ?? items.length, byType, recent };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Grouping
+  // ---------------------------------------------------------------------------
+
+  private settingsOf(raw: unknown): SingleDashboardSettings {
+    if (raw && typeof raw === 'object' && 'singleDashboard' in (raw as Record<string, unknown>)) {
+      const block = (raw as Record<string, unknown>).singleDashboard;
+      if (block && typeof block === 'object') return block as SingleDashboardSettings;
+    }
+    return {};
+  }
+
+  /** Override first; then the first matching default rule; else unassigned. */
+  private groupOf(device: Device, settings: SingleDashboardSettings): SingleDashGroupKey | null {
+    const override = settings.groupOverrides?.[device.id];
+    if (override && SINGLE_DASH_GROUP_KEYS.includes(override)) return override;
+
+    const haystack = [device.deviceProfile, device.deviceType, device.name, device.label]
+      .filter(Boolean)
+      .join(' ');
+    for (const rule of GROUP_RULES) {
+      if (rule.pattern.test(haystack)) return rule.group;
+    }
+    return null;
+  }
+
+  private buildGroup(key: SingleDashGroupKey, devices: Device[], telemetry: GroupTelemetryResult): SingleDashGroup {
+    let online = 0;
+    let offline = 0;
+    let unknown = 0;
+    for (const d of devices) {
+      const s = (d.connectivityStatus || '').toUpperCase();
+      if (s === 'ONLINE') online++;
+      else if (s === 'OFFLINE') offline++;
+      else unknown++;
+    }
+    return {
+      key,
+      deviceCount: devices.length,
+      online,
+      offline,
+      unknown,
+      devices: devices.map((d) => this.buildDeviceCard(d, telemetry)),
+      telemetry: { available: telemetry.available, ...(telemetry.reason ? { reason: telemetry.reason } : {}) },
+    };
+  }
+
+  private buildDeviceCard(device: Device, telemetry: GroupTelemetryResult): SingleDashDeviceCard {
+    const t = telemetry.byDevice[device.id];
+    return {
+      id: device.id,
+      name: device.name,
+      label: device.label,
+      identifier: device.identifier,
+      deviceType: device.deviceType,
+      deviceProfile: device.deviceProfile,
+      connectivityStatus: device.connectivityStatus,
+      lastActivityTime: device.lastActivityTime,
+      telemetry: t ?? null,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Health (§4.3) — deterministic, always explainable via components[].
+  // Active-alarm penalties are wired but score 0 until the alarm source lands
+  // (RFC-0053 Q2); connectivity is computable today.
+  // ---------------------------------------------------------------------------
+
+  private buildHealth(devices: Device[]): SingleDashHealth {
+    const total = devices.length;
+    const offline = devices.filter((d) => (d.connectivityStatus || '').toUpperCase() === 'OFFLINE').length;
+
+    const offlinePenalty = total === 0 ? 0 : Math.min(20, Math.round((offline / total) * 100));
+
+    const components: SingleDashHealthComponent[] = [
+      {
+        key: 'activeAlarms',
+        penalty: 0,
+        detail: 'Active-alarm source pending (RFC-0053 Q2)',
+      },
+      {
+        key: 'offlineSensors',
+        penalty: offlinePenalty,
+        detail: `${offline}/${total} devices offline`,
+      },
+      {
+        key: 'outOfRange',
+        penalty: 0,
+        detail: 'Needs telemetry (RFC-0053 Q1)',
+      },
+    ];
+
+    const score = Math.max(0, 100 - components.reduce((sum, c) => sum + c.penalty, 0));
+    return { score, components };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Goals — reuses the RFC-0046/0052 read model (value + adjustedValue).
+  // ---------------------------------------------------------------------------
+
+  private buildGoalProgress(domain: GoalDomain, result: GoalGetResult, now: Date): SingleDashGoalProgress {
+    const monthKey = String(now.getMonth() + 1).padStart(2, '0');
+    const monthNode = result.tree.monthly?.[monthKey];
+    const annualNode = result.tree.annual;
+    return {
+      domain,
+      unit: result.unit,
+      year: result.year,
+      version: result.version,
+      goalMarginPct: result.goalMargin?.goalMarginPct ?? null,
+      monthRef: `${result.year}-${monthKey}`,
+      monthTarget: monthNode?.value ?? null,
+      monthTargetAdjusted: monthNode?.adjustedValue ?? null,
+      annualTarget: annualNode?.value ?? null,
+      annualTargetAdjusted: annualNode?.adjustedValue ?? null,
+      monthConsumption: null, // telemetry-dependent (RFC-0053 Q1)
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Insights (§4.5) — every heuristic needs the telemetry window; with the
+  // Null client the evaluator returns []. The switch below is the extension
+  // point for night-flow-leak / baseline-deviation / temp-out-of-range /
+  // runtime-increase / refill-frequency / goal-pace once Q1 lands.
+  // ---------------------------------------------------------------------------
+
+  private evaluateInsights(telemetry: GroupTelemetryResult): SingleDashInsight[] {
+    if (!telemetry.available) return [];
+    return [];
+  }
+}
+
+export const singleDashboardService = new SingleDashboardService();

--- a/tests/unit/services/SingleDashboardService.test.ts
+++ b/tests/unit/services/SingleDashboardService.test.ts
@@ -1,0 +1,207 @@
+// RFC-0053 — One-Store Dash: unit tests over mocked registry/goals singletons.
+// Covers the device→group mapping (defaults + settings override + unassigned),
+// the explainable health score and the goal progress block (raw + adjusted).
+
+jest.mock('../../../src/services/DeviceService', () => ({
+  deviceService: { listByCustomer: jest.fn() },
+}));
+jest.mock('../../../src/services/CustomerService', () => ({
+  customerService: { getById: jest.fn() },
+}));
+jest.mock('../../../src/services/ConsumptionGoalService', () => ({
+  consumptionGoalService: { get: jest.fn() },
+}));
+jest.mock('../../../src/services/RuleService', () => ({
+  ruleService: { getByCustomerId: jest.fn() },
+}));
+jest.mock('../../../src/services/AnnotationService', () => ({
+  annotationService: { list: jest.fn() },
+}));
+
+import { SingleDashboardService } from '../../../src/services/SingleDashboardService';
+import { NullIngestionTelemetryClient } from '../../../src/services/IngestionTelemetryClient';
+import { deviceService } from '../../../src/services/DeviceService';
+import { customerService } from '../../../src/services/CustomerService';
+import { consumptionGoalService } from '../../../src/services/ConsumptionGoalService';
+import { ruleService } from '../../../src/services/RuleService';
+import { annotationService } from '../../../src/services/AnnotationService';
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const customerId = '84e0370e-636a-4741-9874-504b5e0b3577';
+
+const mockedDevices = deviceService.listByCustomer as jest.Mock;
+const mockedCustomer = customerService.getById as jest.Mock;
+const mockedGoals = consumptionGoalService.get as jest.Mock;
+const mockedRules = ruleService.getByCustomerId as jest.Mock;
+const mockedAnnotations = annotationService.list as jest.Mock;
+
+function device(partial: Record<string, unknown>) {
+  return {
+    id: 'dev-' + Math.random().toString(36).slice(2, 8),
+    name: 'Device',
+    connectivityStatus: 'UNKNOWN',
+    ...partial,
+  };
+}
+
+function goalResult(domain: string, withMargin: boolean) {
+  return {
+    customerId,
+    domain,
+    unit: domain === 'WATER' ? 'm3' : 'kWh',
+    aggregationMethod: 'SUM',
+    year: new Date().getFullYear(),
+    version: 3,
+    goalMargin: withMargin ? { goalMarginPct: -5, updatedBy: null, updatedAt: null } : null,
+    tree: {
+      annual: { value: 1200, adjustedValue: withMargin ? 1140 : 1200, method: 'SUM' },
+      monthly: Object.fromEntries(
+        Array.from({ length: 12 }, (_, i) => [
+          String(i + 1).padStart(2, '0'),
+          { value: 100, adjustedValue: withMargin ? 95 : 100, method: 'SUM' },
+        ]),
+      ),
+    },
+  };
+}
+
+function makeService() {
+  return new SingleDashboardService(new NullIngestionTelemetryClient());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedCustomer.mockResolvedValue({ id: customerId, name: 'Loja', displayName: 'Loja Teste', settings: {} });
+  mockedGoals.mockImplementation((key: { domain: string }) => Promise.resolve(goalResult(key.domain, key.domain === 'ENERGY')));
+  mockedDevices.mockResolvedValue({ items: [], total: 0 });
+  mockedRules.mockResolvedValue([]);
+  mockedAnnotations.mockResolvedValue({ items: [], pagination: { hasMore: false, total: 0 } });
+});
+
+describe('SingleDashboardService — RFC-0053', () => {
+  it('groups devices by profile/type keywords and surfaces unmatched as unassigned', async () => {
+    mockedDevices.mockResolvedValue({
+      items: [
+        device({ id: 'd1', name: 'Medidor Geral', deviceType: '3F_MEDIDOR' }),
+        device({ id: 'd2', name: 'Hidrômetro Cozinha', deviceProfile: 'HIDROMETRO_AREA_COMUM' }),
+        device({ id: 'd3', name: 'Freezer 2', deviceType: 'TERMOMETRO' }),
+        device({ id: 'd4', name: 'Caixa Superior', deviceType: 'NIVEL_CAIXA' }),
+        device({ id: 'd5', name: 'Bomba Recalque' }),
+        device({ id: 'd6', name: 'Sensor Presença', deviceChannelType: 'presence_sensor' }),
+      ],
+    });
+    const result = await makeService().get(tenantId, customerId, {});
+
+    const byKey = Object.fromEntries(result.groups.map((g) => [g.key, g.devices.map((d) => d.id)]));
+    expect(byKey.energy).toEqual(['d1']);
+    expect(byKey.water).toEqual(['d2']);
+    expect(byKey.temperature).toEqual(['d3']);
+    expect(byKey.tanks).toEqual(expect.arrayContaining(['d4', 'd5']));
+    expect(result.unassigned.map((d) => d.id)).toEqual(['d6']);
+  });
+
+  it('applies customer.settings.singleDashboard.groupOverrides before default rules', async () => {
+    mockedCustomer.mockResolvedValue({
+      id: customerId,
+      name: 'Loja',
+      displayName: 'Loja Teste',
+      settings: { singleDashboard: { groupOverrides: { d1: 'tanks' } } },
+    });
+    mockedDevices.mockResolvedValue({
+      items: [device({ id: 'd1', name: 'Medidor Geral', deviceType: '3F_MEDIDOR' })],
+    });
+    const result = await makeService().get(tenantId, customerId, {});
+
+    const tanks = result.groups.find((g) => g.key === 'tanks')!;
+    const energy = result.groups.find((g) => g.key === 'energy')!;
+    expect(tanks.devices.map((d) => d.id)).toEqual(['d1']);
+    expect(energy.deviceCount).toBe(0);
+  });
+
+  it('computes an explainable health score from connectivity (alarms/telemetry pending)', async () => {
+    mockedDevices.mockResolvedValue({
+      items: [
+        device({ id: 'd1', name: 'Medidor', deviceType: '3F_MEDIDOR', connectivityStatus: 'ONLINE' }),
+        device({ id: 'd2', name: 'Hidro', deviceType: 'HIDROMETRO', connectivityStatus: 'OFFLINE' }),
+        device({ id: 'd3', name: 'Termo', deviceType: 'TERMOMETRO', connectivityStatus: 'OFFLINE' }),
+        device({ id: 'd4', name: 'Caixa', deviceType: 'CAIXA_DAGUA', connectivityStatus: 'ONLINE' }),
+      ],
+    });
+    const result = await makeService().get(tenantId, customerId, {});
+
+    // 2/4 offline → ratio penalty capped at 20.
+    const offlineComponent = result.health.components.find((c) => c.key === 'offlineSensors')!;
+    expect(offlineComponent.penalty).toBe(20);
+    expect(result.health.score).toBe(80);
+    expect(result.health.components).toHaveLength(3);
+  });
+
+  it('returns goal progress with raw and RFC-0052 adjusted targets for the current month', async () => {
+    const result = await makeService().get(tenantId, customerId, {});
+
+    const energy = result.goals.find((g) => g.domain === 'ENERGY')!;
+    expect(energy.goalMarginPct).toBe(-5);
+    expect(energy.monthTarget).toBe(100);
+    expect(energy.monthTargetAdjusted).toBe(95);
+    expect(energy.annualTargetAdjusted).toBe(1140);
+    expect(energy.monthConsumption).toBeNull(); // telemetry pending (Q1)
+
+    const water = result.goals.find((g) => g.domain === 'WATER')!;
+    expect(water.goalMarginPct).toBeNull();
+    expect(water.monthTargetAdjusted).toBe(100);
+  });
+
+  it('degrades telemetry to unavailable with the pending-contract reason', async () => {
+    mockedDevices.mockResolvedValue({
+      items: [device({ id: 'd1', name: 'Medidor', deviceType: '3F_MEDIDOR', ingestionId: 'ing-1' })],
+    });
+    const result = await makeService().get(tenantId, customerId, {});
+
+    const energy = result.groups.find((g) => g.key === 'energy')!;
+    expect(energy.telemetry).toEqual({ available: false, reason: 'INGESTION_CONTRACT_PENDING' });
+    expect(energy.devices[0].telemetry).toBeNull();
+    expect(result.insights).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('consolidates alarm rules by priority and annotations by type', async () => {
+    mockedRules.mockResolvedValue([
+      { id: 'r1', priority: 'CRITICAL', enabled: true },
+      { id: 'r2', priority: 'HIGH', enabled: true },
+      { id: 'r3', priority: 'HIGH', enabled: true },
+      { id: 'r4', priority: 'LOW', enabled: false },
+    ]);
+    mockedAnnotations.mockResolvedValue({
+      items: [
+        { id: 'a1', text: 'Trocar filtro', type: 'maintenance', importance: 4, status: 'created', createdAt: '2026-07-10T10:00:00Z', createdBy: { name: 'Rodrigo' } },
+        { id: 'a2', text: 'Sensor instável', type: 'observation', importance: 3, status: 'created', createdAt: '2026-07-09T10:00:00Z', createdBy: { email: 'x@y.z' } },
+      ],
+      pagination: { hasMore: false, total: 2 },
+    });
+    const result = await makeService().get(tenantId, customerId, {});
+
+    expect(result.alarms).toEqual({
+      rulesTotal: 4,
+      rulesEnabled: 3,
+      byPriority: { CRITICAL: 1, HIGH: 2 },
+      active: null, // orchestrator integration pending (RFC-0053 Q2)
+    });
+    expect(result.annotations?.total).toBe(2);
+    expect(result.annotations?.byType).toEqual({ maintenance: 1, observation: 1 });
+    expect(result.annotations?.recent[0]).toMatchObject({ id: 'a1', createdByName: 'Rodrigo' });
+    expect(result.annotations?.recent[1]).toMatchObject({ id: 'a2', createdByName: 'x@y.z' });
+  });
+
+  it('collects per-section errors instead of failing the whole snapshot', async () => {
+    mockedGoals.mockRejectedValue(new Error('goals backend down'));
+    const result = await makeService().get(tenantId, customerId, {});
+
+    expect(result.goals).toEqual([]);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ section: 'goals:ENERGY' }),
+        expect.objectContaining({ section: 'goals:WATER' }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

RFC-0053 **Single Dashboard** — endpoint de agregação read-only para o dashboard operacional single-customer (loja em shopping, 3–5 sensores por tipo):

- `GET /customers/:customerId/single-dashboard` (hybridAuth, `PERM_CUSTOMERS_READ`)
- **Grupos de devices** (energy/water/temperature/tanks) por regras de keyword sobre type/profile/nome + overrides em `customer.settings.singleDashboard.groupOverrides`
- **Health score** determinístico e explicável (breakdown por componente)
- **Metas do mês** raw + adjusted (integra a margem do RFC-0052)
- **Alarmes consolidados**: regras por prioridade via RuleService (`active: null` — orquestrador pendente, Q2)
- **Anotações consolidadas**: total, byType e 5 recentes via AnnotationService
- `IngestionTelemetryClient` (interface) + `NullIngestionTelemetryClient` — contrato de ingestion pendente (Q1); tudo degrada para "sem dados"
- Erros por seção em `errors[]` (nunca derruba o snapshot inteiro)
- RFC em `docs/rfcs/RFC-0053-One-Store-Dashboard.md` (+ draft original), path no `openapi.yaml`

Inclui também `fix(db-admin)`: scripts ops multi-statement rodando em conexão reservada (`executeRawScript`), gate de escrita do console varrendo o script inteiro e `next: Function` → `NextFunction`.

## Test plan

- [x] 7 testes unitários (`tests/unit/services/SingleDashboardService.test.ts`) — grupos, overrides, health, metas raw/adjusted, telemetria degradada, alarmes/anotações consolidados, erros por seção
- [x] `npx tsc --noEmit` limpo
- [x] Verificado e2e local com customer de teste "Loja Café Aroma" (9 devices + 3 anotações)

## Questões abertas (documentadas no RFC, não bloqueiam)

- Q1: contrato da Ingestion API (telemetria)
- Q2: fonte de alarmes ativos (orquestrador)
- Q3: escopo RBAC dedicado

🤖 Generated with [Claude Code](https://claude.com/claude-code)
