### PR TITLE
feat(devices): RFC-0058 BOX device profile — box_id membership

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1433,6 +1433,14 @@ components:
           type: string
           maxLength: 100
           description: Optional channel sub-type (e.g. "lamp", "presence_sensor").
+        boxId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            RFC-0058: on a member device, the UUID of the containing BOX
+            (a device with deviceProfile='BOX'). Null on a BOX and on
+            standalone devices.
         updatedAt:
           type: string
           format: date-time
@@ -1592,6 +1600,16 @@ components:
         ingestionGatewayId:
           type: string
           format: uuid
+        boxId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            RFC-0058: assign this device to a BOX enclosure (a device with
+            deviceProfile='BOX') by its UUID, or send null to detach. The
+            referenced box must exist in the same tenant and be a BOX; a BOX
+            device may not itself have a boxId; a device may not reference
+            itself.
       example:
         assetId: 455accf5-4aad-49e6-934f-97ae691b6c45
         name: SW QGBT_01_LEN2C37 - Lamp 0
@@ -8072,6 +8090,14 @@ paths:
             type: integer
             minimum: 1
             maximum: 247
+        - name: boxId
+          in: query
+          description: >-
+            RFC-0058: filter to the members of a given BOX enclosure (devices
+            whose box_id equals this UUID).
+          schema:
+            type: string
+            format: uuid
       responses:
         '200':
           description: List of devices
@@ -8079,6 +8105,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PaginatedResponse'
+
+  /devices/{id}/contents:
+    get:
+      tags: [Devices]
+      summary: Get BOX contents summary
+      operationId: getDeviceContents
+      description: >-
+        RFC-0058: returns the member devices of a BOX summarized by
+        deviceProfile, plus a total — e.g. `{ "3F": 3, "HIDR": 2, "total": 5 }`.
+        The device must exist; a device with no members returns `{ "total": 0 }`.
+        Members with a null deviceProfile are grouped under `UNKNOWN`.
+      parameters:
+        - $ref: '#/components/parameters/TenantId'
+        - name: id
+          in: path
+          required: true
+          description: UUID of the BOX device (or any device) whose contents to summarize.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Contents summary keyed by deviceProfile, with a total.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/SuccessResponse'
+                  - properties:
+                      data:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                        description: >-
+                          Map of deviceProfile -> member count, plus a `total`
+                          key with the sum.
+                        example:
+                          '3F': 3
+                          HIDR: 2
+                          total: 5
+        '404':
+          description: Device not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /devices/external/{externalId}:
     get:

--- a/drizzle/migrations/0066_devices_box_id.sql
+++ b/drizzle/migrations/0066_devices_box_id.sql
@@ -1,0 +1,12 @@
+-- Migration 0066: RFC-0058 — BOX device profile membership (box_id)
+--
+-- Adds a nullable self-referential FK so a member device points at its
+-- enclosure (a device with deviceProfile='BOX'). ON DELETE SET NULL detaches
+-- members when a BOX is deleted (never deletes them). The BOX marker itself is
+-- deviceProfile='BOX' (a free varchar) — no enum/migration needed for it.
+--
+-- Profile/tenant/self-reference invariants cannot be SQL CHECKs (a CHECK can't
+-- read the referenced row's profile) and are enforced in DeviceService.
+
+ALTER TABLE devices ADD COLUMN box_id uuid REFERENCES devices(id) ON DELETE SET NULL;
+CREATE INDEX devices_box_id_idx ON devices (tenant_id, box_id);

--- a/src/controllers/devices.controller.ts
+++ b/src/controllers/devices.controller.ts
@@ -15,6 +15,8 @@ import { EventType } from '../shared/types';
 
 const router = Router();
 
+const DEVICE_ID_REQUIRED = 'Device ID is required';
+
 // Apply deep customer resolution to all list endpoints
 router.use('/', resolveDeepCustomers);
 
@@ -55,7 +57,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const { tenantId, requestId } = req.context;
     const {
       assetId, customerId, type, status, connectivityStatus,
-      centralId, slaveId,
+      centralId, slaveId, boxId,
       search, name,
       deviceProfile, identifier, ingestionId, ingestionGatewayId,
       label, externalId,
@@ -85,6 +87,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
       connectivityStatus: connectivityStatus as string | undefined,
       centralId: centralId as string | undefined,
       slaveId: slaveId ? parseInt(slaveId as string, 10) : undefined,
+      boxId: boxId as string | undefined,
       search: (search || name) as string | undefined,
       deviceProfile: deviceProfile as string | undefined,
       identifier: identifier as string | undefined,
@@ -241,6 +244,27 @@ router.get('/:id/rules', async (req: Request, res: Response, next: NextFunction)
 });
 
 /**
+ * GET /devices/:id/contents
+ * RFC-0058: contents summary of a BOX — member counts grouped by deviceProfile,
+ * e.g. { "3F": 3, "HIDR": 2, "total": 5 }.
+ */
+router.get('/:id/contents', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { id } = req.params;
+
+    if (!id) {
+      throw new ValidationError(DEVICE_ID_REQUIRED);
+    }
+
+    const contents = await deviceService.getContents(tenantId, id);
+    sendSuccess(res, contents, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
  * GET /devices/:id
  * Get device by ID
  */
@@ -250,7 +274,7 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
     const { id } = req.params;
 
     if (!id) {
-      throw new ValidationError('Device ID is required');
+      throw new ValidationError(DEVICE_ID_REQUIRED);
     }
 
     const device = await deviceService.getById(tenantId, id);
@@ -278,7 +302,7 @@ const updateDeviceHandler = [
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Device ID is required');
+        throw new ValidationError(DEVICE_ID_REQUIRED);
       }
 
       const data = UpdateDeviceSchema.parse(req.body);
@@ -309,7 +333,7 @@ router.delete('/:id',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Device ID is required');
+        throw new ValidationError(DEVICE_ID_REQUIRED);
       }
 
       await deviceService.delete(tenantId, id, userId);
@@ -338,7 +362,7 @@ router.post('/:id/move',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Device ID is required');
+        throw new ValidationError(DEVICE_ID_REQUIRED);
       }
 
       const data = MoveDeviceSchema.parse(req.body);
@@ -367,7 +391,7 @@ router.patch('/:id/connectivity',
       const { id } = req.params;
 
       if (!id) {
-        throw new ValidationError('Device ID is required');
+        throw new ValidationError(DEVICE_ID_REQUIRED);
       }
 
       const data = UpdateConnectivitySchema.parse(req.body);

--- a/src/domain/entities/Device.ts
+++ b/src/domain/entities/Device.ts
@@ -172,6 +172,11 @@ export interface Device extends BaseEntity {
   meterDomain?: MeterDomain;     // 'ENERGY' | 'WATER'
   tariffCategory?: TariffCategory; // RFC-0054: 'COMMON_AREA' | 'SPECIFIC'
 
+  // RFC-0058: BOX device profile — self-referential membership. On a member
+  // device, boxId points at its enclosure (a device with deviceProfile='BOX').
+  // On a BOX, boxId is undefined (BOX_GROUP nesting is deferred).
+  boxId?: string;                // UUID of the containing BOX device
+
   // Ingestion Integration
   ingestionId?: string;          // UUID in ingestion system
   ingestionGatewayId?: string;   // UUID of ingestion gateway

--- a/src/dto/request/DeviceDTO.ts
+++ b/src/dto/request/DeviceDTO.ts
@@ -115,6 +115,9 @@ export const CreateDeviceSchema = z.object({
   // RFC-0054 (DEC-2): explicit tariff category — the join key between a device's
   // consumption and the hourly tariff. Never inferred; NULL = unclassified.
   tariffCategory: z.enum(['COMMON_AREA', 'SPECIFIC']).nullable().optional(),
+  // RFC-0058: BOX membership — the enclosure (deviceProfile='BOX') this device
+  // belongs to. Profile/tenant/self-reference invariants enforced in DeviceService.
+  boxId: z.string().uuid().nullable().optional(),
 });
 
 export type CreateDeviceDTO = z.infer<typeof CreateDeviceSchema>;
@@ -158,6 +161,9 @@ export const UpdateDeviceSchema = z.object({
   // RFC-0054 (DEC-2): explicit tariff category — the join key between a device's
   // consumption and the hourly tariff. Never inferred; NULL = unclassified.
   tariffCategory: z.enum(['COMMON_AREA', 'SPECIFIC']).nullable().optional(),
+  // RFC-0058: BOX membership. Set a UUID to assign/move into a box, `null` to
+  // detach. Profile/tenant/self-reference invariants enforced in DeviceService.
+  boxId: z.string().uuid().nullable().optional(),
 });
 
 export type UpdateDeviceDTO = z.infer<typeof UpdateDeviceSchema>;
@@ -192,6 +198,8 @@ export interface ListDevicesParams extends PaginationParams {
   // RFC-0008: New filter options
   centralId?: string;
   slaveId?: number;
+  // RFC-0058: members of a given BOX (device_profile='BOX') enclosure.
+  boxId?: string;
   identifier?: string;
   deviceProfile?: string;
   deviceType?: string;

--- a/src/infrastructure/database/drizzle/schema.ts
+++ b/src/infrastructure/database/drizzle/schema.ts
@@ -21,6 +21,7 @@ import {
   uniqueIndex,
   check,
   primaryKey,
+  type AnyPgColumn,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -451,6 +452,13 @@ export const devices = pgTable('devices', {
   deviceProfile: varchar('device_profile', { length: 100 }),  // Device profile (e.g., HIDROMETRO_AREA_COMUM)
   deviceType: varchar('device_type', { length: 100 }),  // Specific device type (e.g., 3F_MEDIDOR)
 
+  // RFC-0058: BOX device profile — self-referential membership. A member
+  // device points at its enclosure (deviceProfile='BOX') via box_id. A BOX
+  // has box_id NULL (BOX_GROUP nesting is deferred). ON DELETE SET NULL:
+  // deleting a BOX detaches its members, never deletes them. Profile/tenant/
+  // self-reference invariants are enforced in DeviceService (see migration 0066).
+  boxId: uuid('box_id').references((): AnyPgColumn => devices.id, { onDelete: 'set null' }),
+
   // Ingestion Integration
   ingestionId: uuid('ingestion_id'),  // ID in ingestion system
   ingestionGatewayId: uuid('ingestion_gateway_id'),  // Gateway ID in ingestion system
@@ -482,6 +490,8 @@ export const devices = pgTable('devices', {
   deviceTypeIdx: index('devices_device_type_idx').on(table.tenantId, table.deviceType),
   ingestionIdIdx: index('devices_ingestion_id_idx').on(table.tenantId, table.ingestionId),
   ingestionGatewayIdIdx: index('devices_ingestion_gateway_id_idx').on(table.tenantId, table.ingestionGatewayId),
+  // RFC-0058: BOX membership lookup (members of a box).
+  boxIdIdx: index('devices_box_id_idx').on(table.tenantId, table.boxId),
   lastActivityTimeIdx: index('devices_last_activity_time_idx').on(table.tenantId, table.lastActivityTime),
   lastAlarmTimeIdx: index('devices_last_alarm_time_idx').on(table.tenantId, table.lastAlarmTime),
 

--- a/src/repositories/DeviceRepository.ts
+++ b/src/repositories/DeviceRepository.ts
@@ -44,6 +44,8 @@ const UPDATE_COPY_FIELDS = [
   'meterDomain',
   // RFC-0054 (DEC-2): explicit tariff category.
   'tariffCategory',
+  // RFC-0058: BOX membership (validated upstream in DeviceService).
+  'boxId',
 ] as const;
 
 /**
@@ -82,6 +84,9 @@ function applyCommonFilters(conditions: ReturnType<typeof sql>[], params: ListDe
   }
   if (params.slaveId !== undefined) {
     conditions.push(eq(devices.slaveId, params.slaveId));
+  }
+  if (params.boxId) {
+    conditions.push(eq(devices.boxId, params.boxId));
   }
   if (params.deviceProfile) {
     conditions.push(eq(devices.deviceProfile, params.deviceProfile));
@@ -157,6 +162,8 @@ export class DeviceRepository implements IDeviceRepository {
       meterDomain: data.meterDomain ?? null,
       // RFC-0054 (DEC-2)
       tariffCategory: data.tariffCategory ?? null,
+      // RFC-0058: BOX membership (validated upstream in DeviceService)
+      boxId: data.boxId ?? null,
     }).returning();
 
     return this.mapToEntity(result);
@@ -458,6 +465,35 @@ export class DeviceRepository implements IDeviceRepository {
     return result[0]?.count || 0;
   }
 
+  /**
+   * RFC-0058: contents summary of a BOX — count of member devices grouped by
+   * device_profile, shaped as `{ <profile>: count, ..., total }`. Members with a
+   * NULL device_profile are grouped under 'UNKNOWN'.
+   */
+  async getContentsSummary(tenantId: string, boxId: string): Promise<Record<string, number>> {
+    const rows = await db
+      .select({
+        deviceProfile: devices.deviceProfile,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(devices)
+      .where(and(
+        eq(devices.tenantId, tenantId),
+        eq(devices.boxId, boxId),
+      ))
+      .groupBy(devices.deviceProfile);
+
+    const summary: Record<string, number> = {};
+    let total = 0;
+    for (const row of rows) {
+      const key = row.deviceProfile ?? 'UNKNOWN';
+      summary[key] = row.count;
+      total += row.count;
+    }
+    summary.total = total;
+    return summary;
+  }
+
   async countByConnectivityStatus(
     tenantId: string,
   ): Promise<{ total: number; byConnectivity: Record<string, number> }> {
@@ -524,6 +560,7 @@ export class DeviceRepository implements IDeviceRepository {
       meterRole: (row.meterRole as Device['meterRole']) || undefined,
       meterDomain: (row.meterDomain as Device['meterDomain']) || undefined,
       tariffCategory: (row.tariffCategory as Device['tariffCategory']) || undefined,
+      boxId: row.boxId || undefined,
       ingestionId: row.ingestionId || undefined,
       ingestionGatewayId: row.ingestionGatewayId || undefined,
       lastActivityTime: row.lastActivityTime?.toISOString(),

--- a/src/repositories/interfaces/IDeviceRepository.ts
+++ b/src/repositories/interfaces/IDeviceRepository.ts
@@ -47,4 +47,8 @@ export interface IDeviceRepository {
   // Count
   countByAsset(tenantId: string, assetId: string): Promise<number>;
   countByCustomer(tenantId: string, customerId: string): Promise<number>;
+
+  // RFC-0058: BOX contents summary — member counts grouped by device_profile,
+  // shaped as `{ <profile>: count, ..., total }`.
+  getContentsSummary(tenantId: string, boxId: string): Promise<Record<string, number>>;
 }

--- a/src/services/DeviceService.ts
+++ b/src/services/DeviceService.ts
@@ -61,8 +61,52 @@ export class DeviceService {
     }
   }
 
+  /**
+   * RFC-0058: validates a BOX membership assignment. Only runs when `boxId` is a
+   * non-null UUID (setting/moving into a box). Detach (`null`) and untouched
+   * (`undefined`) are no-ops. These invariants cannot be SQL CHECKs (a CHECK
+   * cannot read the referenced row's profile), so they live here and are tested.
+   */
+  private async assertBoxAssignment(
+    tenantId: string,
+    opts: { deviceId?: string; effectiveProfile?: string; boxId: string | null | undefined },
+  ): Promise<void> {
+    const { boxId, deviceId, effectiveProfile } = opts;
+    if (boxId === undefined || boxId === null) {
+      return;
+    }
+
+    // A device that is itself a BOX may not be a member of another box
+    // (BOX_GROUP nesting is deferred — see RFC-0058 Future possibilities).
+    if (effectiveProfile === 'BOX') {
+      throw new ValidationError("A BOX device cannot be a member of another box (boxId must be null)");
+    }
+
+    // A device may not reference itself as its box.
+    if (deviceId && boxId === deviceId) {
+      throw new ValidationError('A device cannot reference itself as its box');
+    }
+
+    // The referenced box must exist in the same tenant.
+    const box = await this.repository.getById(tenantId, boxId);
+    if (!box) {
+      throw new NotFoundError(`Box ${boxId} not found`);
+    }
+
+    // The referenced device must actually be a BOX.
+    if (box.deviceProfile !== 'BOX') {
+      throw new ValidationError(`Device ${boxId} is not a BOX (deviceProfile must be 'BOX')`);
+    }
+  }
+
   async create(tenantId: string, data: CreateDeviceDTO, userId: string): Promise<Device> {
     this.assertMeterPair(data);
+    // RFC-0058: a new device gets its id in the repo, so self-reference is not
+    // possible here; validate profile/target-box invariants only.
+    await this.assertBoxAssignment(tenantId, {
+      effectiveProfile: data.deviceProfile,
+      boxId: data.boxId,
+    });
 
     // Validate asset exists
     const asset = await this.assetRepository.getById(tenantId, data.assetId);
@@ -125,6 +169,16 @@ export class DeviceService {
     return device;
   }
 
+  /**
+   * RFC-0058: contents summary of a device's box members, grouped by
+   * deviceProfile — e.g. `{ '3F': 3, 'HIDR': 2, total: 5 }`. The device must
+   * exist (404 otherwise). A device with no members returns `{ total: 0 }`.
+   */
+  async getContents(tenantId: string, id: string): Promise<Record<string, number>> {
+    await this.getById(tenantId, id); // 404 if the box/device does not exist
+    return this.repository.getContentsSummary(tenantId, id);
+  }
+
   async getBySerialNumber(tenantId: string, serialNumber: string): Promise<Device> {
     const device = await this.repository.getBySerialNumber(tenantId, serialNumber);
     if (!device) {
@@ -156,6 +210,17 @@ export class DeviceService {
   async update(tenantId: string, id: string, data: UpdateDeviceDTO, userId: string): Promise<Device> {
     this.assertMeterPair(data);
     const existing = await this.getById(tenantId, id);
+
+    // RFC-0058: validate BOX membership on assign/move. The effective profile is
+    // the incoming one if the update changes it, otherwise the existing profile.
+    const effectiveProfile = data.deviceProfile !== undefined
+      ? data.deviceProfile
+      : existing.deviceProfile;
+    await this.assertBoxAssignment(tenantId, {
+      deviceId: id,
+      effectiveProfile,
+      boxId: data.boxId,
+    });
 
     // Check for duplicate external ID if updating
     if (data.externalId && data.externalId !== existing.externalId) {

--- a/tests/unit/services/DeviceService.box.test.ts
+++ b/tests/unit/services/DeviceService.box.test.ts
@@ -1,0 +1,191 @@
+import { DeviceService } from '../../../src/services/DeviceService';
+import { NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import type { IDeviceRepository } from '../../../src/repositories/interfaces/IDeviceRepository';
+import type { IAssetRepository } from '../../../src/repositories/interfaces/IAssetRepository';
+
+const tenantId = '11111111-1111-1111-1111-111111111111';
+const userId = '22222222-2222-2222-2222-222222222222';
+const assetId = '33333333-3333-3333-3333-333333333333';
+const customerId = '44444444-4444-4444-4444-444444444444';
+
+const boxId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const memberId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const otherId = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+type DeviceRow = { id: string; deviceProfile?: string; [k: string]: unknown };
+
+/**
+ * Builds a DeviceService with mocked repositories. `store` maps device id ->
+ * row so repository.getById can resolve the box (and any existing device)
+ * during BOX-assignment validation.
+ */
+function makeService(store: Record<string, DeviceRow> = {}) {
+  const deviceRepo = {
+    getBySerialNumber: jest.fn().mockResolvedValue(null),
+    getByExternalId: jest.fn().mockResolvedValue(null),
+    findBySlaveId: jest.fn().mockResolvedValue(null),
+    getById: jest.fn().mockImplementation((_t: string, id: string) => Promise.resolve(store[id] ?? null)),
+    create: jest.fn().mockImplementation((_t, data) => Promise.resolve({ id: 'dev-new', ...data })),
+    update: jest.fn().mockImplementation((_t, id, data) => Promise.resolve({ id, ...data })),
+    list: jest.fn().mockResolvedValue({ items: [], pagination: { total: 0, totalPages: 0, hasMore: false } }),
+    getContentsSummary: jest.fn().mockResolvedValue({ '3F': 3, HIDR: 2, total: 5 }),
+  };
+  const assetRepo = {
+    getById: jest.fn().mockResolvedValue({ id: assetId, customerId }),
+  };
+  const service = new DeviceService(
+    deviceRepo as unknown as IDeviceRepository,
+    assetRepo as unknown as IAssetRepository,
+    {} as never,
+    {} as never,
+  );
+  return { service, deviceRepo, assetRepo };
+}
+
+const baseCreate = {
+  assetId,
+  name: 'HIDR member',
+  type: 'METER' as const,
+};
+
+describe('DeviceService — RFC-0058 BOX membership invariants', () => {
+  it('accepts a member pointing at a valid BOX in the same tenant (create)', async () => {
+    const { service, deviceRepo } = makeService({
+      [boxId]: { id: boxId, deviceProfile: 'BOX' },
+    });
+
+    await service.create(tenantId, { ...baseCreate, boxId } as never, userId);
+
+    expect(deviceRepo.getById).toHaveBeenCalledWith(tenantId, boxId);
+    expect(deviceRepo.create).toHaveBeenCalled();
+  });
+
+  it('rejects assigning to a non-existent box (NotFoundError)', async () => {
+    const { service, deviceRepo } = makeService(/* empty store */);
+
+    await expect(
+      service.create(tenantId, { ...baseCreate, boxId } as never, userId),
+    ).rejects.toThrow(NotFoundError);
+
+    expect(deviceRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects assigning to a device that is not a BOX (ValidationError)', async () => {
+    const { service, deviceRepo } = makeService({
+      [boxId]: { id: boxId, deviceProfile: '3F' }, // not a BOX
+    });
+
+    await expect(
+      service.create(tenantId, { ...baseCreate, boxId } as never, userId),
+    ).rejects.toThrow(ValidationError);
+
+    expect(deviceRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a BOX device from being a member of another box (create)', async () => {
+    const { service, deviceRepo } = makeService({
+      [boxId]: { id: boxId, deviceProfile: 'BOX' },
+    });
+
+    await expect(
+      service.create(
+        tenantId,
+        { ...baseCreate, deviceProfile: 'BOX', boxId } as never,
+        userId,
+      ),
+    ).rejects.toThrow(ValidationError);
+
+    // Fails on the profile check before ever looking up the target box.
+    expect(deviceRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('allows creating a BOX with no box_id', async () => {
+    const { service, deviceRepo } = makeService();
+
+    await service.create(tenantId, { ...baseCreate, deviceProfile: 'BOX' } as never, userId);
+
+    expect(deviceRepo.create).toHaveBeenCalled();
+  });
+
+  it('rejects a device referencing itself as its box (update)', async () => {
+    const { service, deviceRepo } = makeService({
+      [memberId]: { id: memberId, deviceProfile: '3F', customerId },
+    });
+
+    await expect(
+      service.update(tenantId, memberId, { boxId: memberId } as never, userId),
+    ).rejects.toThrow(/cannot reference itself/);
+
+    expect(deviceRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('allows assigning a member to a BOX (update)', async () => {
+    const { service, deviceRepo } = makeService({
+      [memberId]: { id: memberId, deviceProfile: '3F', customerId },
+      [boxId]: { id: boxId, deviceProfile: 'BOX' },
+    });
+
+    await service.update(tenantId, memberId, { boxId } as never, userId);
+
+    expect(deviceRepo.update).toHaveBeenCalled();
+  });
+
+  it('allows detaching a member (boxId: null) without validating a target', async () => {
+    const { service, deviceRepo } = makeService({
+      [memberId]: { id: memberId, deviceProfile: '3F', customerId },
+    });
+
+    await service.update(tenantId, memberId, { boxId: null } as never, userId);
+
+    // null short-circuits: only the existing-device getById runs, never a box lookup.
+    expect(deviceRepo.getById).toHaveBeenCalledTimes(1);
+    expect(deviceRepo.update).toHaveBeenCalled();
+  });
+
+  it('rejects turning an existing BOX into a member via update', async () => {
+    const { service, deviceRepo } = makeService({
+      [memberId]: { id: memberId, deviceProfile: 'BOX', customerId },
+      [boxId]: { id: boxId, deviceProfile: 'BOX' },
+    });
+
+    await expect(
+      service.update(tenantId, memberId, { boxId } as never, userId),
+    ).rejects.toThrow(ValidationError);
+
+    expect(deviceRepo.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('DeviceService — RFC-0058 contents summary', () => {
+  it('returns the profile-grouped summary with a total', async () => {
+    const { service, deviceRepo } = makeService({
+      [boxId]: { id: boxId, deviceProfile: 'BOX', customerId },
+    });
+
+    const contents = await service.getContents(tenantId, boxId);
+
+    expect(deviceRepo.getById).toHaveBeenCalledWith(tenantId, boxId);
+    expect(deviceRepo.getContentsSummary).toHaveBeenCalledWith(tenantId, boxId);
+    expect(contents).toEqual({ '3F': 3, HIDR: 2, total: 5 });
+  });
+
+  it('404s when the box/device does not exist', async () => {
+    const { service, deviceRepo } = makeService(/* empty */);
+
+    await expect(service.getContents(tenantId, otherId)).rejects.toThrow(NotFoundError);
+    expect(deviceRepo.getContentsSummary).not.toHaveBeenCalled();
+  });
+});
+
+describe('DeviceService — RFC-0058 boxId list filter', () => {
+  it('passes the boxId filter through to the repository', async () => {
+    const { service, deviceRepo } = makeService();
+
+    await service.list(tenantId, { boxId, limit: 20 } as never);
+
+    expect(deviceRepo.list).toHaveBeenCalledWith(
+      tenantId,
+      expect.objectContaining({ boxId }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Implements **RFC-0058 — BOX Device Profile** (backend). A **BOX** is a device (`deviceProfile='BOX'`) representing a physical enclosure that **contains** member devices of mixed types (e.g. 3× `3F` + 2× `HIDR`) via a single self-referential `box_id` FK. The BOX produces no telemetry — it is identity + grouping so scanning one label resolves the enclosure and its contents.

## Changes

**Data model**
- Migration **0066** — `ALTER TABLE devices ADD COLUMN box_id uuid REFERENCES devices(id) ON DELETE SET NULL` + `devices_box_id_idx (tenant_id, box_id)`. `ON DELETE SET NULL` detaches members when a BOX is deleted (never deletes them). The BOX marker is `deviceProfile='BOX'` (free varchar — no enum, no marker migration).
- `schema.ts` self-referential `boxId` column; `Device` entity `boxId?`.

**API** (extends `/devices`)
- `GET /devices?boxId={uuid}` — list members of a box.
- `GET /devices/:id/contents` — `{ "3F": 3, "HIDR": 2, "total": 5 }` (group-by member `deviceProfile`).
- `POST` / `PATCH /devices` accept `boxId` (assign / move / detach with `null`).

**Service-layer invariants** (cannot be SQL `CHECK`; reused by create + update, tested):
- target box must **exist in the same tenant** (`NotFoundError`);
- target must be `deviceProfile='BOX'` (`ValidationError`);
- no **self-reference** (`ValidationError`);
- a **BOX cannot be a member** of another box — BOX_GROUP nesting deferred (`ValidationError`).

**Tests / docs**
- `DeviceService.box.test.ts` — 12 unit tests (all invariants + contents summary + `boxId` filter).
- OpenAPI: `boxId` field, `?boxId` filter, `/contents` endpoint.

## Scope decisions (RFC Unresolved Questions — MVP)
`deviceProfile='BOX'` marker (no `type` enum) · FK not join table · BOX_GROUP deferred (a BOX's `box_id` stays NULL) · mixed domains allowed / no max member count.

## Verification
- `tsc --noEmit` clean · `eslint --max-warnings 0` clean on all changed files · `jest` **12/12** new + **5/5** regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
