### PR TITLE
feat(centrals): accept Customer API Key on /centrals reads (alarms M2M)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -223,6 +223,8 @@ apiV1Router.use(
 const PERM_BUNDLES_READ = 'bundles:read';
 const PERM_CUSTOMERS_READ = 'customers:read';
 const PERM_TEMPLATES_READ = 'templates:read';
+const PERM_CENTRALS_READ = 'centrals:read';
+const PERM_CENTRALS_WRITE = 'centrals:write';
 
 // -----------------------------------------------------------------------------
 // Authentication (public)
@@ -267,7 +269,8 @@ apiV1Router.get('/customers/:customerId/internal-support-rules', hybridAuthMiddl
 apiV1Router.delete('/customers/:customerId/rules/devices', authMiddleware, clearCustomerRuleDevicesHandler);
 
 // Customer Centrals (nested route)
-apiV1Router.get('/customers/:customerId/centrals', authMiddleware, centralsListByCustomerHandler);
+// hybridAuth: supports JWT + API Key (alarms-backend M2M) — read-only list.
+apiV1Router.get('/customers/:customerId/centrals', hybridAuthMiddleware(PERM_CENTRALS_READ), centralsListByCustomerHandler);
 
 // Customer Themes (nested routes)
 apiV1Router.get('/customers/:customerId/themes/default', authMiddleware, themesGetDefaultByCustomerHandler);
@@ -388,7 +391,8 @@ apiV1Router.use('/entity-types', entitiesRateLimiter, hybridAuthByMethod('entiti
 apiV1Router.get('/assets/:assetId/devices', authMiddleware, devicesListByAssetHandler);
 
 // Asset Centrals (nested route)
-apiV1Router.get('/assets/:assetId/centrals', authMiddleware, centralsListByAssetHandler);
+// hybridAuth: supports JWT + API Key (alarms-backend M2M) — read-only list.
+apiV1Router.get('/assets/:assetId/centrals', hybridAuthMiddleware(PERM_CENTRALS_READ), centralsListByAssetHandler);
 
 // Central ID (serial) helpers — PUBLIC (no auth), must come before the
 // auth-gated /centrals router. Global collision check, format S1.S2.S3.S4.
@@ -396,7 +400,10 @@ apiV1Router.get('/centrals/serial/available', centralSerialAvailableHandler);
 apiV1Router.get('/centrals/serial/next', centralSerialNextHandler);
 
 // Centrals
-apiV1Router.use('/centrals', authMiddleware, centralsController);
+// hybridAuth: GET* accept JWT + API Key (alarms-backend M2M) with centrals:read;
+// mutations (POST/PUT/PATCH/DELETE: commands, enroll, mqtt, backup/restore) require
+// centrals:write, which the alarms read-only key does not hold.
+apiV1Router.use('/centrals', hybridAuthByMethod(PERM_CENTRALS_READ, PERM_CENTRALS_WRITE), centralsController);
 
 // Zero-touch enrollment (Slice 1.5). PUBLIC and mounted BEFORE the
 // centralAuthMiddleware /central-agent mount: a freshly-flashed central has no

--- a/src/domain/entities/CustomerApiKey.ts
+++ b/src/domain/entities/CustomerApiKey.ts
@@ -34,6 +34,8 @@ export type ApiKeyScope =
   | 'entities:write'    // Write generic entity registry — MYIO operator only (RFC-0047)
   | 'entities:admin'    // Create entity_types + mutate is_system rows (RFC-0047)
   | 'templates:read'    // Read/render HTML templates (RFC-0021) — used by EMAIL_SENDER (M2M)
+  | 'centrals:read'     // Read centrals/gateways — used by alarms-backend (M2M)
+  | 'centrals:write'    // Write centrals/gateways (commands, enroll, mqtt, backup/restore)
   | '*:read';           // Read all resources
 
 /**


### PR DESCRIPTION
## What

Allow **alarms-backend** to read centrals/gateway data using a **Customer API Key** (`X-API-Key: gcdr_cust_*`), mirroring the `/templates/render` M2M pattern (#36).

## Changes

- Add `centrals:read` / `centrals:write` to the `ApiKeyScope` enum (`CustomerApiKey.ts`).
- `/centrals` router → `hybridAuthByMethod('centrals:read', 'centrals:write')`:
  - **GET** `/centrals`, `/:id`, `/:id/statistics`, `/serial/:serialNumber`, `/:id/backups`, `/:id/commands` accept **JWT + master key + Customer API Key** with `centrals:read`.
  - **Mutations** (POST/PUT/PATCH/DELETE — commands, enroll-token, mqtt-passwords, backup/restore, delete) require `centrals:write`, which the read-only alarms key does **not** hold → stay protected.
- Nested read lists `GET /customers/:customerId/centrals` and `GET /assets/:assetId/centrals` switched from `authMiddleware` to `hybridAuthMiddleware('centrals:read')`.

`*:read` also covers `centrals:read` automatically.

## Consumer setup (alarms)

1. Create/update the alarms Customer API Key with scope `centrals:read`.
2. Call `/centrals` with header `X-API-Key: gcdr_cust_...`. Writes return 403.
3. To span multiple customers, the key needs `hierarchyAccess: SUBTREE`/`TENANT`, or use the nested `/customers/:id/centrals` route.

## Verification

- `tsc --noEmit` clean
- `eslint --max-warnings 0` on changed files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
