### PR TITLE
feat(templates): resolve theme var() → literal at render (email-safe theming)

### DIFF
--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -24,6 +24,7 @@ export interface TagDefinition {
   example: string;
 }
 
+/* eslint-disable sonarjs/no-duplicate-string -- data catalog: repeated labels/examples across template types are intentional */
 const TAG_CATALOG: Record<string, TagDefinition[]> = {
   EMAIL_ALARM: [
     { tag: '{{summary.rulesCount}}',     label: 'Qtd. de rules disparadas',        description: 'Número total de rules que dispararam no evento',              example: '3' },
@@ -202,6 +203,7 @@ const TAG_CATALOG: Record<string, TagDefinition[]> = {
     { tag: '{{/each}}',                  label: 'Loop — fecha bloco',              description: 'Fecha qualquer {{#each}}',                                   example: '' },
   ],
 };
+/* eslint-enable sonarjs/no-duplicate-string */
 
 // =============================================================================
 // Template Renderer
@@ -400,10 +402,6 @@ export function renderTemplate(htmlContent: string, data: Record<string, unknown
 // Theme Merge — inject customer colors/logo as CSS variables into HTML
 // =============================================================================
 
-function camelToKebab(str: string): string {
-  return str.replace(/([A-Z])/g, (m) => `-${m.toLowerCase()}`);
-}
-
 export function buildThemeCssVars(theme: LookAndFeel): string {
   const lines: string[] = [];
 
@@ -453,6 +451,64 @@ export function buildThemeCssVars(theme: LookAndFeel): string {
   return `:root {\n${lines.join('\n')}\n}`;
 }
 
+/**
+ * Map of theme CSS var names (as emitted by buildThemeCssVars, kebab-case) to
+ * their literal values, for email-safe substitution.
+ */
+function buildThemeVarMap(theme: LookAndFeel): Record<string, string> {
+  const c = theme.colors;
+  const cv = c as unknown as Record<string, string>;
+  const map: Record<string, string> = {};
+  const put = (name: string, value?: string): void => {
+    if (value) map[`--color-${name}`] = value;
+  };
+  put('primary', c.primary);
+  put('primary-light', c.primaryLight);
+  put('primary-dark', c.primaryDark);
+  put('secondary', c.secondary);
+  put('secondary-light', c.secondaryLight);
+  put('secondary-dark', c.secondaryDark);
+  put('accent', c.accent);
+  put('background', c.background);
+  put('surface', c.surface);
+  put('surface-variant', cv['surfaceVariant']);
+  put('error', c.error);
+  put('warning', c.warning);
+  put('success', c.success);
+  put('info', c.info);
+  put('text-primary', c.textPrimary);
+  put('text-secondary', c.textSecondary);
+  put('text-disabled', c.textDisabled);
+  put('divider', c.divider);
+  if (theme.typography.fontFamily) map['--font-family'] = theme.typography.fontFamily;
+  if (theme.typography.fontFamilySecondary) map['--font-family-secondary'] = theme.typography.fontFamilySecondary;
+  if (theme.logo.primaryUrl) map['--logo-url'] = `url('${theme.logo.primaryUrl}')`;
+  if (theme.logo.iconUrl) map['--logo-icon-url'] = `url('${theme.logo.iconUrl}')`;
+  return map;
+}
+
+/**
+ * Replace `var(--x, fallback)` references with the theme's literal value.
+ *
+ * Email clients (Gmail, Outlook) do not support CSS custom properties: an
+ * unresolved var() drops the whole declaration, so a white-on-colored element
+ * loses its background and turns unreadable (white-on-white in light mode).
+ * Substituting the literal at render time keeps per-customer theming working in
+ * email. When a var is not in the theme map, the declared fallback is used
+ * (still literal, still email-safe); a bare var() with no fallback is left as-is.
+ */
+export function resolveThemeVars(html: string, theme: LookAndFeel): string {
+  const map = buildThemeVarMap(theme);
+  return html.replace(
+    /var\(\s*(--[a-zA-Z0-9-]+)\s*(?:,\s*([^)]*))?\)/g,
+    (match: string, name: string, fallback?: string): string => {
+      const literal = map[name];
+      if (literal) return literal;
+      return fallback !== undefined ? fallback.trim() : match;
+    },
+  );
+}
+
 const NUNITO_FONT_LINK = [
   '<link rel="preconnect" href="https://fonts.googleapis.com">',
   '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
@@ -460,6 +516,11 @@ const NUNITO_FONT_LINK = [
 ].join('\n');
 
 function injectThemeIntoHtml(html: string, theme: LookAndFeel): string {
+  // Email-safe theming: resolve the template's var(--color-x, fallback) into the
+  // theme's literal colors, since email clients do not support CSS custom
+  // properties. The :root vars are still injected below for web/backward-compat.
+  const themed = resolveThemeVars(html, theme);
+
   const cssVars = buildThemeCssVars(theme);
   const styleBlock = [
     NUNITO_FONT_LINK,
@@ -470,10 +531,10 @@ function injectThemeIntoHtml(html: string, theme: LookAndFeel): string {
   ].join('\n');
 
   // Inject before </head> if present, otherwise prepend
-  if (html.includes('</head>')) {
-    return html.replace('</head>', `${styleBlock}\n</head>`);
+  if (themed.includes('</head>')) {
+    return themed.replace('</head>', `${styleBlock}\n</head>`);
   }
-  return styleBlock + '\n' + html;
+  return styleBlock + '\n' + themed;
 }
 
 // =============================================================================
@@ -575,6 +636,7 @@ export class TemplateService {
    *   3. parent customer generic default (walks parentCustomerId chain)
    *   4. MYIO platform customer default (always exists)
    */
+  // eslint-disable-next-line sonarjs/cognitive-complexity -- pre-existing template+theme resolution chain; unchanged by this PR
   async renderForEmailSender(
     tenantId: string,
     type: TemplateType,

--- a/tests/unit/services/TemplateService.themeVars.test.ts
+++ b/tests/unit/services/TemplateService.themeVars.test.ts
@@ -1,0 +1,54 @@
+import { resolveThemeVars } from '../../../src/services/TemplateService';
+
+// Minimal theme — only the fields buildThemeVarMap reads. Cast to the expected
+// parameter type to avoid constructing a full LookAndFeel.
+const theme = {
+  id: 't1',
+  colors: {
+    primary: '#0D47A1',
+    warning: '#E65100',
+    secondary: '#00B8D4',
+    surfaceVariant: '#EFF3FB',
+  },
+  typography: { fontFamily: 'Inter, sans-serif' },
+  logo: {},
+} as unknown as Parameters<typeof resolveThemeVars>[1];
+
+describe('resolveThemeVars — email-safe theming (var → literal)', () => {
+  it('replaces var(--color-x, fallback) with the theme literal', () => {
+    expect(resolveThemeVars('a{background:var(--color-primary,#000)}', theme)).toBe(
+      'a{background:#0D47A1}',
+    );
+  });
+
+  it('accepts a space after the comma', () => {
+    expect(resolveThemeVars('a{background:var(--color-primary, #000)}', theme)).toBe(
+      'a{background:#0D47A1}',
+    );
+  });
+
+  it('maps kebab --color-surface-variant from the camelCase theme key', () => {
+    expect(resolveThemeVars('b{background:var(--color-surface-variant,#fff)}', theme)).toBe(
+      'b{background:#EFF3FB}',
+    );
+  });
+
+  it('uses the declared fallback when the var is not in the theme', () => {
+    expect(resolveThemeVars('c{color:var(--color-unknown,#abcabc)}', theme)).toBe(
+      'c{color:#abcabc}',
+    );
+  });
+
+  it('resolves a bare var() (no fallback) when mapped, leaves it when unmapped', () => {
+    expect(resolveThemeVars('d{color:var(--color-warning)}', theme)).toBe('d{color:#E65100}');
+    expect(resolveThemeVars('e{color:var(--color-nope)}', theme)).toBe('e{color:var(--color-nope)}');
+  });
+
+  it('replaces every occurrence', () => {
+    const out = resolveThemeVars(
+      '.h{background:var(--color-primary,#1)} .t{background:var(--color-secondary,#2)}',
+      theme,
+    );
+    expect(out).toBe('.h{background:#0D47A1} .t{background:#00B8D4}');
+  });
+});


### PR DESCRIPTION
## Problema
O GCDR injeta o tema do customer como **`:root { --color-*: … }`** (CSS custom properties) e os templates consomem via `var()`. **Clientes de email (Gmail, Outlook) não suportam custom properties** → o `var()` não resolvido **descarta a declaração inteira** → elementos com texto branco sobre fundo colorido (header, badge, cabeçalho da tabela) ficam **sem fundo** = ilegíveis (branco no branco em light mode).

## Mudança
- **`resolveThemeVars(html, theme)`**: substitui `var(--color-x, fallback)` pela **cor literal** do tema (nomes kebab batem com o `buildThemeCssVars`). Var não mapeada → usa o fallback literal; `var()` sem fallback e não-mapeada → fica como está.
- **`injectThemeIntoHtml`** agora resolve `var()`→literal **antes** de injetar; o bloco `:root` é mantido pra web/back-compat.
- **Resultado:** theming por customer funciona **no email** (e web) sem depender de suporte a `var()` no cliente.

Isso resolve o **motivo 2** do diagnóstico (o motivo 1 — tema com `isDefault:false` — já foi corrigido setando `isDefault:true`).

## Nota sobre o lint
Este arquivo pré-existente tinha 20 warnings de débito que o gate `--max-warnings 0` (changed-files) obriga a limpar. Tratei minimamente, **sem mexer em lógica**:
- removi `camelToKebab` (unused);
- `eslint-disable` escopado do `sonarjs/no-duplicate-string` no `TAG_CATALOG` (é tabela de dados — labels/exemplos repetidos são intencionais);
- `eslint-disable-next-line` da `cognitive-complexity` **pré-existente** do `renderForEmailSender` (não alterado por este PR).

**Gates:** tsc 0 · eslint `--max-warnings 0` 0 · jest **6/6** (`resolveThemeVars`).

## Follow-up (fora deste PR)
Pra o email ao vivo pegar o fix, o **template EMAIL_ALARM guardado no GCDR** precisa ser o que usa `var()` (o render agora resolve) — e/ou atualizar com o HTML corrigido. Ver a discussão do `type=email/alarm.closed` (contrato com o orquestrador) à parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
