### PR TITLE
feat(centrals): allow serialNumber (logical Central ID) update, guarded by uniqueness

### DIFF
--- a/src/dto/request/CentralDTO.ts
+++ b/src/dto/request/CentralDTO.ts
@@ -81,6 +81,10 @@ export type CreateCentralDTO = z.infer<typeof CreateCentralSchema>;
 export const UpdateCentralSchema = z.object({
   name: z.string().min(1).max(255).optional(),
   displayName: z.string().min(1).max(255).optional(),
+  // serialNumber = logical Central ID (RFC-0005). Mutable for data
+  // reconciliation (e.g. an ID mis-registered on import) — service enforces
+  // per-tenant uniqueness. Physical hardware swaps still use POST /replace.
+  serialNumber: z.string().min(1).max(100).optional(),
   type: z.enum(['NODEHUB', 'GATEWAY', 'EDGE_CONTROLLER', 'VIRTUAL']).optional(),
   firmwareVersion: z.string().max(50).optional(),
   softwareVersion: z.string().max(50).optional(),

--- a/src/repositories/CentralRepository.ts
+++ b/src/repositories/CentralRepository.ts
@@ -178,6 +178,7 @@ export class CentralRepository implements ICentralRepository {
     // Only update fields that are provided
     if (data.name !== undefined) updateData.name = data.name;
     if (data.displayName !== undefined) updateData.displayName = data.displayName;
+    if (data.serialNumber !== undefined) updateData.serialNumber = data.serialNumber;
     if (data.firmwareVersion !== undefined) updateData.firmwareVersion = data.firmwareVersion;
     if (data.softwareVersion !== undefined) updateData.softwareVersion = data.softwareVersion;
     if (data.frequency !== undefined) updateData.frequency = data.frequency;

--- a/src/services/CentralService.ts
+++ b/src/services/CentralService.ts
@@ -1,5 +1,5 @@
 import { randomInt } from 'crypto';
-import { Central, CentralMqttPasswordsSet, ConnectionStatus } from '../domain/entities/Central';
+import { Central, CentralMqttPasswordsSet } from '../domain/entities/Central';
 import {
   CreateCentralDTO,
   UpdateCentralDTO,
@@ -116,6 +116,15 @@ export class CentralService {
     const existing = await this.repository.getById(tenantId, id);
     if (!existing) {
       throw new NotFoundError(`Central ${id} not found`);
+    }
+
+    // serialNumber is mutable (data reconciliation) but unique per tenant.
+    // Guard here for a clean 409 before hitting the DB unique constraint.
+    if (data.serialNumber && data.serialNumber !== existing.serialNumber) {
+      const clash = await this.repository.getBySerialNumber(tenantId, data.serialNumber);
+      if (clash && clash.id !== id) {
+        throw new ConflictError(`Central with serial number ${data.serialNumber} already exists`);
+      }
     }
 
     const updated = await this.repository.update(tenantId, id, data, userId);

--- a/tests/unit/services/CentralService.serial.test.ts
+++ b/tests/unit/services/CentralService.serial.test.ts
@@ -1,5 +1,5 @@
 import { CentralService } from '../../../src/services/CentralService';
-import { ConflictError } from '../../../src/shared/errors/AppError';
+import { ConflictError, NotFoundError } from '../../../src/shared/errors/AppError';
 import type { ICentralRepository } from '../../../src/repositories/interfaces/ICentralRepository';
 
 function makeService(existsImpl?: (s: string) => boolean) {
@@ -51,6 +51,32 @@ describe('CentralService — central_id (serial) S1.S2.S3.S4', () => {
     it('returns false when valid but already taken', async () => {
       const { svc } = makeService(() => true);
       expect(await svc.isSerialAvailable('10.20.30.40')).toBe(false);
+    });
+  });
+
+  describe('update — serialNumber reconciliation guard', () => {
+    it('rejects changing serialNumber to one already taken by another central (409)', async () => {
+      const repo = {
+        getById: jest.fn(async () => ({ id: 'c-1', serialNumber: '1.1.1.1', customerId: 'cust-1' })),
+        getBySerialNumber: jest.fn(async () => ({ id: 'c-2', serialNumber: '2.2.2.2' })),
+      } as unknown as ICentralRepository;
+      const svc = new CentralService(repo, {} as never);
+      await expect(
+        svc.update('t-1', 'c-1', { serialNumber: '2.2.2.2' } as never, 'u-1'),
+      ).rejects.toThrow(ConflictError);
+      expect(repo.getBySerialNumber).toHaveBeenCalledWith('t-1', '2.2.2.2');
+    });
+
+    it('throws NotFoundError when the central does not exist', async () => {
+      const repo = {
+        getById: jest.fn(async () => null),
+        getBySerialNumber: jest.fn(),
+      } as unknown as ICentralRepository;
+      const svc = new CentralService(repo, {} as never);
+      await expect(
+        svc.update('t-1', 'missing', { serialNumber: '2.2.2.2' } as never, 'u-1'),
+      ).rejects.toThrow(NotFoundError);
+      expect(repo.getBySerialNumber).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Por quê
O `serialNumber` da Central é o **ID lógico** (RFC-0005). Era **imutável via `PUT`** (fora do `UpdateCentralSchema`), então corrigir um ID cadastrado errado exigia o fluxo de **substituição de hardware** (`POST /replace`) — exagero para uma **reconciliação de dado** (mesmo hardware, ID errado gravado no import do data-ingestion).

## O que muda
- `UpdateCentralSchema`: aceita `serialNumber` (min 1, max 100).
- `CentralService.update`: ao mudar o serial, valida **unicidade por tenant** e lança `ConflictError` (**409**) antes de bater no índice único (`centrals_tenant_serial_unique`).
- `CentralRepository.update`: mapeia `serialNumber` no update set.
- Testes: 409 em colisão; 404 quando a central não existe.

## Segurança
- Troca de hardware física continua via `POST /centrals/:id/replace` (novo UUID).
- O `serialNumber` da central **não** é chave de bundle/alarme (esses usam o serial dos **devices**) → raio de impacto do rename limitado ao lookup `by-serial`.
- Remove um import morto pré-existente (`ConnectionStatus`) que o gate de lint (changed-files, `--max-warnings 0`) apontava.

## Par frontend
gh-myio/gcdr-frontend `feat/central-serial-editable` (campo editável + warnings).

**Gates:** tsc 0 · eslint `--max-warnings 0` limpo · jest 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
