### PR TITLE
feat(templates): accept Customer API Key on /templates/render (M2M)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -222,6 +222,7 @@ apiV1Router.use(
 // Frequently-reused permission scopes (sonarjs/no-duplicate-string).
 const PERM_BUNDLES_READ = 'bundles:read';
 const PERM_CUSTOMERS_READ = 'customers:read';
+const PERM_TEMPLATES_READ = 'templates:read';
 
 // -----------------------------------------------------------------------------
 // Authentication (public)
@@ -465,8 +466,18 @@ apiV1Router.use('/access-bundle', authMiddleware, accessBundleController);
 // RFC-0020: Public Single Apps (mixed auth — managed within controller)
 apiV1Router.use('/public-apps', authMiddleware, publicSingleAppsController);
 
-// RFC-0021: HTML Templates Engine
-apiV1Router.use('/templates', authMiddleware, templatesController);
+// RFC-0021: HTML Templates Engine.
+// The two /render endpoints are consumed by EMAIL_SENDER (M2M), so they also
+// accept a Customer API Key with the `templates:read` scope (hybrid auth). Every
+// other template route (list/get/create/update/delete/preview) stays JWT/master
+// only via authMiddleware.
+const templatesRenderAuth = hybridAuthMiddleware(PERM_TEMPLATES_READ);
+apiV1Router.use(
+  '/templates',
+  (req, res, next) =>
+    (req.path.endsWith('/render') ? templatesRenderAuth : authMiddleware)(req, res, next),
+  templatesController,
+);
 apiV1Router.use('/template-types', authMiddleware, templateTypesController);
 
 // Dashboard summary

--- a/src/domain/entities/CustomerApiKey.ts
+++ b/src/domain/entities/CustomerApiKey.ts
@@ -33,6 +33,7 @@ export type ApiKeyScope =
   | 'entities:read'     // Read/resolve generic entity registry (RFC-0047)
   | 'entities:write'    // Write generic entity registry — MYIO operator only (RFC-0047)
   | 'entities:admin'    // Create entity_types + mutate is_system rows (RFC-0047)
+  | 'templates:read'    // Read/render HTML templates (RFC-0021) — used by EMAIL_SENDER (M2M)
   | '*:read';           // Read all resources
 
 /**


### PR DESCRIPTION
## Problema
`/templates` estava montado atrás do **`authMiddleware`**, que só aceita **JWT Bearer** ou a **master API key** — Customer/Partner API Keys (`gcdr_cust_*`/`gcdr_pk_*`) eram **rejeitadas**. Mas os dois endpoints **`/render`** são consumidos pelo **EMAIL_SENDER (M2M)**, que autentica com **Customer API Key**.

## Mudança
- Adiciona o scope **`templates:read`** ao `ApiKeyScope` (RFC-0021).
- Roteia **`/templates/render`** (GET + POST) via **`hybridAuthMiddleware('templates:read')`** → aceita JWT + master + **Customer API Key** com o scope. As demais rotas de template (list/get/create/update/delete/preview) **continuam JWT/master only**.

Implementação: um dispatcher no mount `/templates` (`req.path.endsWith('/render') ? hybridAuth : authMiddleware`), sem mexer rota-a-rota no controller.

## Como usar
Uma customer key precisa do scope **`templates:read`** (ou `*:read`):
```
GET /api/v1/templates/render?type=EMAIL_ALARM&customerId=<uuid>
X-API-Key: gcdr_cust_...
```

## ⚠️ Nota de segurança
O `/render` usa o `customerId` do **request**, não o da key — uma customer key pode renderizar o tema de **outro** customer do mesmo tenant (o template é tenant-level; o `customerId` injeta o tema/branding). Se quiser travar ao customer da própria key, dá pra adicionar um check. Fora do escopo desta mudança.

**Gates:** tsc 0 · eslint `--max-warnings 0` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
