### PR TITLE
RFC-0055 — NO_CONSUMPTION rule type (backend)

### DIFF
--- a/docs/rfcs/RFC-0055-No-Consumption-Incidents.md
+++ b/docs/rfcs/RFC-0055-No-Consumption-Incidents.md
@@ -321,17 +321,39 @@ with offset**.
 - **Internal rule definitions** (`NO_CONSUMPTION`) are **read-only metadata**
   visible only to admin/support — never customer-editable.
 
-### 7. Frontend transport decision
+### 7. Frontend transport decision — DECIDED (ED-1077): thin GCDR proxy
 
 The GCDR Frontend consumes an **Alarms-owned** incidents API while still needing
-GCDR master-data context. Decision:
+GCDR master-data context.
 
-- **If** auth, tenant headers and CORS are already standardized between the
-  frontend and Alarms → the frontend calls the Alarms `/incidents` API **directly**
-  and hydrates display fields from GCDR enrichment.
-- **Otherwise** → add a **thin GCDR-Backend proxy** for `/incidents*`. This is a
-  **transport/auth concern only** — it does **not** move incident *ownership* to
-  GCDR (Alarms remains the system of record).
+**Decision (ED-1077, 2026-08-04): Option B — a thin GCDR-Backend proxy for
+`/incidents*`.** The browser calls GCDR; GCDR forwards to the Alarms API and
+enriches the response in-process before returning it:
+
+```
+Browser (panel) ──► GCDR /incidents* ──► Alarms incidents API
+                         └─ enriches device/central/customer names in-process
+```
+
+This is a **transport/auth concern only** — it does **not** move incident
+*ownership* to GCDR (Alarms remains the system of record).
+
+Rationale (over calling Alarms directly):
+
+- **Auth / CORS / tenant scoping / asset-level RBAC already live in GCDR**
+  (`authMiddleware`, `contextMiddleware`, viewer-by-asset). The direct path would
+  force Alarms to re-implement all of it for the browser.
+- **Enrichment (ED-1080) runs in-process** — the proxy calls `EnrichmentService`
+  directly to inject `deviceName`/`centralName`/`customerName`, with no extra HTTP
+  round trip.
+- **The frontend stays GCDR-only** (single base URL, single auth model). The
+  `incidentService` is already transport-agnostic (`VITE_INCIDENTS_API_URL`).
+
+Cost accepted: one extra hop and four pass-through endpoints in GCDR
+(`GET /incidents`, `GET /incidents/:id`, `POST /incidents/:id/ack|resolve`).
+
+Implementation: **ED-1088** (GCDR proxy endpoints) + point `VITE_INCIDENTS_API_URL`
+at GCDR. Blocked only on the Alarms internal incidents API existing.
 
 ### 8. Compatibility / versioning
 

--- a/docs/rfcs/RFC-0055-No-Consumption-Incidents.md
+++ b/docs/rfcs/RFC-0055-No-Consumption-Incidents.md
@@ -1,0 +1,519 @@
+# RFC-0055 — No-Consumption Detection & Incidents Panel
+
+- **Status:** Draft v2 (feedback-v1 folded in)
+- **Created:** 2026-08-03
+- **Updated:** 2026-08-03 (amended per feedback-v1)
+- **Author:** GCDR Core Team
+- **Domain:** Rules Engine / Alarms Orchestrator / Incidents / Frontend
+- **Related RFCs:** RFC-0015 (Alarm Bundle Version History), RFC-0016 (ThingsBoard Entity Mapping), RFC-0035 (Plural MQTT on Centrals), `docs/RULE-ENTITY.md`, `docs/EMAIL-SENDER-PAYLOAD-CONTRACT.md`
+- **Owners (split):** GCDR Backend · GCDR Frontend · Alarms Orchestrator · Central Agent (read-only)
+
+> **Changelog v2 (feedback-v1):** added a normative bundle payload; pinned the
+> definition of "empty slot" (zero is present, null/absent is empty); decided the
+> day-rollover + late-telemetry policy; changed the status model to
+> `OPEN | RESOLVED` + ack metadata (no `ACKNOWLEDGED` status); switched slot ranges
+> to **full timestamps** in storage/API (UI renders `HH:mm`); metric moved to the
+> device level + validated enum; `timezone` required; v1 restricts `windowMinutes`
+> to 60 and ships the rule **disabled by default** until Alarms confirms support;
+> added Authorization, Frontend transport decision, Testing, and Acceptance
+> Criteria sections; unique key now includes `customer_id`.
+
+---
+
+## Summary
+
+Detect when a device **stops producing consumption telemetry** — i.e. its hourly
+telemetry slot is **empty** for a 1-hour window (or a run of windows) even though
+the device may still be "online" at the connectivity level — and surface it as a
+first-class **Incident** in a dedicated **Incidents panel**.
+
+Three moving parts:
+
+1. **GCDR** gains a new **internal rule type `NO_CONSUMPTION`** (a *data-absence*
+   rule, distinct from the connectivity-based `DEVICE_OFFLINE`). It is
+   platform-managed (`internalRule = true`), enters the alarm bundle like any
+   other rule, and carries the detection window + expected-cadence config.
+
+2. The **Alarms Orchestrator** consumes the bundle, evaluates the telemetry
+   stream against the rule, and — when slots are empty — creates a **detailed
+   Incident candidate**: *central X, date Y, device(s) with empty slots from hour
+   T1 to T2* (or a set of intervals). Incidents are **aggregated by day per
+   central**, grouping the affected devices, and within each device the **empty
+   time-slot ranges**.
+
+3. **GCDR Frontend** renders the **Incidents panel**: day → central → device →
+   slot ranges, with drill-down, filters and status.
+
+This RFC defines the rule shape, the detection semantics, the incident data
+model, the API contracts, and — importantly — **who owns each piece**.
+
+---
+
+## Motivation
+
+`DEVICE_OFFLINE` answers "is the central/device reachable?". It does **not**
+answer "is the device actually reporting the consumption metric we bill/monitor
+on?". A meter can hold a live MQTT/connectivity link and still deliver **empty
+consumption slots** (sensor fault, mis-mapped channel, upstream drop, ingestion
+gap). Today that gap is invisible until someone notices a flat chart — exactly
+the WestPlaza-style escalation (telemetry gaps) that reaches us via the client.
+
+We need:
+
+- A **declarative, internal rule** that states "every device in scope must have a
+  non-empty consumption slot every hour", versioned and shipped in the bundle so
+  the alarms side evaluates it uniformly.
+- A **structured incident** (not a raw alarm per slot) that rolls the noise up
+  into something an operator can act on: *"Central X, 2026-08-02: 4 devices with
+  gaps; device A 03:00–05:00 and 21:00; device B 14:00–14:00; …"*.
+- A **panel** to triage those incidents by day and central.
+
+---
+
+## Guide-level explanation
+
+### The concept
+
+```
+GCDR (master data)                 Alarms Orchestrator                 GCDR Frontend
+──────────────────                 ───────────────────                 ─────────────
+NO_CONSUMPTION rule    ── bundle ─▶ evaluate telemetry slots  ── API ─▶ Incidents panel
+(internal, per scope)               detect empty hourly slots            day ▸ central ▸
+                                    build Incident candidate             device ▸ slots
+   device/central       ◀─ enrich ─ (names, slaveId, central)
+   registry lookups
+```
+
+- A slot is **"empty"** for an hour bucket `[H, H+1)` when the device produced
+  **no consumption sample** (or only null/absent values) for the configured
+  metric in that bucket. "Consumption" here is the metric domain already used by
+  goals/tariffs (energy/water/etc.).
+- The rule scopes to a set of devices (or a whole central/customer). Evaluation
+  is hourly, aligned to a timezone.
+- One **Incident** aggregates, for a `(central, day)`, all devices that had ≥1
+  empty slot that day; each device carries its **merged empty-slot ranges**.
+- The panel lets an operator see the day, expand a central, expand a device, and
+  read the exact hour ranges — then acknowledge / resolve.
+
+### Example incident (shape, not final schema)
+
+```json
+{
+  "id": "inc_...",
+  "kind": "NO_CONSUMPTION",
+  "ruleId": "rule_no_consumption_internal",
+  "customerId": "…", "customerName": "WestPlaza",
+  "centralId": "…",  "centralName": "Central WestPlaza L1",
+  "day": "2026-08-02",
+  "timezone": "America/Sao_Paulo",
+  "severity": "HIGH",
+  "status": "OPEN",
+  "acknowledgedAt": null, "acknowledgedBy": null,
+  "devices": [
+    { "deviceId": "…", "slaveId": 12, "name": "Medidor Loja 12", "metric": "ENERGY_CONSUMPTION",
+      "emptySlots": [
+        { "from": "2026-08-02T03:00:00-03:00", "to": "2026-08-02T05:00:00-03:00", "slotCount": 2 },
+        { "from": "2026-08-02T21:00:00-03:00", "to": "2026-08-02T22:00:00-03:00", "slotCount": 1 }
+      ],
+      "slotCount": 3 },
+    { "deviceId": "…", "slaveId": 7,  "name": "Medidor Chiller", "metric": "ENERGY_CONSUMPTION",
+      "emptySlots": [
+        { "from": "2026-08-02T14:00:00-03:00", "to": "2026-08-02T15:00:00-03:00", "slotCount": 1 }
+      ],
+      "slotCount": 1 }
+  ],
+  "totals": { "devices": 2, "emptySlots": 4 },
+  "firstDetectedAt": "…", "lastEvaluatedAt": "…"
+}
+```
+
+> Storage/API use **full ISO timestamps** for slot ranges (timezone/DST/late-telemetry
+> correctness); the panel renders the compact `03:00–05:00` form.
+
+---
+
+## Reference-level explanation
+
+### 1. The rule — `NO_CONSUMPTION` (GCDR backend)
+
+New value in the `rule_type` pgEnum (currently
+`ALARM_THRESHOLD | SLA | ESCALATION | MAINTENANCE_WINDOW | DEVICE_OFFLINE`) →
+add `NO_CONSUMPTION`.
+
+Config object (`noConsumptionConfig`, jsonb, mirrors how `alarmConfig` /
+`slaConfig` live today):
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `metric` | **enum** (consumption domain) | — | Which consumption metric must be present. Validated against a small enum (e.g. `ENERGY_CONSUMPTION`, `WATER_CONSUMPTION`), **not** an arbitrary string. |
+| `windowMinutes` | int | `60` | Slot size. **v1: only `60` accepted** — reject other values until Alarms supports variable windows. |
+| `minSamplesPerWindow` | int | `1` | A slot is "filled" when it has ≥ this many non-null samples. |
+| `graceWindows` | int | `1` | Consecutive empty windows tolerated before it counts (debounce). |
+| `activeHours` | `{start,end}?` | null | Only evaluate inside these local hours (skip known-idle periods). **v1: rule-level only** (per-device override deferred). |
+| `timezone` | string | **required** | Bucket alignment + day categorization. Not silently defaulted — a missing tz is a config error (hides bugs). |
+| `severity` | RulePriority | `HIGH` | Incident severity. |
+
+Rule flags: `internalRule = true`, `isInternalSupportRule = true` (platform-owned,
+not customer-editable), `scope` = devices / central / customer (reuse the
+existing `scope` + `scopeEntityIds uuid[]`).
+
+**Ships disabled by default.** The rule is created with `enabled = false` and is
+only flipped on once the Alarms Orchestrator confirms support for the bundle
+version that carries `NO_CONSUMPTION` (see §Compatibility). This prevents shipping
+a rule the consumer can't yet evaluate.
+
+**Visibility:** `NO_CONSUMPTION` rule definitions are **read-only metadata visible
+only to admin/support roles**. Customer users do **not** see or edit them (they
+see the resulting incidents, scoped to their customer — §Authorization).
+
+#### Normative alarm-bundle payload (GCDR → Alarms)
+
+The rule appears in the existing bundle `rules[]` exactly as:
+
+```json
+{
+  "id": "rule_uuid",
+  "type": "NO_CONSUMPTION",
+  "internalRule": true,
+  "isInternalSupportRule": true,
+  "enabled": true,
+  "scope": "CENTRAL",
+  "scopeEntityIds": ["central_uuid"],
+  "priority": "HIGH",
+  "noConsumptionConfig": {
+    "metric": "ENERGY_CONSUMPTION",
+    "windowMinutes": 60,
+    "minSamplesPerWindow": 1,
+    "graceWindows": 1,
+    "timezone": "America/Sao_Paulo",
+    "activeHours": null
+  }
+}
+```
+
+> **Config storage (open confirmation):** confirm whether the `rules` table has a
+> generic JSONB config column that can safely carry `noConsumptionConfig`
+> alongside `alarmConfig`/`slaConfig`/etc. If not, add a `no_consumption_config
+> jsonb` column in the migration (§Migrations).
+
+> **Why a new type and not `ALARM_THRESHOLD` with `COUNT == 0`?** Data-absence has
+> different evaluation semantics (you alarm on the *lack* of events, which a
+> threshold-on-arrival engine never fires for), a different lifecycle
+> (auto-resolve when data returns), and a different output (an aggregated
+> incident, not a per-sample alarm). Modeling it as a threshold would overload
+> `alarmConfig` and hide the "no data" nature. Alternative kept in §Alternatives.
+
+The rule is exposed to the alarms side **through the existing alarm bundle**
+(`GET /customers/:id/alarm-rules/bundle/*`, versioned per RFC-0015). No new
+transport — `NO_CONSUMPTION` rules just appear in `rules[]` with their config.
+
+### 2. Detection & incident construction (Alarms Orchestrator)
+
+The orchestrator already consumes the bundle and the telemetry stream. It gains a
+**no-consumption evaluator**:
+
+- **Bucketing:** for each in-scope device, align telemetry to hourly buckets in
+  the rule timezone.
+- **What "empty" means (normative):**
+  > A slot is **empty** only when the configured `metric` has **zero non-null
+  > samples** for the device in `[slotStart, slotEnd)` after the grace period.
+  > A numeric **zero is a valid sample** and is **never** treated as empty.
+  > Duplicate samples in the same slot **count as present** but do not inflate the
+  > slot count. `null`/absent = empty.
+- **Metric source (v1 decision):** absence is checked against the **hourly
+  consumption aggregation** the goals/tariffs pipeline already produces (normalized
+  per device), not raw sample-arrival events — because we alarm on *absence*, which
+  an arrival-driven path never emits. (Confirm the exact aggregation table/feed —
+  §Unresolved.)
+- **Debounce:** only count a bucket after `graceWindows` consecutive empties.
+- **Candidate:** emit an **Incident candidate** keyed by
+  `(tenantId, customerId, centralId, day, ruleId, kind)`. This is the
+  aggregation/dedup key — the same key **updates** the open incident for that day
+  instead of creating N alarms. `day` is computed in the rule timezone.
+- **Grouping:** within the candidate, group by `deviceId`; within each device,
+  **merge contiguous empty buckets into full-timestamp ranges**
+  (`2026-08-02T03:00-03:00 → 05:00`), which the UI renders as `03:00–05:00`.
+- **Lifecycle (v1 decision):** status is `OPEN | RESOLVED`; acknowledgement is
+  **metadata**, not a status (avoids the awkward `ACKNOWLEDGED → RESOLVED`
+  terminal-state problem):
+  - `OPEN` → created on first detection for the key; **updated** (append/shrink
+    devices+slots) while the day is current.
+  - **Late telemetry** may **shrink or remove** slot ranges while the incident is
+    `OPEN`. After it is acknowledged, late telemetry still updates the evidence but
+    **must not erase the audit trail** (`acknowledgedAt/By` + note are preserved).
+  - **Day rollover:** at midnight (rule tz) the incident is auto-`RESOLVED`
+    **only if** no device still has an unresolved *current* empty run; otherwise it
+    stays `OPEN` carrying the ongoing run.
+  - `acknowledgedAt` / `acknowledgedBy` / `acknowledgementNote` set when an operator
+    acks in the panel (does not change `status`).
+- **Dispatch (optional):** an incident MAY notify via the existing channel model
+  (RFC channels / EMAIL_RELAY) — reusing dispatch, not reinventing it. Default:
+  incident is created silently and only shown in the panel; notification is a
+  follow-on policy.
+
+### 3. Incident persistence & ownership
+
+**Decision (proposed):** incidents are **owned/persisted by the Alarms
+Orchestrator** (it owns the event/decision plane; GCDR is master data). GCDR
+provides:
+
+- the **rule** (via bundle),
+- **enrichment** lookups (device name/slaveId, central name, customer name) so the
+  incident payload and the panel don't need raw UUIDs.
+
+GCDR **does not** store incidents. The frontend reads incidents from the alarms
+API. (Alternative — GCDR hosts an incidents table — in §Alternatives.)
+
+### 4. APIs
+
+**Alarms Orchestrator (new):**
+- `GET /incidents?kind=NO_CONSUMPTION&customerId&centralId&dayFrom&dayTo&status&severity&cursor&limit`
+  — list, filterable, paginated. Use a **`dayFrom`/`dayTo` range** (operators need
+  weekly/monthly views), not a single `day`.
+- `GET /incidents/:id` — full incident (device groups + full-timestamp slot ranges).
+- `POST /incidents/:id/ack` — body `{ "comment": "…" }`; persists `actorId`,
+  timestamp, tenant. Sets ack metadata, not status.
+- `POST /incidents/:id/resolve` — body `{ "reason": "…" }`; persists `actorId`,
+  timestamp, tenant.
+- (internal) candidate ingestion is in-process; no public create endpoint.
+- The orchestrator **exposes support/version info** (which bundle version /
+  rule types it can evaluate) so GCDR can flip the rule on safely (§Compatibility).
+
+**List item / detail shape (normative):** list items carry `id, kind, customerId,
+customerName, centralId, centralName, day, timezone, severity, status,
+acknowledgedAt, totals:{devices,emptySlots}, firstDetectedAt, lastEvaluatedAt`.
+The detail adds `devices[]` with `{deviceId, slaveId, name, metric, emptySlots:[{
+from, to, slotCount }], slotCount}` where `from`/`to` are **full ISO timestamps
+with offset**.
+
+**GCDR Backend (new/updated):**
+- Rule CRUD already supports internal rules — add `NO_CONSUMPTION` type +
+  `noConsumptionConfig` validation (Zod) and bundle serialization.
+- **Enrichment endpoint** (if not already covered): batch resolve
+  `deviceId[] → {name, slaveId, centralId}` and `centralId → {name}` for the
+  alarms side to hydrate incidents. Reuse existing device/central reads where
+  possible.
+
+**GCDR Frontend (new):**
+- **Incidents panel** consuming the alarms `/incidents` API: grouped
+  **day ▸ central ▸ device ▸ slot ranges**, with day/central/status filters,
+  severity chips, ack/resolve actions, and a drill-down. Lives as a top-level
+  page and/or a tab on the central/customer detail.
+
+### 5. Categorization / grouping (the panel)
+
+- **Top level:** group by **day** (desc), then by **central**.
+- **Within a central card:** one row per device, showing merged empty-slot ranges
+  as chips (`03:00–05:00`, `21:00`), a slot count, and severity.
+- **Aggregates:** per day-per-central totals (devices affected / empty slots);
+  per central over time (trend).
+- Reuse the OS/OneStore card + collapsible section patterns already in the
+  frontend (RFC-0053 style) for the day/central grouping and expand/collapse-all.
+
+### 6. Authorization & access (v1)
+
+- **Tenant isolation is mandatory** on every Alarms incident endpoint.
+- **View:** customer users can view incidents scoped to **their own customer**;
+  admin/support see all.
+- **Ack/Resolve:** only **operator/admin** roles.
+- **Partner API keys** do **not** access the incidents API unless explicitly
+  granted a scope for it.
+- **Internal rule definitions** (`NO_CONSUMPTION`) are **read-only metadata**
+  visible only to admin/support — never customer-editable.
+
+### 7. Frontend transport decision
+
+The GCDR Frontend consumes an **Alarms-owned** incidents API while still needing
+GCDR master-data context. Decision:
+
+- **If** auth, tenant headers and CORS are already standardized between the
+  frontend and Alarms → the frontend calls the Alarms `/incidents` API **directly**
+  and hydrates display fields from GCDR enrichment.
+- **Otherwise** → add a **thin GCDR-Backend proxy** for `/incidents*`. This is a
+  **transport/auth concern only** — it does **not** move incident *ownership* to
+  GCDR (Alarms remains the system of record).
+
+### 8. Compatibility / versioning
+
+- The `NO_CONSUMPTION` rule ships **`enabled = false`** and is flipped on only
+  after the Alarms Orchestrator reports it supports the bundle version carrying the
+  new type (the orchestrator exposes support/version info; §4).
+- Adding the enum value is additive; older Alarms builds that don't recognize the
+  type must **ignore** unknown rule types in the bundle (confirm this is the
+  current behavior before enabling).
+
+---
+
+## Responsibility matrix
+
+| # | Item | GCDR Backend | GCDR Frontend | Alarms Orchestrator | Central Agent |
+|---|---|---|---|---|---|
+| 1 | `NO_CONSUMPTION` rule type + `noConsumptionConfig` (schema, Zod, migration) | **Owns** | — | consumes via bundle | — |
+| 2 | Internal rule seed/management UI (create the platform rule) | **Owns** (API) | Owns (admin UI, optional) | — | — |
+| 3 | Rule in alarm bundle (versioned) | **Owns** | — | **Consumes** | — |
+| 4 | Telemetry bucketing + empty-slot detection | — | — | **Owns** | produces telemetry (unchanged) |
+| 5 | Debounce (`graceWindows`) + timezone bucket alignment | defines config | — | **Owns** logic | — |
+| 6 | Incident candidate build (group by device, merge slot ranges) | — | — | **Owns** | — |
+| 7 | Incident persistence + lifecycle (OPEN/ACK/RESOLVED, auto-resolve) | — | — | **Owns** | — |
+| 8 | Incident enrichment (device/central/customer names, slaveId) | **Owns** (lookup API) | — | consumes lookup | — |
+| 9 | `GET /incidents*` + ack/resolve API | — | consumes | **Owns** | — |
+| 10 | Incidents panel (day▸central▸device▸slots, filters, drill-down) | — | **Owns** | — | — |
+| 11 | Optional notification of incidents (reuse channels/EMAIL_RELAY) | provides channel config | — | **Owns** dispatch | — |
+| 12 | Docs / contract (this RFC, bundle field, incident payload) | co-owns | co-owns | co-owns | — |
+
+---
+
+## Data model (proposed, alarms-owned)
+
+```
+incidents
+  id                  uuid pk
+  kind                text            -- 'NO_CONSUMPTION' (future: other kinds)
+  tenant_id           uuid
+  customer_id         uuid
+  central_id          uuid
+  rule_id             uuid
+  day                 date            -- categorization axis (rule tz)
+  timezone            text            -- rule tz, stored on the row
+  severity            text
+  status              text            -- OPEN | RESOLVED   (ack is metadata, below)
+  acknowledged_at     timestamptz null
+  acknowledged_by     uuid null
+  acknowledgement_note text null
+  totals              jsonb           -- { devices, emptySlots }
+  first_detected_at   timestamptz
+  last_evaluated_at   timestamptz
+  resolved_at         timestamptz null
+  UNIQUE (tenant_id, customer_id, central_id, day, rule_id, kind)  -- dedup/aggregation key
+
+incident_devices
+  incident_id       uuid fk
+  device_id         uuid
+  slave_id          smallint null
+  metric            text            -- device-level (safer for heterogeneous devices)
+  empty_slots       jsonb           -- [{from:<iso>, to:<iso>, slotCount:int, lastCheckedAt:<iso>}] merged ranges
+  slot_count        int
+  UNIQUE (incident_id, device_id)
+```
+
+Notes:
+- `status` is `OPEN | RESOLVED`; acknowledgement is metadata
+  (`acknowledged_at/by/note`) so `ack` and `resolve` are independent.
+- Slot ranges are stored as **full timestamps** (not `HH:mm`) — timezone/DST/late
+  telemetry/cross-day correctness. The UI renders the compact form.
+- `metric` at device level supports future rules over heterogeneous device metrics.
+- `customer_id` is in the unique key even though `central_id` is globally unique —
+  clearer tenant/customer filtering and debugging.
+
+Indexes:
+
+```sql
+CREATE INDEX incidents_customer_day_idx ON incidents (tenant_id, customer_id, day DESC);
+CREATE INDEX incidents_central_day_idx  ON incidents (tenant_id, central_id, day DESC);
+CREATE INDEX incidents_status_idx       ON incidents (tenant_id, status, day DESC);
+```
+
+`incident_devices` keeps one row per device per day (merged `empty_slots` jsonb),
+avoiding a row-per-slot explosion and matching the panel's grouping.
+
+---
+
+## Migrations
+
+- **GCDR:** `00XX_rule_type_no_consumption.sql` — `ALTER TYPE rule_type ADD VALUE
+  'NO_CONSUMPTION'` (additive, safe). No new column needed if `noConsumptionConfig`
+  reuses an existing config jsonb slot; otherwise add `no_consumption_config jsonb`.
+  > **Migration number:** pick the next free number **at implementation time** —
+  > prod is baselined through `0063` (see the migration governance runbook). Do
+  > **not** hardcode a number in this RFC.
+- **Alarms:** `incidents` + `incident_devices` tables (alarms DB).
+
+---
+
+## Testing (per owned repo)
+
+- **GCDR Backend:** `NO_CONSUMPTION` enum support; valid `noConsumptionConfig`
+  accepted; invalid config rejected (unknown `metric`, missing `timezone`,
+  `windowMinutes != 60`); bundle serialization + version bump; internal-rule
+  visibility/edit restrictions; migration compatibility.
+- **Alarms:** empty-bucket detection; **zero counts as present**; null/absent =
+  empty; duplicate samples present but no double-count; grace-window debounce;
+  contiguous slot merge; non-contiguous ranges stay separate; day boundary in the
+  configured timezone; late-telemetry shrink/remove while OPEN; dedup by incident
+  key (idempotent update); ack/resolve audit fields persisted.
+- **Frontend:** grouping day▸central▸device; device expansion; slot-range
+  rendering; empty/loading/error/permission-denied states; ack/resolve flows;
+  permission-gated controls.
+
+## Acceptance criteria
+
+Implementation-ready when:
+
+- GCDR can create/seed an internal `NO_CONSUMPTION` rule and serialize it in the
+  bundle with the stable config contract (§1).
+- Alarms evaluates the rule **independent of sample arrival**.
+- Alarms persists **one incident per `(tenant, customer, central, day, rule,
+  kind)`** and updates it idempotently.
+- Incident detail groups devices and merged **full-timestamp** slot ranges.
+- Frontend can list (with `dayFrom/dayTo`), filter, inspect, acknowledge, and
+  resolve incidents.
+- Auth + tenant isolation defined and enforced across GCDR and Alarms (§6).
+- Tests exist in each owning repo for the responsibilities above.
+
+## Drawbacks
+
+- New rule type = touch points in GCDR (enum, Zod, bundle serializer, tests) and a
+  new evaluator in the alarms side. Cross-repo coordination (bundle contract).
+- "No data" detection needs a reliable notion of *expected* cadence per metric;
+  `minSamplesPerWindow`/`activeHours` mitigate but require correct config to avoid
+  false positives (a genuinely idle device flagged as a gap).
+- Incident ownership on the alarms side means the panel depends on a second
+  service's API (cross-origin/auth), and enrichment is a server-to-server hop.
+
+## Alternatives considered
+
+1. **`ALARM_THRESHOLD` + `COUNT == 0` over 1h.** Reuses existing type, but overloads
+   `alarmConfig`, fires per-window (noise), has no incident aggregation, and a
+   threshold engine typically evaluates on sample arrival — the wrong trigger for
+   *absence*. Rejected as the primary model; could back a v0 spike.
+2. **Extend `DEVICE_OFFLINE`.** Conflates connectivity with data-presence — a device
+   can be ONLINE yet empty. Rejected.
+3. **GCDR hosts incidents.** Keeps everything in the master-data DB and one API for
+   the frontend, but puts an event-plane concern in GCDR and duplicates what the
+   alarms decision engine already does. Kept as a fallback if cross-service auth
+   for the panel proves heavy.
+
+## Unresolved questions
+
+**Decided in v2 (feedback-v1):**
+- ~~Day rollover policy~~ → auto-`RESOLVED` at midnight (rule tz) only if no device
+  has an ongoing empty run; else stays OPEN (§2).
+- ~~Late-telemetry behavior~~ → may shrink/remove ranges while OPEN; preserves audit
+  after ack (§2).
+- ~~Status model~~ → `OPEN | RESOLVED` + ack metadata (§2, Data model).
+- ~~`activeHours` per device vs rule~~ → v1 rule-level; per-device override deferred.
+- ~~Slot storage format~~ → full ISO timestamps; UI renders `HH:mm`.
+
+**Still open:**
+1. **Exact metric source:** which hourly-consumption aggregation table/feed does
+   Alarms read (goals/tariffs aggregation vs normalized telemetry)? Named source
+   before build (§2 v1 decision narrows this but doesn't pin the table).
+2. **Config storage:** reuse a generic `rules` JSONB config column for
+   `noConsumptionConfig`, or add `no_consumption_config` (§1, §Migrations)?
+3. **Notification default:** panel-only (proposed) vs dispatch via
+   channel/EMAIL_RELAY, per customer/central opt-in?
+4. **Incident ↔ alarm linkage:** should an incident also reference DEVICE_OFFLINE
+   alarms in the same window for context, or stay a pure no-consumption roll-up?
+
+## Rollout / phases
+
+1. **Phase 1 — GCDR:** add `NO_CONSUMPTION` type + config + Zod + bundle
+   serialization + tests; seed one internal rule for a pilot customer (e.g.
+   WestPlaza). No behavior change until the alarms side consumes it.
+2. **Phase 2 — Alarms:** evaluator (bucketing, debounce, merge), `incidents`
+   tables, candidate build + lifecycle, `/incidents` read API + ack/resolve.
+3. **Phase 3 — Frontend:** Incidents panel (day▸central▸device▸slots) against the
+   alarms API + GCDR enrichment.
+4. **Phase 4 — Optional dispatch** of incidents via existing channels.
+
+Each phase is independently shippable; Phase 1 is inert until Phase 2 lands.

--- a/drizzle/migrations/0064_rule_no_consumption.sql
+++ b/drizzle/migrations/0064_rule_no_consumption.sql
@@ -1,0 +1,18 @@
+-- Migration 0064: RFC-0055 — NO_CONSUMPTION rule type (data-absence detection)
+--
+-- Adds the NO_CONSUMPTION value to the rule_type enum and the
+-- no_consumption_config JSONB column on `rules`.
+--
+-- The CHECK constraint that references the new enum value lives in migration
+-- 0065 on purpose: Postgres forbids using a freshly-added enum value in the same
+-- transaction that added it, and the custom runner wraps each file in its own tx.
+--
+-- Additive and safe on an existing database.
+--
+-- NOTE (numbering): prod is baselined through 0063. This number may collide with
+-- other in-flight branches (e.g. PR #20 central-wifi) — reconcile the sequence at
+-- merge time; the runner keys by filename + checksum, so it is not fatal.
+
+ALTER TYPE "public"."rule_type" ADD VALUE IF NOT EXISTS 'NO_CONSUMPTION';
+
+ALTER TABLE "rules" ADD COLUMN IF NOT EXISTS "no_consumption_config" jsonb;

--- a/drizzle/migrations/0065_rule_no_consumption_check.sql
+++ b/drizzle/migrations/0065_rule_no_consumption_check.sql
@@ -1,0 +1,9 @@
+-- Migration 0065: RFC-0055 — NO_CONSUMPTION config CHECK constraint
+--
+-- Separate from 0064 because Postgres cannot use the 'NO_CONSUMPTION' enum value
+-- in the same transaction that added it. Mirrors valid_alarm_config /
+-- valid_sla_config etc.: a NO_CONSUMPTION rule must carry its config.
+
+ALTER TABLE "rules" DROP CONSTRAINT IF EXISTS "valid_no_consumption_config";
+ALTER TABLE "rules" ADD CONSTRAINT "valid_no_consumption_config"
+  CHECK ("type" != 'NO_CONSUMPTION' OR "no_consumption_config" IS NOT NULL);

--- a/scripts/db/ops/rfc0055-seed-no-consumption-moxuara.sql
+++ b/scripts/db/ops/rfc0055-seed-no-consumption-moxuara.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- RFC-0055 (ED-1079) — Curated internal NO_CONSUMPTION rule for Moxuara.
+-- =============================================================================
+-- Detects devices with NO energy-consumption telemetry in a 1h window.
+--
+-- Marked is_internal_support_rule = true so it ships in the alarm bundle's
+-- noConsumptionRules[] section (consumed by the Alarms Orchestrator) WITHOUT
+-- appearing in the customer-facing rules UI. Scope = CUSTOMER, so it covers
+-- every metering device under Moxuara (convention: scope_entity_ids = {customer}).
+--
+-- Idempotent: fixed rule id + ON CONFLICT DO UPDATE. Safe to re-run.
+--
+-- Run (local, Docker Desktop):
+--   docker cp scripts/db/ops/rfc0055-seed-no-consumption-moxuara.sql \
+--     gcdr-db-local:/tmp/seed.sql
+--   docker exec gcdr-db-local psql -U postgres -d db_gcdr -f /tmp/seed.sql
+-- =============================================================================
+
+BEGIN;
+
+-- Drop the earlier throwaway mock (superseded by the curated rule below).
+DELETE FROM rules
+ WHERE id = '9007a272-2f8c-4f33-82b7-3b9ecdf272c8';
+
+INSERT INTO rules (
+  id,
+  tenant_id,
+  customer_id,
+  name,
+  description,
+  type,
+  priority,
+  scope_type,
+  scope_entity_ids,
+  no_consumption_config,
+  status,
+  enabled,
+  is_internal_support_rule
+) VALUES (
+  '55c05500-0055-4055-8055-000000000001',
+  '11111111-1111-1111-1111-111111111111',           -- tenant default
+  '84e0370e-636a-4741-9874-504b5e0b3577',           -- Moxuara
+  'Sem consumo (1h) - Moxuara',
+  'RFC-0055: nenhum dado de consumo de energia recebido na janela de 1h.',
+  'NO_CONSUMPTION',
+  'MEDIUM',
+  'CUSTOMER',
+  ARRAY['84e0370e-636a-4741-9874-504b5e0b3577']::uuid[],
+  '{"metric":"energy_consumption","windowMinutes":60,"minSamplesPerWindow":1,"graceWindows":1,"timezone":"America/Sao_Paulo","activeHours":null}'::jsonb,
+  'ACTIVE',
+  true,
+  true
+)
+ON CONFLICT (id) DO UPDATE SET
+  name                     = EXCLUDED.name,
+  description              = EXCLUDED.description,
+  type                     = EXCLUDED.type,
+  priority                 = EXCLUDED.priority,
+  scope_type               = EXCLUDED.scope_type,
+  scope_entity_ids         = EXCLUDED.scope_entity_ids,
+  no_consumption_config    = EXCLUDED.no_consumption_config,
+  status                   = EXCLUDED.status,
+  enabled                  = EXCLUDED.enabled,
+  is_internal_support_rule = EXCLUDED.is_internal_support_rule,
+  updated_at               = now();
+
+COMMIT;
+
+-- Verification
+SELECT id, name, type, enabled, is_internal_support_rule, scope_type, scope_entity_ids
+  FROM rules
+ WHERE id = '55c05500-0055-4055-8055-000000000001';

--- a/src/app.ts
+++ b/src/app.ts
@@ -95,6 +95,7 @@ import {
   woTicketsController,
   woEventTypesHandler,
   assistantController,
+  enrichmentController,
   // RFC-0036: Device/Work-Order Annotations (polymorphic)
   annotationsController,
 } from './controllers';
@@ -525,6 +526,10 @@ apiV1Router.use('/wo/customers', woCustomersController);
 
 // RFC-0043: GCDR Copiloto (read-only LLM assistant over the WO tools).
 apiV1Router.use('/assistant', authMiddleware, assistantController);
+
+// RFC-0055 (ED-1080): batch entity enrichment for the Alarms Orchestrator.
+// M2M consumer — same auth as the bundle to-verify-service (master key + JWT).
+apiV1Router.use('/enrichment', authMiddleware, enrichmentController);
 
 // Mount API v1 router
 app.use('/api/v1', apiV1Router);

--- a/src/controllers/enrichment.controller.ts
+++ b/src/controllers/enrichment.controller.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { sendSuccess } from '../middleware/response';
+import { enrichmentService } from '../services/EnrichmentService';
+import { EnrichmentResolveSchema } from '../dto/request/EnrichmentDTO';
+
+const router = Router();
+
+/**
+ * RFC-0055 (ED-1080) — Batch-resolve entity IDs to display metadata.
+ *
+ * POST /api/v1/enrichment/resolve
+ * Body: { deviceIds?: string[], centralIds?: string[], customerIds?: string[] }
+ * Returns: { devices: {id -> {name, slaveId, centralId}},
+ *            centrals: {id -> {name}},
+ *            customers: {id -> {name}} }
+ *
+ * Used by the Alarms Orchestrator to hydrate incidents (which store only IDs).
+ * Tenant-scoped; unknown or cross-tenant IDs are simply absent from the maps.
+ */
+router.post('/resolve', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const data = EnrichmentResolveSchema.parse(req.body);
+    const result = await enrichmentService.resolve(tenantId, data);
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -80,6 +80,8 @@ export { default as customerIntegrationsController } from './customer-integratio
 
 // RFC-0043: GCDR Copiloto (assistant)
 export { default as assistantController } from './assistant.controller';
+// RFC-0055 (ED-1080): batch entity enrichment for the Alarms Orchestrator
+export { default as enrichmentController } from './enrichment.controller';
 
 // RFC-0047: Generic Entity Registry
 export { default as entitiesController, entityTypesRouter as entityTypesController } from './entities.controller';

--- a/src/domain/entities/AlarmBundle.ts
+++ b/src/domain/entities/AlarmBundle.ts
@@ -1,4 +1,17 @@
-import { RulePriority, ComparisonOperator, AggregationType, MetricDomain } from './Rule';
+import { RulePriority, ComparisonOperator, AggregationType, MetricDomain, NoConsumptionConfig } from './Rule';
+
+/**
+ * RFC-0055 — No-consumption (data-absence) rule in the bundle. Additive section
+ * consumed by the Alarms Orchestrator (not Node-RED threshold eval). Carries the
+ * scope (devices/central/customer) and the detection config.
+ */
+export interface NoConsumptionBundleRule {
+  id: string;
+  name: string;
+  priority: RulePriority;
+  scope: { type: string; entityIds: string[] };
+  config: NoConsumptionConfig;
+}
 
 /**
  * Alarm Rule in compact format for the bundle
@@ -86,6 +99,11 @@ export interface AlarmRulesBundle {
    * Catalog of all rules (referenced by ID to avoid duplication)
    */
   rules: Record<string, BundleAlarmRule>;
+
+  /**
+   * RFC-0055 — no-consumption rules (present only when the customer has any).
+   */
+  noConsumptionRules?: NoConsumptionBundleRule[];
 }
 
 /**
@@ -185,4 +203,6 @@ export interface SimpleAlarmRulesBundle {
   meta: SimpleBundleMeta;
   deviceIndex: Record<string, SimpleDeviceMapping>;
   rules: Record<string, SimpleBundleAlarmRule>;
+  // RFC-0055 — no-consumption rules (present only when the customer has any).
+  noConsumptionRules?: NoConsumptionBundleRule[];
 }

--- a/src/domain/entities/Rule.ts
+++ b/src/domain/entities/Rule.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, EntityStatus } from '../../shared/types';
 
-export type RuleType = 'ALARM_THRESHOLD' | 'SLA' | 'ESCALATION' | 'MAINTENANCE_WINDOW' | 'DEVICE_OFFLINE';
+export type RuleType = 'ALARM_THRESHOLD' | 'SLA' | 'ESCALATION' | 'MAINTENANCE_WINDOW' | 'DEVICE_OFFLINE' | 'NO_CONSUMPTION';
 export type RulePriority = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
 export type ComparisonOperator = 'GT' | 'GTE' | 'LT' | 'LTE' | 'EQ' | 'NEQ' | 'BETWEEN' | 'OUTSIDE' | 'UNCHANGED';
 export type AggregationType = 'AVG' | 'MIN' | 'MAX' | 'SUM' | 'COUNT' | 'LAST';
@@ -145,6 +145,19 @@ export interface MaintenanceWindowConfig {
   affectedRules?: string[]; // Rule IDs to suppress, empty means all
 }
 
+// No-Consumption Configuration (RFC-0055) — data-absence detection.
+// A device in scope must produce a non-empty consumption slot every
+// `windowMinutes`. This is distinct from DEVICE_OFFLINE (connectivity): a device
+// can be ONLINE yet report empty consumption slots.
+export interface NoConsumptionConfig {
+  metric: MetricDomain;        // consumption metric that must be present (e.g. 'energy_consumption')
+  windowMinutes: number;       // slot size; v1 accepts only 60
+  minSamplesPerWindow: number; // a slot is "filled" with >= this many non-null samples (default 1)
+  graceWindows: number;        // consecutive empty windows tolerated before it counts (default 1)
+  timezone: string;            // bucket alignment + day categorization (required)
+  activeHours?: { start: string; end: string } | null; // HH:mm local; only evaluate inside these hours
+}
+
 // Alarm lifecycle actions (RFC-0024)
 export type AlarmAction = 'OPEN' | 'ACK' | 'ESCALATE' | 'SNOOZE' | 'CLOSE' | 'STATE_HISTORY';
 
@@ -247,6 +260,7 @@ export interface Rule extends BaseEntity {
   slaConfig?: SLAConfig;
   escalationConfig?: EscalationConfig;
   maintenanceConfig?: MaintenanceWindowConfig;
+  noConsumptionConfig?: NoConsumptionConfig;
 
   // Notification settings — delivery channels (webhook/SMS config)
   notificationChannels?: NotificationChannel[];
@@ -299,4 +313,8 @@ export function isEscalationRule(rule: Rule): rule is Rule & { escalationConfig:
 
 export function isMaintenanceRule(rule: Rule): rule is Rule & { maintenanceConfig: MaintenanceWindowConfig } {
   return rule.type === 'MAINTENANCE_WINDOW' && !!rule.maintenanceConfig;
+}
+
+export function isNoConsumptionRule(rule: Rule): rule is Rule & { noConsumptionConfig: NoConsumptionConfig } {
+  return rule.type === 'NO_CONSUMPTION' && !!rule.noConsumptionConfig;
 }

--- a/src/dto/request/EnrichmentDTO.ts
+++ b/src/dto/request/EnrichmentDTO.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * RFC-0055 (ED-1080) — Enrichment / batch-resolve request.
+ *
+ * The Alarms Orchestrator persists incidents referencing only IDs (deviceId,
+ * centralId, customerId). This endpoint lets it hydrate those IDs into
+ * human-readable names (+ slaveId/centralId for devices) in a single call,
+ * scoped to the caller's tenant. All three lists are optional; unknown IDs are
+ * simply absent from the response maps.
+ */
+
+const MAX_IDS = 500;
+
+const idList = z
+  .array(z.string().uuid())
+  .max(MAX_IDS, `A maximum of ${MAX_IDS} ids per type is allowed`)
+  .optional()
+  .default([]);
+
+export const EnrichmentResolveSchema = z
+  .object({
+    deviceIds: idList,
+    centralIds: idList,
+    customerIds: idList,
+  })
+  .refine(
+    (data) =>
+      data.deviceIds.length > 0 ||
+      data.centralIds.length > 0 ||
+      data.customerIds.length > 0,
+    { message: 'At least one of deviceIds, centralIds or customerIds must be provided' }
+  );
+
+export type EnrichmentResolveInput = z.infer<typeof EnrichmentResolveSchema>;

--- a/src/dto/request/RuleDTO.ts
+++ b/src/dto/request/RuleDTO.ts
@@ -1,7 +1,21 @@
 import { z } from 'zod';
 
 // Enums
-const RuleTypeSchema = z.enum(['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE']);
+const RuleTypeSchema = z.enum(['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE', 'NO_CONSUMPTION']);
+
+// RFC-0055 — no-consumption (data-absence) rule config. v1 restricts windowMinutes
+// to 60 and metric to the consumption domains; timezone is required (never defaulted).
+const NoConsumptionConfigSchema = z.object({
+  metric: z.enum(['energy_consumption', 'water_flow']),
+  windowMinutes: z.literal(60).default(60),
+  minSamplesPerWindow: z.number().int().positive().default(1),
+  graceWindows: z.number().int().min(0).default(1),
+  timezone: z.string().min(1),
+  activeHours: z
+    .object({ start: z.string(), end: z.string() })
+    .nullable()
+    .optional(),
+});
 const RulePrioritySchema = z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
 const ComparisonOperatorSchema = z.enum(['GT', 'GTE', 'LT', 'LTE', 'EQ', 'NEQ', 'BETWEEN', 'OUTSIDE']);
 const ScopTypeSchema = z.enum(['GLOBAL', 'CUSTOMER', 'ASSET', 'DEVICE']);
@@ -204,6 +218,7 @@ export const CreateRuleSchema = z.object({
   slaConfig: SLAConfigSchema.optional(),
   escalationConfig: EscalationConfigSchema.optional(),
   maintenanceConfig: MaintenanceWindowConfigSchema.optional(),
+  noConsumptionConfig: NoConsumptionConfigSchema.optional(),
   notificationChannels: z.array(NotificationChannelSchema).optional(),
   notifications: RuleNotificationsSchema.optional(),
   scopeEntityOverrides: z.record(z.string().uuid(), RuleValueOverrideSchema).optional(),
@@ -226,6 +241,8 @@ export const CreateRuleSchema = z.object({
         return !!data.maintenanceConfig;
       case 'DEVICE_OFFLINE':
         return !!data.alarmConfig; // alarmConfig carries schedule + centralId
+      case 'NO_CONSUMPTION':
+        return !!data.noConsumptionConfig;
       default:
         return false;
     }
@@ -245,6 +262,7 @@ export const UpdateRuleSchema = z.object({
   slaConfig: SLAConfigSchema.optional(),
   escalationConfig: EscalationConfigSchema.optional(),
   maintenanceConfig: MaintenanceWindowConfigSchema.optional(),
+  noConsumptionConfig: NoConsumptionConfigSchema.optional(),
   notificationChannels: z.array(NotificationChannelSchema).optional(),
   notifications: RuleNotificationsSchema.optional(),
   scopeEntityOverrides: z.record(z.string().uuid(), RuleValueOverrideSchema).optional(),

--- a/src/infrastructure/database/drizzle/schema.ts
+++ b/src/infrastructure/database/drizzle/schema.ts
@@ -53,7 +53,7 @@ export const connectivityStatusEnum = pgEnum('connectivity_status', ['ONLINE', '
 
 export const partnerStatusEnum = pgEnum('partner_status', ['PENDING', 'APPROVED', 'ACTIVE', 'SUSPENDED', 'REJECTED']);
 
-export const ruleTypeEnum = pgEnum('rule_type', ['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE']);
+export const ruleTypeEnum = pgEnum('rule_type', ['ALARM_THRESHOLD', 'SLA', 'ESCALATION', 'MAINTENANCE_WINDOW', 'DEVICE_OFFLINE', 'NO_CONSUMPTION']);
 
 export const rulePriorityEnum = pgEnum('rule_priority', ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
 
@@ -683,6 +683,7 @@ export const rules = pgTable('rules', {
   slaConfig: jsonb('sla_config'),
   escalationConfig: jsonb('escalation_config'),
   maintenanceConfig: jsonb('maintenance_config'),
+  noConsumptionConfig: jsonb('no_consumption_config'),  // RFC-0055
 
   // Notification settings
   notificationChannels: jsonb('notification_channels').notNull().default([]),
@@ -744,6 +745,10 @@ export const rules = pgTable('rules', {
   validMaintenanceConfig: check(
     'valid_maintenance_config',
     sql`${table.type} != 'MAINTENANCE_WINDOW' OR ${table.maintenanceConfig} IS NOT NULL`
+  ),
+  validNoConsumptionConfig: check(   // RFC-0055
+    'valid_no_consumption_config',
+    sql`${table.type} != 'NO_CONSUMPTION' OR ${table.noConsumptionConfig} IS NOT NULL`
   ),
   // valid_scope_entity constraint removed — DEVICE scope with empty entityIds is valid
   // (intermediate state when user clears devices before adding new ones). See migration 0015.

--- a/src/repositories/CentralRepository.ts
+++ b/src/repositories/CentralRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { db, schema } from '../infrastructure/database/drizzle/db';
 import { Central, ConnectionStatus, createDefaultCentralConfig, createDefaultCentralStats } from '../domain/entities/Central';
 import { CreateCentralDTO, UpdateCentralDTO, ListCentralsDTO } from '../dto/request/CentralDTO';
@@ -53,6 +53,16 @@ export class CentralRepository implements ICentralRepository {
       .limit(1);
 
     return result ? this.mapToEntity(result) : null;
+  }
+
+  /** RFC-0055 — batch lookup for the enrichment endpoint. */
+  async findByIds(tenantId: string, ids: string[]): Promise<Central[]> {
+    if (ids.length === 0) return [];
+    const rows = await db
+      .select()
+      .from(centrals)
+      .where(and(eq(centrals.tenantId, tenantId), inArray(centrals.id, ids)));
+    return rows.map((r) => this.mapToEntity(r));
   }
 
   async getBySerialNumber(tenantId: string, serialNumber: string): Promise<Central | null> {

--- a/src/repositories/CustomerRepository.ts
+++ b/src/repositories/CustomerRepository.ts
@@ -72,6 +72,16 @@ export class CustomerRepository implements ICustomerRepository {
     return result ? this.mapToEntity(result) : null;
   }
 
+  /** RFC-0055 — batch lookup for the enrichment endpoint. */
+  async findByIds(tenantId: string, ids: string[]): Promise<Customer[]> {
+    if (ids.length === 0) return [];
+    const rows = await db
+      .select()
+      .from(customers)
+      .where(and(eq(customers.tenantId, tenantId), inArray(customers.id, ids)));
+    return rows.map((r) => this.mapToEntity(r));
+  }
+
   async getByCode(tenantId: string, code: string): Promise<Customer | null> {
     const [result] = await db
       .select()

--- a/src/repositories/RuleRepository.ts
+++ b/src/repositories/RuleRepository.ts
@@ -33,6 +33,7 @@ export class RuleRepository implements IRuleRepository {
       slaConfig: data.slaConfig || null,
       escalationConfig: data.escalationConfig || null,
       maintenanceConfig: data.maintenanceConfig || null,
+      noConsumptionConfig: data.noConsumptionConfig || null,
       notificationChannels: data.notificationChannels || [],
       notifications: data.notifications || null,
       scopeProfiles: data.scope.scopeProfiles ?? null,
@@ -102,6 +103,7 @@ export class RuleRepository implements IRuleRepository {
     if (data.slaConfig !== undefined) updateData.slaConfig = data.slaConfig;
     if (data.escalationConfig !== undefined) updateData.escalationConfig = data.escalationConfig;
     if (data.maintenanceConfig !== undefined) updateData.maintenanceConfig = data.maintenanceConfig;
+    if (data.noConsumptionConfig !== undefined) updateData.noConsumptionConfig = data.noConsumptionConfig;
 
     const [result] = await db
       .update(rules)
@@ -405,6 +407,7 @@ export class RuleRepository implements IRuleRepository {
       slaConfig: row.slaConfig as Rule['slaConfig'],
       escalationConfig: row.escalationConfig as Rule['escalationConfig'],
       maintenanceConfig: row.maintenanceConfig as Rule['maintenanceConfig'],
+      noConsumptionConfig: row.noConsumptionConfig as Rule['noConsumptionConfig'],
       notificationChannels: row.notificationChannels as Rule['notificationChannels'],
       notifications: row.notifications as RuleNotifications ?? undefined,
       scopeProfiles: (row.scopeProfiles && row.scopeProfiles.length > 0) ? row.scopeProfiles as string[] : undefined,

--- a/src/services/AlarmBundleService.ts
+++ b/src/services/AlarmBundleService.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto';
-import { Rule, isAlarmRule } from '../domain/entities/Rule';
+import { Rule, isAlarmRule, isNoConsumptionRule } from '../domain/entities/Rule';
 import { Device } from '../domain/entities/Device';
 import { Customer } from '../domain/entities/Customer';
 import {
@@ -14,6 +14,7 @@ import {
   SimpleDeviceMapping,
   SimpleBundleMeta,
   RuleIdEntry,
+  NoConsumptionBundleRule,
 } from '../domain/entities/AlarmBundle';
 import { RuleRepository } from '../repositories/RuleRepository';
 import { DeviceRepository } from '../repositories/DeviceRepository';
@@ -137,8 +138,15 @@ export class AlarmBundleService {
       alarmRules = alarmRules.filter(r => r.enabled);
     }
 
+    // RFC-0055: collect no-consumption rules separately (internal by design, so
+    // not caught by the alarm-threshold filter). Respect the disabled filter.
+    let noConsumptionRules = allRules.filter(isNoConsumptionRule);
+    if (!includeDisabled) {
+      noConsumptionRules = noConsumptionRules.filter(r => r.enabled);
+    }
+
     // Build the bundle structure
-    const bundle = this.buildBundle(customer, devices, alarmRules, tenantId);
+    const bundle = this.buildBundle(customer, devices, alarmRules, tenantId, noConsumptionRules);
 
     // Sign the bundle
     bundle.meta.signature = this.signBundle(bundle);
@@ -209,8 +217,15 @@ export class AlarmBundleService {
       alarmRules = alarmRules.filter(r => r.enabled);
     }
 
+    // RFC-0055: collect no-consumption rules for the target customers (internal
+    // by design, so not caught by the alarm-threshold filter). Respect disabled.
+    let noConsumptionRules = allRules.filter(isNoConsumptionRule);
+    if (!includeDisabled) {
+      noConsumptionRules = noConsumptionRules.filter(r => r.enabled);
+    }
+
     // Build simplified bundle
-    const bundle = this.buildSimplifiedBundle(customer, devices, alarmRules, tenantId);
+    const bundle = this.buildSimplifiedBundle(customer, devices, alarmRules, tenantId, noConsumptionRules);
 
     // Sign the bundle
     bundle.meta.signature = this.signSimplifiedBundle(bundle);
@@ -373,7 +388,8 @@ export class AlarmBundleService {
     customer: Customer,
     devices: Device[],
     rules: Rule[],
-    tenantId: string
+    tenantId: string,
+    noConsumptionRules: Rule[] = []
   ): SimpleAlarmRulesBundle {
     const generatedAt = new Date().toISOString();
 
@@ -479,8 +495,15 @@ export class AlarmBundleService {
     // Merge variant rules (overridden) into the catalog
     Object.assign(rulesCatalog, variantRules);
 
+    // RFC-0055: additive no-consumption section (present only when non-empty).
+    const ncRules = this.toNoConsumptionBundleRules(noConsumptionRules);
+
     // Calculate version hash from content
-    const bundleContent = { deviceIndex, rules: rulesCatalog };
+    const bundleContent = {
+      deviceIndex,
+      rules: rulesCatalog,
+      ...(ncRules.length ? { noConsumptionRules: ncRules } : {}),
+    };
     const version = this.calculateVersionHash(bundleContent);
 
     const meta: SimpleBundleMeta = {
@@ -501,7 +524,24 @@ export class AlarmBundleService {
       meta,
       deviceIndex,
       rules: rulesCatalog,
+      ...(ncRules.length ? { noConsumptionRules: ncRules } : {}),
     };
+  }
+
+  /**
+   * RFC-0055 — map NO_CONSUMPTION rules to the bundle's additive section.
+   */
+  private toNoConsumptionBundleRules(rules: Rule[]): NoConsumptionBundleRule[] {
+    return rules.filter(isNoConsumptionRule).map((r) => ({
+      id: r.id,
+      name: r.name,
+      priority: r.priority,
+      scope: {
+        type: r.scope.type,
+        entityIds: r.scope.entityIds ?? (r.scope.entityId ? [r.scope.entityId] : []),
+      },
+      config: r.noConsumptionConfig,
+    }));
   }
 
   /**
@@ -595,7 +635,8 @@ export class AlarmBundleService {
     customer: Customer,
     devices: Device[],
     rules: Rule[],
-    tenantId: string
+    tenantId: string,
+    noConsumptionRules: Rule[] = []
   ): AlarmRulesBundle {
     const generatedAt = new Date().toISOString();
 
@@ -671,11 +712,15 @@ export class AlarmBundleService {
       };
     }
 
+    // RFC-0055: additive no-consumption section (present only when non-empty).
+    const ncRules = this.toNoConsumptionBundleRules(noConsumptionRules);
+
     // Create bundle without signature (will be added after)
     const bundleContent = {
       rulesByDeviceType,
       deviceIndex,
       rules: rulesCatalog,
+      ...(ncRules.length ? { noConsumptionRules: ncRules } : {}),
     };
 
     // Calculate version hash from content

--- a/src/services/EnrichmentService.ts
+++ b/src/services/EnrichmentService.ts
@@ -1,0 +1,74 @@
+import { deviceRepository } from '../repositories/DeviceRepository';
+import { centralRepository } from '../repositories/CentralRepository';
+import { customerRepository } from '../repositories/CustomerRepository';
+import { EnrichmentResolveInput } from '../dto/request/EnrichmentDTO';
+
+/**
+ * RFC-0055 (ED-1080) — Enrichment service.
+ *
+ * Batch-resolves entity IDs to display metadata so the Alarms Orchestrator can
+ * hydrate incidents (which store only IDs). Everything is scoped to the caller's
+ * tenant; IDs not found (or belonging to another tenant) are omitted.
+ */
+
+export interface EnrichedDevice {
+  id: string;
+  name: string;
+  slaveId: number | null;
+  centralId: string | null;
+}
+
+export interface EnrichedCentral {
+  id: string;
+  name: string;
+}
+
+export interface EnrichedCustomer {
+  id: string;
+  name: string;
+}
+
+export interface EnrichmentResult {
+  devices: Record<string, EnrichedDevice>;
+  centrals: Record<string, EnrichedCentral>;
+  customers: Record<string, EnrichedCustomer>;
+}
+
+export class EnrichmentService {
+  async resolve(tenantId: string, input: EnrichmentResolveInput): Promise<EnrichmentResult> {
+    // Dedupe ids before hitting the DB.
+    const deviceIds = [...new Set(input.deviceIds)];
+    const centralIds = [...new Set(input.centralIds)];
+    const customerIds = [...new Set(input.customerIds)];
+
+    const [deviceRows, centralRows, customerRows] = await Promise.all([
+      deviceRepository.findByIds(tenantId, deviceIds),
+      centralRepository.findByIds(tenantId, centralIds),
+      customerRepository.findByIds(tenantId, customerIds),
+    ]);
+
+    const devices: Record<string, EnrichedDevice> = {};
+    for (const d of deviceRows) {
+      devices[d.id] = {
+        id: d.id,
+        name: d.name,
+        slaveId: d.slaveId ?? null,
+        centralId: d.centralId ?? null,
+      };
+    }
+
+    const centrals: Record<string, EnrichedCentral> = {};
+    for (const c of centralRows) {
+      centrals[c.id] = { id: c.id, name: c.name };
+    }
+
+    const customers: Record<string, EnrichedCustomer> = {};
+    for (const c of customerRows) {
+      customers[c.id] = { id: c.id, name: c.name };
+    }
+
+    return { devices, centrals, customers };
+  }
+}
+
+export const enrichmentService = new EnrichmentService();

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -217,6 +217,7 @@ export class RuleService {
       ESCALATION: 0,
       MAINTENANCE_WINDOW: 0,
       DEVICE_OFFLINE: 0,
+      NO_CONSUMPTION: 0,
     };
 
     const byPriority: Record<string, number> = {

--- a/tests/unit/dto/EnrichmentDTO.test.ts
+++ b/tests/unit/dto/EnrichmentDTO.test.ts
@@ -1,0 +1,38 @@
+import { EnrichmentResolveSchema } from '../../../src/dto/request/EnrichmentDTO';
+
+const UUID_A = '11111111-1111-1111-1111-111111111111';
+const UUID_B = '22222222-2222-2222-2222-222222222222';
+
+describe('EnrichmentDTO — resolve (RFC-0055 / ED-1080)', () => {
+  it('accepts a request with deviceIds only and defaults the other lists to []', () => {
+    const parsed = EnrichmentResolveSchema.parse({ deviceIds: [UUID_A, UUID_B] });
+    expect(parsed.deviceIds).toEqual([UUID_A, UUID_B]);
+    expect(parsed.centralIds).toEqual([]);
+    expect(parsed.customerIds).toEqual([]);
+  });
+
+  it('accepts a mixed request', () => {
+    const parsed = EnrichmentResolveSchema.parse({
+      deviceIds: [UUID_A],
+      centralIds: [UUID_B],
+      customerIds: [UUID_A],
+    });
+    expect(parsed.centralIds).toEqual([UUID_B]);
+  });
+
+  it('rejects an empty request (no ids at all)', () => {
+    expect(() => EnrichmentResolveSchema.parse({})).toThrow();
+    expect(() =>
+      EnrichmentResolveSchema.parse({ deviceIds: [], centralIds: [], customerIds: [] })
+    ).toThrow();
+  });
+
+  it('rejects non-uuid ids', () => {
+    expect(() => EnrichmentResolveSchema.parse({ deviceIds: ['not-a-uuid'] })).toThrow();
+  });
+
+  it('rejects more than 500 ids of a single type', () => {
+    const many = Array.from({ length: 501 }, () => UUID_A);
+    expect(() => EnrichmentResolveSchema.parse({ deviceIds: many })).toThrow();
+  });
+});

--- a/tests/unit/dto/RuleDTO.noConsumption.test.ts
+++ b/tests/unit/dto/RuleDTO.noConsumption.test.ts
@@ -1,0 +1,67 @@
+import { CreateRuleSchema } from '../../../src/dto/request/RuleDTO';
+
+// RFC-0055 — NO_CONSUMPTION rule type validation.
+const baseRule = {
+  customerId: 'cust-1',
+  name: 'No-consumption energy (1h)',
+  type: 'NO_CONSUMPTION' as const,
+  scope: { type: 'CUSTOMER' as const, entityId: '11111111-1111-1111-1111-111111111111' },
+};
+
+const validConfig = {
+  metric: 'energy_consumption' as const,
+  timezone: 'America/Sao_Paulo',
+};
+
+describe('RuleDTO — NO_CONSUMPTION (RFC-0055)', () => {
+  it('accepts a valid NO_CONSUMPTION rule and applies config defaults', () => {
+    const parsed = CreateRuleSchema.parse({ ...baseRule, noConsumptionConfig: validConfig });
+    expect(parsed.type).toBe('NO_CONSUMPTION');
+    expect(parsed.noConsumptionConfig).toMatchObject({
+      metric: 'energy_consumption',
+      windowMinutes: 60,
+      minSamplesPerWindow: 1,
+      graceWindows: 1,
+      timezone: 'America/Sao_Paulo',
+    });
+  });
+
+  it('rejects NO_CONSUMPTION without noConsumptionConfig (config must match type)', () => {
+    expect(() => CreateRuleSchema.parse({ ...baseRule })).toThrow();
+  });
+
+  it('rejects an unknown metric', () => {
+    expect(() =>
+      CreateRuleSchema.parse({
+        ...baseRule,
+        noConsumptionConfig: { ...validConfig, metric: 'temperature' },
+      })
+    ).toThrow();
+  });
+
+  it('requires timezone', () => {
+    expect(() =>
+      CreateRuleSchema.parse({
+        ...baseRule,
+        noConsumptionConfig: { metric: 'energy_consumption' },
+      })
+    ).toThrow();
+  });
+
+  it('rejects windowMinutes other than 60 (v1)', () => {
+    expect(() =>
+      CreateRuleSchema.parse({
+        ...baseRule,
+        noConsumptionConfig: { ...validConfig, windowMinutes: 30 },
+      })
+    ).toThrow();
+  });
+
+  it('accepts an explicit activeHours window', () => {
+    const parsed = CreateRuleSchema.parse({
+      ...baseRule,
+      noConsumptionConfig: { ...validConfig, activeHours: { start: '06:00', end: '22:00' } },
+    });
+    expect(parsed.noConsumptionConfig?.activeHours).toEqual({ start: '06:00', end: '22:00' });
+  });
+});


### PR DESCRIPTION
Single umbrella PR for **RFC-0055 — No-Consumption Detection & Incidents Panel** (backend side). Feature branches merge into `rfc-0055`.

Epic: **ED-1073** · RFC: `docs/rfcs/RFC-0055-No-Consumption-Incidents.md`

## Included (ED-1078)
- New internal rule type **`NO_CONSUMPTION`** (data-absence; distinct from `DEVICE_OFFLINE`).
- Entity `NoConsumptionConfig` + `isNoConsumptionRule` guard.
- Zod `NoConsumptionConfigSchema` (consumption metric, `windowMinutes=60` v1, `minSamples`/`graceWindows` defaults, **required timezone**, `activeHours`) + create/update wiring + type↔config refine.
- Schema: `rule_type` enum value, `no_consumption_config` jsonb column, `valid_no_consumption_config` check.
- Repository mapping + `RuleService` statistics.
- Migrations **0064** (enum + column) and **0065** (check — separate tx per the PG new-enum-value rule).
- Unit tests (6) — all green. Typecheck clean.

## Deferred (follow-ups, tracked)
- **Bundle serialization** of `NO_CONSUMPTION` (ED-1081) — depends on the Alarms contract (spike **ED-1074**). The current bundle builder is threshold-only.
- Enrichment endpoint (ED-1080), internal-rule admin/seed (ED-1079), authorization (ED-1089).

## Migration numbering
Prod baselined through `0063`. `0064/0065` may collide with other in-flight branches (e.g. PR #20) — reconcile the sequence at merge time (runner keys by filename + checksum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
