### PR TITLE
fix(bundle): forward NO_CONSUMPTION rules to Alarms via to-verify-service (RFC-0055)

### DIFF
--- a/src/controllers/rules.controller.ts
+++ b/src/controllers/rules.controller.ts
@@ -16,6 +16,9 @@ import { sendSuccess, sendCreated, sendNoContent, logEvent } from '../middleware
 import { ValidationError } from '../shared/errors/AppError';
 import { EventType } from '../shared/types';
 
+const ERR_RULE_ID_REQUIRED = 'Rule ID is required';
+const ERR_CUSTOMER_ID_REQUIRED = 'Customer ID is required';
+
 const router = Router();
 
 /**
@@ -208,7 +211,7 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
     const { id } = req.params;
 
     if (!id) {
-      throw new ValidationError('Rule ID is required');
+      throw new ValidationError(ERR_RULE_ID_REQUIRED);
     }
 
     if (!UUID_REGEX.test(id)) {
@@ -241,7 +244,7 @@ router.patch('/:id',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Rule ID is required');
+        throw new ValidationError(ERR_RULE_ID_REQUIRED);
       }
 
       if (!UUID_REGEX.test(id)) {
@@ -275,7 +278,7 @@ router.put('/:id',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Rule ID is required');
+        throw new ValidationError(ERR_RULE_ID_REQUIRED);
       }
 
       if (!UUID_REGEX.test(id)) {
@@ -361,7 +364,7 @@ router.delete('/:id',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Rule ID is required');
+        throw new ValidationError(ERR_RULE_ID_REQUIRED);
       }
 
       if (!UUID_REGEX.test(id)) {
@@ -393,7 +396,7 @@ router.post('/:id/toggle',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Rule ID is required');
+        throw new ValidationError(ERR_RULE_ID_REQUIRED);
       }
 
       const data = ToggleRuleSchema.parse(req.body);
@@ -422,7 +425,7 @@ router.post('/:id/trigger',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Rule ID is required');
+        throw new ValidationError(ERR_RULE_ID_REQUIRED);
       }
 
       const { count, triggeredAt } = TriggerRuleSchema.parse(req.body ?? {});
@@ -444,7 +447,7 @@ export const listByCustomerHandler = async (req: Request, res: Response, next: N
     const { customerId } = req.params;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     const params = ListRulesParamsSchema.parse({ ...req.query, customerId });
@@ -467,7 +470,7 @@ export const listInternalSupportRulesHandler = async (req: Request, res: Respons
     const { customerId } = req.params;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     const result = await ruleService.list(tenantId, {
@@ -512,7 +515,7 @@ export const getAlarmBundleHandler = async (req: Request, res: Response, next: N
     const { domain, deviceType, includeDisabled } = req.query;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     // Check for conditional request (If-None-Match header)
@@ -589,7 +592,7 @@ export const getSimplifiedAlarmBundleHandler = async (req: Request, res: Respons
     const clientVersionId = req.headers['x-version-id'] as string | undefined;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     // Validate X-Central-Id if provided
@@ -700,7 +703,7 @@ export const getAlarmBundleVerifyHandler = async (req: Request, res: Response, n
     const centralId = req.headers['x-central-id'] as string | undefined;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     const bundle = await alarmBundleService.verifyBundle({
@@ -716,6 +719,12 @@ export const getAlarmBundleVerifyHandler = async (req: Request, res: Response, n
       versionId: bundle.meta.version,
       deviceIndex: bundle.deviceIndex,
       rules: bundle.rules,
+      // RFC-0055: forward NO_CONSUMPTION rules to the Alarms Orchestrator (the
+      // consumer of to-verify-service). verifyBundle already builds them; the
+      // handler previously dropped them, so the no-consumption evaluator never
+      // received any rule. Included only when present → byte-identical bundle
+      // for customers without NC rules. NOT exposed on /simple (Node-RED).
+      ...(bundle.noConsumptionRules?.length ? { noConsumptionRules: bundle.noConsumptionRules } : {}),
     }, 200, requestId);
   } catch (err) {
     next(err);
@@ -733,7 +742,7 @@ export const invalidateAlarmBundleCacheHandler = async (req: Request, res: Respo
     const { customerId } = req.params;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     alarmBundleService.invalidateCache(tenantId, customerId, {
@@ -760,7 +769,7 @@ export const getAlarmBundleVersionsHandler = async (req: Request, res: Response,
     const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 20;
 
     if (!customerId) {
-      throw new ValidationError('Customer ID is required');
+      throw new ValidationError(ERR_CUSTOMER_ID_REQUIRED);
     }
 
     const versions = await alarmBundleService.getVersionHistory(tenantId, customerId, limit);

--- a/tests/unit/controllers/rules.verify.test.ts
+++ b/tests/unit/controllers/rules.verify.test.ts
@@ -1,0 +1,95 @@
+import type { Request, Response } from 'express';
+import { getAlarmBundleVerifyHandler } from '../../../src/controllers/rules.controller';
+import { alarmBundleService } from '../../../src/services/AlarmBundleService';
+
+// RFC-0055 — the Alarms Orchestrator consumes /alarm-rules/bundle/to-verify-service.
+// verifyBundle already builds noConsumptionRules; the handler must forward them
+// (and only them — not on /simple, which is Node-RED). These tests pin that the
+// field is passed through when present and omitted when absent.
+
+jest.mock('../../../src/services/AlarmBundleService', () => ({
+  alarmBundleService: { verifyBundle: jest.fn() },
+}));
+
+const verifyBundleMock = alarmBundleService.verifyBundle as jest.Mock;
+
+interface VerifyData {
+  versionId: string;
+  deviceIndex: unknown;
+  rules: unknown;
+  noConsumptionRules?: unknown[];
+}
+
+function mockRes(): { res: Response; json: jest.Mock } {
+  const json = jest.fn();
+  const status = jest.fn();
+  const set = jest.fn();
+  const res = { status, json, set } as unknown as Response;
+  status.mockReturnValue(res);
+  json.mockReturnValue(res);
+  set.mockReturnValue(res);
+  return { res, json };
+}
+
+function mockReq(): Request {
+  return {
+    context: { tenantId: 't-1', requestId: 'req-1' },
+    params: { customerId: '84e0370e-636a-4741-9874-504b5e0b3577' },
+    query: {},
+    headers: {},
+  } as unknown as Request;
+}
+
+const baseBundle = {
+  meta: { version: 'v-1' },
+  deviceIndex: { 'dev-1': { deviceName: 'x' } },
+  rules: { 'rule-1': { id: 'rule-1' } },
+};
+
+function dataFrom(json: jest.Mock): VerifyData {
+  return (json.mock.calls[0][0] as { data: VerifyData }).data;
+}
+
+describe('getAlarmBundleVerifyHandler — RFC-0055 noConsumptionRules on to-verify-service', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('forwards noConsumptionRules to the Alarms consumer when present', async () => {
+    const nc = [
+      {
+        id: 'nc-1',
+        name: 'Sem consumo (1h)',
+        priority: 'MEDIUM',
+        scope: { type: 'CUSTOMER', entityIds: ['84e0370e-636a-4741-9874-504b5e0b3577'] },
+        config: { metric: 'energy_consumption', windowMinutes: 60 },
+      },
+    ];
+    verifyBundleMock.mockResolvedValue({ ...baseBundle, noConsumptionRules: nc });
+
+    const { res, json } = mockRes();
+    await getAlarmBundleVerifyHandler(mockReq(), res, jest.fn());
+
+    const data = dataFrom(json);
+    expect(data.noConsumptionRules).toEqual(nc);
+    expect(data.rules).toEqual(baseBundle.rules);
+    expect(data.deviceIndex).toEqual(baseBundle.deviceIndex);
+    expect(data.versionId).toBe('v-1');
+  });
+
+  it('omits noConsumptionRules when the customer has none (empty array)', async () => {
+    verifyBundleMock.mockResolvedValue({ ...baseBundle, noConsumptionRules: [] });
+
+    const { res, json } = mockRes();
+    await getAlarmBundleVerifyHandler(mockReq(), res, jest.fn());
+
+    expect(dataFrom(json)).not.toHaveProperty('noConsumptionRules');
+  });
+
+  it('omits noConsumptionRules when the field is absent', async () => {
+    verifyBundleMock.mockResolvedValue({ ...baseBundle });
+
+    const { res, json } = mockRes();
+    await getAlarmBundleVerifyHandler(mockReq(), res, jest.fn());
+
+    expect(dataFrom(json)).not.toHaveProperty('noConsumptionRules');
+  });
+});


### PR DESCRIPTION
## Problem

The Alarms Orchestrator consumes the bundle via `GET /customers/:id/alarm-rules/bundle/to-verify-service` (`gcdr.client.ts`). The GCDR handler (`getAlarmBundleVerifyHandler`) built the bundle with `verifyBundle(...)` — which **already computes `noConsumptionRules`** — but returned only `{ versionId, deviceIndex, rules }`, **dropping `noConsumptionRules`**.

Result: even with a seeded `NO_CONSUMPTION` rule present in the bundle, the Alarms no-consumption evaluator received **zero** rules → RFC-0055 §8 was silently not delivered.

## Fix

- Forward `bundle.noConsumptionRules` on `to-verify-service`, **only when non-empty** (byte-identical bundle for customers without NC rules).
- **Not** exposed on `/simple` (Node-RED, which does not evaluate no-consumption) — per the RFC-0055 design.
- Extracted two duplicated error-message literals to constants (`ERR_RULE_ID_REQUIRED`, `ERR_CUSTOMER_ID_REQUIRED`) to satisfy the strict changed-files lint gate.

## Tests

`tests/unit/controllers/rules.verify.test.ts` (3 tests) — the handler forwards `noConsumptionRules` when present and omits it when the array is empty or the field is absent.

## Gates
- `tsc --noEmit` → EXIT 0
- `eslint --max-warnings 0` on changed files → clean
- 3/3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
