### PR TITLE
feat(inventory): M1 Catálogo & BOM (P0)

### DIFF
--- a/src/controllers/inventory/catalog.controller.ts
+++ b/src/controllers/inventory/catalog.controller.ts
@@ -1,22 +1,113 @@
-import { Router } from 'express';
-import { defer, requireUuid, requireConfirmation } from './shared';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireConfirmation } from './shared';
+import { sendSuccess, sendCreated, sendNoContent } from '../../middleware';
 import {
   CreateItemSchema,
   UpdateItemSchema,
   ItemListQuerySchema,
   PutBomSchema,
 } from '../../dto/request/InventoryDTO';
+import { inventoryItemService } from '../../services/inventory/InventoryItemService';
 
-// M1 — Catálogo & BOM (P0)
+// =============================================================================
+// M1 — Catálogo & BOM (P0). Zod validation at the boundary, business rules in
+// InventoryItemService, data access in InventoryItemRepository. Auth is mounted
+// in app.ts (hybridAuthByMethod inventory:read/inventory:write).
+// =============================================================================
+
 const router = Router();
 
-router.get('/items', defer('M1', 'P0', (req) => { ItemListQuerySchema.parse(req.query); }));
-router.post('/items', defer('M1', 'P0', (req) => { CreateItemSchema.parse(req.body ?? {}); }));
-router.get('/items/:id', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); }));
-router.patch('/items/:id', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); UpdateItemSchema.parse(req.body ?? {}); }));
-router.delete('/items/:id', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); requireConfirmation(req); }));
-router.get('/items/:id/stock', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); }));
-router.get('/items/:id/bom', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); }));
-router.put('/items/:id/bom', defer('M1', 'P0', (req) => { requireUuid('id', req.params.id); PutBomSchema.parse(req.body ?? {}); }));
+router.get('/items', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const query = ItemListQuerySchema.parse(req.query);
+    const data = await inventoryItemService.listItems(req.context.tenantId, query);
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/items', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const dto = CreateItemSchema.parse(req.body ?? {});
+    const data = await inventoryItemService.createItem(req.context.tenantId, dto, req.context.userId);
+    sendCreated(res, data, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/items/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    const data = await inventoryItemService.getItem(req.context.tenantId, req.params.id);
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/items/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    const dto = UpdateItemSchema.parse(req.body ?? {});
+    const data = await inventoryItemService.updateItem(
+      req.context.tenantId,
+      req.params.id,
+      dto,
+      req.context.userId,
+    );
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/items/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    requireConfirmation(req); // destructive verb — server-side token (S3)
+    await inventoryItemService.deleteItem(req.context.tenantId, req.params.id);
+    sendNoContent(res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/items/:id/stock', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    const data = await inventoryItemService.getItemStock(req.context.tenantId, req.params.id);
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/items/:id/bom', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    const data = await inventoryItemService.getBom(req.context.tenantId, req.params.id);
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/items/:id/bom', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    requireUuid('id', req.params.id);
+    const dto = PutBomSchema.parse(req.body ?? {});
+    const data = await inventoryItemService.putBom(
+      req.context.tenantId,
+      req.params.id,
+      dto,
+      req.context.userId,
+    );
+    sendSuccess(res, data, 200, req.context.requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryItemRepository.ts
+++ b/src/repositories/inventory/InventoryItemRepository.ts
@@ -1,0 +1,216 @@
+import { and, asc, eq, ilike, inArray, sql } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+import { countWhere } from '../helpers/countQuery';
+
+// =============================================================================
+// RFC-0061 M1 — Catálogo & BOM data access (inv_items + inv_boms) and the
+// aggregated per-location balance for GET /items/:id/stock (derived from
+// inv_stock_movements — DEC-2, balance is NEVER stored).
+//
+// Query builders are exposed as public *Query methods so SQL-shape unit tests
+// can assert them via PgDialect.sqlToQuery without a database (same pattern as
+// CentralReplacementRepository.sql.test.ts).
+// =============================================================================
+
+const { invItems, invBoms, invStockMovements } = schema;
+
+export type InvItemRow = typeof invItems.$inferSelect;
+export type NewInvItemRow = typeof invItems.$inferInsert;
+export type InvBomRow = typeof invBoms.$inferSelect;
+
+export interface InvItemListFilter {
+  page: number;
+  pageSize: number;
+  domain?: string;
+  active?: boolean;
+  q?: string;
+}
+
+export interface InvItemUpdatePatch {
+  name?: string;
+  link?: string | null;
+  description?: string | null;
+  isManufactured?: boolean;
+  lossPercent?: string;
+  lotQuantity?: number | null;
+  purchaseType?: string | null;
+  photoFileId?: string | null;
+  active?: boolean;
+}
+
+export interface InvBomComponentRow {
+  componentItemId: string;
+  componentName: string;
+  quantity: string;
+}
+
+export interface InvItemStockRow {
+  location: string;
+  totalIn: string;
+  totalOut: string;
+  balance: string;
+  lastMovementAt: Date | null;
+}
+
+export class InventoryItemRepository {
+  // ---------------------------------------------------------------------------
+  // Items
+  // ---------------------------------------------------------------------------
+
+  private listConditions(tenantId: string, filter: InvItemListFilter) {
+    const conditions = [eq(invItems.tenantId, tenantId)];
+    if (filter.domain) conditions.push(eq(invItems.domain, filter.domain));
+    if (filter.active !== undefined) conditions.push(eq(invItems.active, filter.active));
+    if (filter.q) conditions.push(ilike(invItems.name, `%${filter.q}%`));
+    return conditions;
+  }
+
+  /** Paged list query (builder — asserted by the SQL-shape unit test). */
+  listQuery(tenantId: string, filter: InvItemListFilter) {
+    return db
+      .select()
+      .from(invItems)
+      .where(and(...this.listConditions(tenantId, filter)))
+      .orderBy(asc(invItems.name))
+      .limit(filter.pageSize)
+      .offset((filter.page - 1) * filter.pageSize);
+  }
+
+  async list(tenantId: string, filter: InvItemListFilter): Promise<{ items: InvItemRow[]; total: number }> {
+    const [items, total] = await Promise.all([
+      this.listQuery(tenantId, filter),
+      countWhere(invItems, this.listConditions(tenantId, filter)),
+    ]);
+    return { items, total };
+  }
+
+  async getById(tenantId: string, id: string): Promise<InvItemRow | null> {
+    const [row] = await db
+      .select()
+      .from(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), eq(invItems.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async create(data: NewInvItemRow): Promise<InvItemRow> {
+    const [row] = await db.insert(invItems).values(data).returning();
+    return row;
+  }
+
+  async update(
+    tenantId: string,
+    id: string,
+    patch: InvItemUpdatePatch,
+    updatedBy: string | null,
+  ): Promise<InvItemRow | null> {
+    const [row] = await db
+      .update(invItems)
+      .set({ ...patch, updatedAt: new Date(), updatedBy })
+      .where(and(eq(invItems.tenantId, tenantId), eq(invItems.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  /** Hard delete. FK RESTRICT from the ledger/purchase orders surfaces as 23503. */
+  async delete(tenantId: string, id: string): Promise<boolean> {
+    const rows = await db
+      .delete(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), eq(invItems.id, id)))
+      .returning({ id: invItems.id });
+    return rows.length > 0;
+  }
+
+  async findByIds(tenantId: string, ids: string[]): Promise<InvItemRow[]> {
+    if (ids.length === 0) return [];
+    return db
+      .select()
+      .from(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), inArray(invItems.id, ids)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // BOM
+  // ---------------------------------------------------------------------------
+
+  /** BOM read query, joined with the component's catalog row (builder). */
+  bomQuery(tenantId: string, productItemId: string) {
+    return db
+      .select({
+        componentItemId: invBoms.componentItemId,
+        componentName: invItems.name,
+        quantity: invBoms.quantity,
+      })
+      .from(invBoms)
+      .innerJoin(invItems, eq(invBoms.componentItemId, invItems.id))
+      .where(and(eq(invBoms.tenantId, tenantId), eq(invBoms.productItemId, productItemId)))
+      .orderBy(asc(invItems.name));
+  }
+
+  async getBom(tenantId: string, productItemId: string): Promise<InvBomComponentRow[]> {
+    return this.bomQuery(tenantId, productItemId);
+  }
+
+  /**
+   * PUT /items/:id/bom semantics — replace the WHOLE component list in one
+   * transaction (delete-all + insert). An empty list clears the BOM.
+   */
+  async replaceBom(
+    tenantId: string,
+    productItemId: string,
+    components: Array<{ componentItemId: string; quantity: string }>,
+    createdBy: string | null,
+  ): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(invBoms)
+        .where(and(eq(invBoms.tenantId, tenantId), eq(invBoms.productItemId, productItemId)));
+
+      if (components.length > 0) {
+        await tx.insert(invBoms).values(
+          components.map((c) => ({
+            tenantId,
+            productItemId,
+            componentItemId: c.componentItemId,
+            quantity: c.quantity,
+            createdBy,
+          })),
+        );
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stock (aggregated balance per location — GET /items/:id/stock)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Aggregate ledger query (builder — asserted by the SQL-shape unit test):
+   * per location, SUM in-types, SUM out-types, balance = in − out, and the
+   * last movement timestamp. AJUSTE adds (source semantics, §Data model).
+   */
+  stockByItemQuery(tenantId: string, itemId: string) {
+    const totalIn = sql<string>`coalesce(sum(case when ${invStockMovements.type} in ('ENTRADA','AJUSTE','TRANSFERENCIA_IN') then ${invStockMovements.quantity} else 0 end), 0)`;
+    const totalOut = sql<string>`coalesce(sum(case when ${invStockMovements.type} in ('SAIDA','TRANSFERENCIA_OUT') then ${invStockMovements.quantity} else 0 end), 0)`;
+    const balance = sql<string>`coalesce(sum(case when ${invStockMovements.type} in ('ENTRADA','AJUSTE','TRANSFERENCIA_IN') then ${invStockMovements.quantity} else -${invStockMovements.quantity} end), 0)`;
+
+    return db
+      .select({
+        location: invStockMovements.location,
+        totalIn,
+        totalOut,
+        balance,
+        lastMovementAt: sql<Date | null>`max(${invStockMovements.createdAt})`,
+      })
+      .from(invStockMovements)
+      .where(and(eq(invStockMovements.tenantId, tenantId), eq(invStockMovements.itemId, itemId)))
+      .groupBy(invStockMovements.location);
+  }
+
+  async getStockByItem(tenantId: string, itemId: string): Promise<InvItemStockRow[]> {
+    return this.stockByItemQuery(tenantId, itemId);
+  }
+}
+
+// Singleton (repo layer convention).
+export const inventoryItemRepository = new InventoryItemRepository();

--- a/src/services/inventory/InventoryItemService.ts
+++ b/src/services/inventory/InventoryItemService.ts
@@ -1,0 +1,293 @@
+import {
+  InventoryItemRepository,
+  inventoryItemRepository,
+  InvItemRow,
+  InvItemUpdatePatch,
+} from '../../repositories/inventory/InventoryItemRepository';
+import {
+  CreateItemDTO,
+  UpdateItemDTO,
+  ItemListQuery,
+  PutBomDTO,
+} from '../../dto/request/InventoryDTO';
+import {
+  InvItemResponse,
+  InvPaginatedResponse,
+  InvStockBalanceResponse,
+} from '../../dto/response/InventoryResponseDTO';
+import type { InvItemDomain, InvPurchaseType, InvStockLocation } from '../../domain/entities/Inventory';
+import { ConflictError, NotFoundError, ValidationError } from '../../shared/errors/AppError';
+
+// =============================================================================
+// RFC-0061 M1 — Catálogo & BOM business rules:
+//   - name unique per (tenant, domain, lower(btrim(name))) — 23505 → 409
+//   - W4 invariant: is_manufactured = true ⇒ domain = 'PRODUCT' (400)
+//   - BOM PUT replaces the whole list; component ≠ product; quantity > 0
+//   - DELETE with ledger/PO references (FK RESTRICT, 23503) → friendly 409
+// =============================================================================
+
+/** BOM read model (M1) — component list of a product. */
+export interface InvBomComponentResponse {
+  componentItemId: string;
+  componentName: string;
+  quantity: number;
+}
+export interface InvBomResponse {
+  productItemId: string;
+  components: InvBomComponentResponse[];
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Drizzle/postgres-js wraps driver errors (DrizzleQueryError): the real
+ * SQLSTATE lives on `err.cause`, not on the wrapper. Walk the cause chain.
+ */
+function pgSqlState(err: unknown): string | undefined {
+  let current: unknown = err;
+  for (let i = 0; i < 5 && current; i++) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string' && /^[0-9A-Z]{5}$/.test(code)) return code;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+/** created_by/updated_by are uuid columns; req.context.userId may be 'system'. */
+function asActorUuid(userId: string | undefined): string | null {
+  return userId && UUID_REGEX.test(userId) ? userId : null;
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export class InventoryItemService {
+  private repository: InventoryItemRepository;
+
+  constructor(repository?: InventoryItemRepository) {
+    this.repository = repository ?? inventoryItemRepository;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Items
+  // ---------------------------------------------------------------------------
+
+  async listItems(tenantId: string, query: ItemListQuery): Promise<InvPaginatedResponse<InvItemResponse>> {
+    const { items, total } = await this.repository.list(tenantId, {
+      page: query.page,
+      pageSize: query.pageSize,
+      domain: query.domain,
+      active: query.active,
+      q: query.q,
+    });
+
+    return {
+      items: items.map((row) => this.mapItem(row)),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: Math.ceil(total / query.pageSize),
+    };
+  }
+
+  async getItem(tenantId: string, id: string): Promise<InvItemResponse> {
+    const row = await this.repository.getById(tenantId, id);
+    if (!row) throw new NotFoundError(`Item ${id} not found`);
+    return this.mapItem(row);
+  }
+
+  async createItem(tenantId: string, dto: CreateItemDTO, userId?: string): Promise<InvItemResponse> {
+    // W4 invariant — the DTO mirrors it, the service is the authority.
+    this.assertManufacturedInvariant(dto.isManufactured ?? false, dto.domain);
+
+    try {
+      const row = await this.repository.create({
+        tenantId,
+        name: dto.name,
+        domain: dto.domain,
+        link: dto.link ?? null,
+        description: dto.description ?? null,
+        isManufactured: dto.isManufactured ?? false,
+        lossPercent: String(dto.lossPercent ?? 0),
+        lotQuantity: dto.lotQuantity ?? null,
+        purchaseType: dto.purchaseType ?? null,
+        photoFileId: dto.photoFileId ?? null,
+        active: dto.active ?? true,
+        createdBy: asActorUuid(userId),
+      });
+      return this.mapItem(row);
+    } catch (err) {
+      this.rethrowUniqueNameViolation(err, dto.name, dto.domain);
+    }
+  }
+
+  async updateItem(tenantId: string, id: string, dto: UpdateItemDTO, userId?: string): Promise<InvItemResponse> {
+    const current = await this.repository.getById(tenantId, id);
+    if (!current) throw new NotFoundError(`Item ${id} not found`);
+
+    // Domain is immutable; validate the EFFECTIVE isManufactured against it.
+    const effectiveManufactured = dto.isManufactured ?? current.isManufactured;
+    this.assertManufacturedInvariant(effectiveManufactured, current.domain);
+
+    const patch: InvItemUpdatePatch = {};
+    if (dto.name !== undefined) patch.name = dto.name;
+    if (dto.link !== undefined) patch.link = dto.link;
+    if (dto.description !== undefined) patch.description = dto.description;
+    if (dto.isManufactured !== undefined) patch.isManufactured = dto.isManufactured;
+    if (dto.lossPercent !== undefined) patch.lossPercent = String(dto.lossPercent);
+    if (dto.lotQuantity !== undefined) patch.lotQuantity = dto.lotQuantity;
+    if (dto.purchaseType !== undefined) patch.purchaseType = dto.purchaseType;
+    if (dto.photoFileId !== undefined) patch.photoFileId = dto.photoFileId;
+    if (dto.active !== undefined) patch.active = dto.active;
+
+    try {
+      const row = await this.repository.update(tenantId, id, patch, asActorUuid(userId));
+      if (!row) throw new NotFoundError(`Item ${id} not found`);
+      return this.mapItem(row);
+    } catch (err) {
+      this.rethrowUniqueNameViolation(err, dto.name ?? current.name, current.domain);
+    }
+  }
+
+  async deleteItem(tenantId: string, id: string): Promise<void> {
+    const current = await this.repository.getById(tenantId, id);
+    if (!current) throw new NotFoundError(`Item ${id} not found`);
+
+    try {
+      await this.repository.delete(tenantId, id);
+    } catch (err) {
+      if (pgSqlState(err) === '23503') {
+        // FK RESTRICT — ledger movements / purchase orders reference the item.
+        throw new ConflictError(
+          'Item possui movimentações de estoque ou pedidos vinculados e não pode ser excluído',
+        );
+      }
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stock (GET /items/:id/stock)
+  // ---------------------------------------------------------------------------
+
+  async getItemStock(tenantId: string, id: string): Promise<InvStockBalanceResponse[]> {
+    const item = await this.repository.getById(tenantId, id);
+    if (!item) throw new NotFoundError(`Item ${id} not found`);
+
+    const rows = await this.repository.getStockByItem(tenantId, id);
+    return rows.map((row) => ({
+      itemId: item.id,
+      itemName: item.name,
+      domain: item.domain as InvItemDomain,
+      location: row.location as InvStockLocation,
+      balance: Number(row.balance),
+      totalIn: Number(row.totalIn),
+      totalOut: Number(row.totalOut),
+      lastMovementAt: toIso(row.lastMovementAt),
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // BOM
+  // ---------------------------------------------------------------------------
+
+  async getBom(tenantId: string, productItemId: string): Promise<InvBomResponse> {
+    const item = await this.repository.getById(tenantId, productItemId);
+    if (!item) throw new NotFoundError(`Item ${productItemId} not found`);
+
+    const rows = await this.repository.getBom(tenantId, productItemId);
+    return {
+      productItemId,
+      components: rows.map((r) => ({
+        componentItemId: r.componentItemId,
+        componentName: r.componentName,
+        quantity: Number(r.quantity),
+      })),
+    };
+  }
+
+  /** Replace-all semantics: the payload IS the BOM; an empty list clears it. */
+  async putBom(tenantId: string, productItemId: string, dto: PutBomDTO, userId?: string): Promise<InvBomResponse> {
+    const product = await this.repository.getById(tenantId, productItemId);
+    if (!product) throw new NotFoundError(`Item ${productItemId} not found`);
+    if (product.domain !== 'PRODUCT') {
+      throw new ValidationError('BOM is only supported for PRODUCT items');
+    }
+
+    const seen = new Set<string>();
+    for (const component of dto.components) {
+      if (component.componentItemId === productItemId) {
+        throw new ValidationError('A product cannot be a component of its own BOM');
+      }
+      if (!(component.quantity > 0)) {
+        throw new ValidationError('BOM component quantity must be greater than zero');
+      }
+      if (seen.has(component.componentItemId)) {
+        throw new ValidationError(`Duplicate component in BOM: ${component.componentItemId}`);
+      }
+      seen.add(component.componentItemId);
+    }
+
+    const ids = dto.components.map((c) => c.componentItemId);
+    const found = await this.repository.findByIds(tenantId, ids);
+    const foundIds = new Set(found.map((r) => r.id));
+    const missing = ids.filter((cid) => !foundIds.has(cid));
+    if (missing.length > 0) {
+      throw new ValidationError(`Component item(s) not found: ${missing.join(', ')}`);
+    }
+
+    await this.repository.replaceBom(
+      tenantId,
+      productItemId,
+      dto.components.map((c) => ({ componentItemId: c.componentItemId, quantity: String(c.quantity) })),
+      asActorUuid(userId),
+    );
+
+    return this.getBom(tenantId, productItemId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private assertManufacturedInvariant(isManufactured: boolean, domain: string): void {
+    if (isManufactured && domain !== 'PRODUCT') {
+      throw new ValidationError('isManufactured requires domain=PRODUCT');
+    }
+  }
+
+  /**
+   * Map a unique violation on (tenant, domain, normalized_name) to a clear
+   * 409. Appendix D has no item-name code, so the generic CONFLICT applies
+   * (the DrizzleQueryError wrapper hides the SQLSTATE — read err.cause).
+   */
+  private rethrowUniqueNameViolation(err: unknown, name: string, domain: string): never {
+    if (pgSqlState(err) === '23505') {
+      throw new ConflictError(`Já existe um item com o nome "${name}" no domínio ${domain}`);
+    }
+    throw err;
+  }
+
+  private mapItem(row: InvItemRow): InvItemResponse {
+    return {
+      id: row.id,
+      name: row.name,
+      domain: row.domain as InvItemDomain,
+      link: row.link,
+      description: row.description,
+      isManufactured: row.isManufactured,
+      lossPercent: Number(row.lossPercent),
+      lotQuantity: row.lotQuantity,
+      purchaseType: row.purchaseType as InvPurchaseType | null,
+      photoFileId: row.photoFileId,
+      active: row.active,
+      createdAt: toIso(row.createdAt) as string,
+      updatedAt: toIso(row.updatedAt) as string,
+    };
+  }
+}
+
+// Singleton (service layer convention).
+export const inventoryItemService = new InventoryItemService();

--- a/tests/unit/inventory/m1-InventoryItemRepository.sql.test.ts
+++ b/tests/unit/inventory/m1-InventoryItemRepository.sql.test.ts
@@ -1,0 +1,83 @@
+/**
+ * RFC-0061 M1 — SQL-shape tests for InventoryItemRepository. The query
+ * builders are asserted via PgDialect.sqlToQuery without a database, same
+ * pattern as CentralReplacementRepository.sql.test.ts.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { InventoryItemRepository } from '../../../src/repositories/inventory/InventoryItemRepository';
+
+const dialect = new PgDialect();
+
+function queryOf(builder: unknown): { sql: string; params: unknown[] } {
+  const sqlObj = (builder as { getSQL: () => import('drizzle-orm').SQL }).getSQL();
+  const q = dialect.sqlToQuery(sqlObj);
+  return { sql: q.sql, params: q.params };
+}
+
+const repo = new InventoryItemRepository();
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM = '22222222-2222-2222-2222-222222222222';
+
+describe('InventoryItemRepository.stockByItemQuery SQL shape (GET /items/:id/stock)', () => {
+  const { sql, params } = queryOf(repo.stockByItemQuery(TENANT, ITEM));
+
+  it('aggregates the ledger scoped to tenant + item, grouped by location', () => {
+    expect(sql).toMatch(/from\s+"inv_stock_movements"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/"item_id"\s*=/i);
+    expect(sql).toMatch(/group\s+by\s+"inv_stock_movements"\."location"/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, ITEM]));
+  });
+
+  it('adds ENTRADA/AJUSTE/TRANSFERENCIA_IN and subtracts SAIDA/TRANSFERENCIA_OUT', () => {
+    // total_in branch: the three in-types sum the quantity.
+    expect(sql).toMatch(/case when .*'ENTRADA','AJUSTE','TRANSFERENCIA_IN'.* then .*"quantity" else 0 end/i);
+    // total_out branch: the two out-types sum the quantity.
+    expect(sql).toMatch(/case when .*'SAIDA','TRANSFERENCIA_OUT'.* then .*"quantity" else 0 end/i);
+    // balance branch: out-types are NEGATED (else -quantity).
+    expect(sql).toMatch(/then .*"quantity" else -.*"quantity" end/i);
+    // never NULL on an empty ledger.
+    expect(sql).toMatch(/coalesce\(sum\(/i);
+  });
+
+  it('exposes the last movement timestamp per location', () => {
+    expect(sql).toMatch(/max\(.*"created_at".*\)/i);
+  });
+});
+
+describe('InventoryItemRepository.listQuery SQL shape (GET /items)', () => {
+  it('pages, filters by tenant and orders by name', () => {
+    const { sql, params } = queryOf(repo.listQuery(TENANT, { page: 2, pageSize: 20 }));
+    expect(sql).toMatch(/from\s+"inv_items"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/order\s+by\s+"inv_items"\."name"\s+asc/i);
+    expect(sql).toMatch(/limit\s+/i);
+    expect(sql).toMatch(/offset\s+/i);
+    // page 2 × pageSize 20 → offset 20
+    expect(params).toEqual(expect.arrayContaining([TENANT, 20, 20]));
+  });
+
+  it('applies domain/active/q filters when present (q via ILIKE on name)', () => {
+    const { sql, params } = queryOf(
+      repo.listQuery(TENANT, { page: 1, pageSize: 10, domain: 'PRODUCT', active: true, q: 'medidor' }),
+    );
+    expect(sql).toMatch(/"domain"\s*=/i);
+    expect(sql).toMatch(/"active"\s*=/i);
+    expect(sql).toMatch(/"name"\s+ilike\s+/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, 'PRODUCT', true, '%medidor%']));
+  });
+});
+
+describe('InventoryItemRepository.bomQuery SQL shape (GET /items/:id/bom)', () => {
+  const { sql, params } = queryOf(repo.bomQuery(TENANT, ITEM));
+
+  it('joins inv_boms to the component catalog row, scoped to tenant + product', () => {
+    expect(sql).toMatch(/from\s+"inv_boms"/i);
+    expect(sql).toMatch(/inner\s+join\s+"inv_items"/i);
+    expect(sql).toMatch(/"component_item_id"\s*=\s*"inv_items"\."id"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/"product_item_id"\s*=/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, ITEM]));
+  });
+});

--- a/tests/unit/inventory/m1-InventoryItemService.test.ts
+++ b/tests/unit/inventory/m1-InventoryItemService.test.ts
@@ -1,0 +1,322 @@
+/**
+ * RFC-0061 M1 — InventoryItemService unit tests (repository mocked, no DB).
+ * Covers: (tenant, domain, normalized_name) uniqueness → 409, the W4
+ * is_manufactured ⇒ PRODUCT invariant → 400, BOM replace-all rules, the
+ * FK-RESTRICT delete → friendly 409, and the stock read model mapping.
+ *
+ * The 23505/23503 errors are asserted through a DrizzleQueryError-shaped
+ * wrapper: the SQLSTATE lives on `err.cause`, NOT on the wrapper (known
+ * gotcha — reference_drizzle_error_cause).
+ */
+
+import { InventoryItemService } from '../../../src/services/inventory/InventoryItemService';
+import type { InventoryItemRepository, InvItemRow } from '../../../src/repositories/inventory/InventoryItemRepository';
+import { ConflictError, NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import type { CreateItemDTO, PutBomDTO } from '../../../src/dto/request/InventoryDTO';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const PRODUCT_ID = '22222222-2222-2222-2222-222222222222';
+const COMPONENT_ID = '33333333-3333-3333-3333-333333333333';
+const USER_ID = '44444444-4444-4444-4444-444444444444';
+
+/** Drizzle wraps driver errors; the SQLSTATE is only on the cause chain. */
+function drizzleWrapped(sqlState: string): Error {
+  const cause = Object.assign(new Error('driver error'), { code: sqlState });
+  const wrapper = new Error('Failed query: insert into "inv_items" ...');
+  (wrapper as { cause?: unknown }).cause = cause;
+  return wrapper;
+}
+
+function itemRow(overrides: Partial<InvItemRow> = {}): InvItemRow {
+  return {
+    id: PRODUCT_ID,
+    tenantId: TENANT,
+    name: 'Medidor V6',
+    normalizedName: 'medidor v6',
+    domain: 'PRODUCT',
+    link: null,
+    description: null,
+    isManufactured: true,
+    lossPercent: '2.50',
+    lotQuantity: null,
+    purchaseType: null,
+    photoFileId: null,
+    active: true,
+    createdAt: new Date('2026-08-01T12:00:00Z'),
+    createdBy: null,
+    updatedAt: new Date('2026-08-01T12:00:00Z'),
+    updatedBy: null,
+    ...overrides,
+  } as InvItemRow;
+}
+
+function buildRepo(overrides: Partial<Record<keyof InventoryItemRepository, jest.Mock>> = {}) {
+  return {
+    list: jest.fn(),
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    findByIds: jest.fn(),
+    getBom: jest.fn(),
+    replaceBom: jest.fn(),
+    getStockByItem: jest.fn(),
+    listQuery: jest.fn(),
+    bomQuery: jest.fn(),
+    stockByItemQuery: jest.fn(),
+    ...overrides,
+  } as unknown as InventoryItemRepository;
+}
+
+const createDto = (overrides: Partial<CreateItemDTO> = {}): CreateItemDTO =>
+  ({ name: 'Medidor V6', domain: 'PRODUCT', isManufactured: false, lossPercent: 0, active: true, ...overrides }) as CreateItemDTO;
+
+describe('InventoryItemService — uniqueness (tenant, domain, normalized_name)', () => {
+  it('maps a wrapped 23505 on create to ConflictError 409 with a clear message', async () => {
+    const repo = buildRepo({ create: jest.fn().mockRejectedValue(drizzleWrapped('23505')) });
+    const service = new InventoryItemService(repo);
+
+    const err = await service.createItem(TENANT, createDto(), USER_ID).catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictError);
+    expect(err.statusCode).toBe(409);
+    expect(err.message).toContain('Medidor V6');
+    expect(err.message).toContain('PRODUCT');
+  });
+
+  it('maps a wrapped 23505 on rename (update) to ConflictError 409', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      update: jest.fn().mockRejectedValue(drizzleWrapped('23505')),
+    });
+    const service = new InventoryItemService(repo);
+
+    const err = await service.updateItem(TENANT, PRODUCT_ID, { name: 'Duplicado' }, USER_ID).catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictError);
+    expect(err.message).toContain('Duplicado');
+  });
+
+  it('rethrows non-23505 errors untouched (no false conflicts)', async () => {
+    const boom = drizzleWrapped('40001');
+    const repo = buildRepo({ create: jest.fn().mockRejectedValue(boom) });
+    const service = new InventoryItemService(repo);
+
+    await expect(service.createItem(TENANT, createDto(), USER_ID)).rejects.toBe(boom);
+  });
+});
+
+describe('InventoryItemService — W4 invariant (is_manufactured ⇒ PRODUCT)', () => {
+  it('rejects create with isManufactured=true and domain != PRODUCT (400)', async () => {
+    const repo = buildRepo();
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.createItem(TENANT, createDto({ domain: 'COMPONENT', isManufactured: true }), USER_ID),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(repo.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects setting isManufactured=true on a non-PRODUCT item via PATCH (400)', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow({ domain: 'COMPONENT', isManufactured: false })),
+    });
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.updateItem(TENANT, PRODUCT_ID, { isManufactured: true }, USER_ID),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(repo.update).not.toHaveBeenCalled();
+  });
+
+  it('keeps a manufactured PRODUCT valid on unrelated PATCH (effective value check)', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      update: jest.fn().mockResolvedValue(itemRow({ description: 'ok' })),
+    });
+    const service = new InventoryItemService(repo);
+
+    const result = await service.updateItem(TENANT, PRODUCT_ID, { description: 'ok' }, USER_ID);
+    expect(result.description).toBe('ok');
+  });
+});
+
+describe('InventoryItemService — delete', () => {
+  it('maps a wrapped FK 23503 (RESTRICT from the ledger) to a friendly 409', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      delete: jest.fn().mockRejectedValue(drizzleWrapped('23503')),
+    });
+    const service = new InventoryItemService(repo);
+
+    const err = await service.deleteItem(TENANT, PRODUCT_ID).catch((e) => e);
+    expect(err).toBeInstanceOf(ConflictError);
+    expect(err.statusCode).toBe(409);
+    expect(err.message).toContain('movimenta');
+  });
+
+  it('404s on a missing item before attempting the delete', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(null) });
+    const service = new InventoryItemService(repo);
+
+    await expect(service.deleteItem(TENANT, PRODUCT_ID)).rejects.toBeInstanceOf(NotFoundError);
+    expect(repo.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('InventoryItemService — BOM (PUT replaces the whole list)', () => {
+  const putDto = (components: PutBomDTO['components']): PutBomDTO => ({ components });
+
+  it('rejects a BOM on a non-PRODUCT item (400)', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(itemRow({ domain: 'COMPONENT', isManufactured: false })) });
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.putBom(TENANT, PRODUCT_ID, putDto([{ componentItemId: COMPONENT_ID, quantity: 2 }]), USER_ID),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects the product referencing itself as a component (400)', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(itemRow()) });
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.putBom(TENANT, PRODUCT_ID, putDto([{ componentItemId: PRODUCT_ID, quantity: 1 }]), USER_ID),
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(repo.replaceBom).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-positive quantity (400)', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(itemRow()) });
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.putBom(TENANT, PRODUCT_ID, putDto([{ componentItemId: COMPONENT_ID, quantity: 0 }]), USER_ID),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects duplicated components in the payload (400)', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(itemRow()) });
+    const service = new InventoryItemService(repo);
+
+    await expect(
+      service.putBom(
+        TENANT,
+        PRODUCT_ID,
+        putDto([
+          { componentItemId: COMPONENT_ID, quantity: 1 },
+          { componentItemId: COMPONENT_ID, quantity: 2 },
+        ]),
+        USER_ID,
+      ),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects components that do not exist in the tenant (400 listing the ids)', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      findByIds: jest.fn().mockResolvedValue([]),
+    });
+    const service = new InventoryItemService(repo);
+
+    const err = await service
+      .putBom(TENANT, PRODUCT_ID, putDto([{ componentItemId: COMPONENT_ID, quantity: 1 }]), USER_ID)
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain(COMPONENT_ID);
+    expect(repo.replaceBom).not.toHaveBeenCalled();
+  });
+
+  it('replaces the whole list in one call and returns the fresh read model', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      findByIds: jest.fn().mockResolvedValue([itemRow({ id: COMPONENT_ID, domain: 'COMPONENT', isManufactured: false })]),
+      replaceBom: jest.fn().mockResolvedValue(undefined),
+      getBom: jest.fn().mockResolvedValue([
+        { componentItemId: COMPONENT_ID, componentName: 'Sensor', quantity: '2.500' },
+      ]),
+    });
+    const service = new InventoryItemService(repo);
+
+    const result = await service.putBom(
+      TENANT,
+      PRODUCT_ID,
+      putDto([{ componentItemId: COMPONENT_ID, quantity: 2.5 }]),
+      USER_ID,
+    );
+
+    expect(repo.replaceBom).toHaveBeenCalledWith(
+      TENANT,
+      PRODUCT_ID,
+      [{ componentItemId: COMPONENT_ID, quantity: '2.5' }],
+      USER_ID,
+    );
+    expect(result).toEqual({
+      productItemId: PRODUCT_ID,
+      components: [{ componentItemId: COMPONENT_ID, componentName: 'Sensor', quantity: 2.5 }],
+    });
+  });
+
+  it('accepts an empty list (clears the BOM) without touching findByIds', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      findByIds: jest.fn().mockResolvedValue([]),
+      replaceBom: jest.fn().mockResolvedValue(undefined),
+      getBom: jest.fn().mockResolvedValue([]),
+    });
+    const service = new InventoryItemService(repo);
+
+    const result = await service.putBom(TENANT, PRODUCT_ID, putDto([]), USER_ID);
+    expect(repo.replaceBom).toHaveBeenCalledWith(TENANT, PRODUCT_ID, [], USER_ID);
+    expect(result.components).toEqual([]);
+  });
+});
+
+describe('InventoryItemService — stock read model & list pagination', () => {
+  it('maps aggregated ledger rows to the InvStockBalanceResponse shape', async () => {
+    const repo = buildRepo({
+      getById: jest.fn().mockResolvedValue(itemRow()),
+      getStockByItem: jest.fn().mockResolvedValue([
+        {
+          location: 'FABRICA',
+          totalIn: '10.000',
+          totalOut: '3.000',
+          balance: '7.000',
+          lastMovementAt: new Date('2026-08-20T10:00:00Z'),
+        },
+      ]),
+    });
+    const service = new InventoryItemService(repo);
+
+    const rows = await service.getItemStock(TENANT, PRODUCT_ID);
+    expect(rows).toEqual([
+      {
+        itemId: PRODUCT_ID,
+        itemName: 'Medidor V6',
+        domain: 'PRODUCT',
+        location: 'FABRICA',
+        balance: 7,
+        totalIn: 10,
+        totalOut: 3,
+        lastMovementAt: '2026-08-20T10:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('404s the stock read for a missing item', async () => {
+    const repo = buildRepo({ getById: jest.fn().mockResolvedValue(null) });
+    const service = new InventoryItemService(repo);
+
+    await expect(service.getItemStock(TENANT, PRODUCT_ID)).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('computes total/totalPages for the list envelope', async () => {
+    const repo = buildRepo({
+      list: jest.fn().mockResolvedValue({ items: [itemRow()], total: 41 }),
+    });
+    const service = new InventoryItemService(repo);
+
+    const result = await service.listItems(TENANT, { page: 1, pageSize: 20 });
+    expect(result.total).toBe(41);
+    expect(result.totalPages).toBe(3);
+    expect(result.items[0]).toMatchObject({ id: PRODUCT_ID, lossPercent: 2.5 });
+  });
+});

--- a/tests/unit/inventory/m1-contract.test.ts
+++ b/tests/unit/inventory/m1-contract.test.ts
@@ -1,0 +1,270 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+// RFC-0061 M1 — catalog contract, now CONCRETE (was 501 in the shared
+// tests/unit/controllers/inventory.contract.test.ts — its M1 cases are
+// superseded by this file and should be removed at integration time).
+// Same harness: REAL router + REAL auth chain (contextMiddleware →
+// hybridAuthByMethod); only the auth leaves and the M1 service are mocked,
+// so no database is touched.
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryItemService', () => ({
+  inventoryItemService: {
+    listItems: jest.fn(),
+    getItem: jest.fn(),
+    createItem: jest.fn(),
+    updateItem: jest.fn(),
+    deleteItem: jest.fn(),
+    getItemStock: jest.fn(),
+    getBom: jest.fn(),
+    putBom: jest.fn(),
+  },
+}));
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryItemService } from '../../../src/services/inventory/InventoryItemService';
+import { ConflictError, NotFoundError } from '../../../src/shared/errors/AppError';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+const KEY_HEADERS = { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' };
+
+const itemResponse = {
+  id: ITEM_ID,
+  name: 'Medidor V6',
+  domain: 'PRODUCT',
+  link: null,
+  description: null,
+  isManufactured: true,
+  lossPercent: 2.5,
+  lotQuantity: null,
+  purchaseType: null,
+  photoFileId: null,
+  active: true,
+  createdAt: '2026-08-01T12:00:00.000Z',
+  updatedAt: '2026-08-01T12:00:00.000Z',
+};
+
+type OkBody<T> = { success: boolean; data: T };
+type ErrBody = { success: boolean; error: { code: string; message?: string } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue({
+    keyId: 'key-1', tenantId: TENANT, customerId: TENANT,
+    scopes: ['inventory:read', 'inventory:write'], name: 'inv-key', hierarchyAccess: 'SELF',
+  });
+});
+
+describe('M1 catalog — concrete contract (supersedes the 501 M1 cases)', () => {
+  it('GET /items → 200 with the paginated envelope (was: 501 stub)', async () => {
+    (inventoryItemService.listItems as jest.Mock).mockResolvedValue({
+      items: [itemResponse], page: 1, pageSize: 20, total: 1, totalPages: 1,
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/items?domain=PRODUCT'), { headers: KEY_HEADERS });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: unknown[]; total: number; totalPages: number }>;
+      expect(body.success).toBe(true);
+      expect(body.data.total).toBe(1);
+      expect(body.data.totalPages).toBe(1);
+      expect(inventoryItemService.listItems).toHaveBeenCalledWith(
+        TENANT,
+        expect.objectContaining({ page: 1, pageSize: 20, domain: 'PRODUCT' }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /items still validates the query DTO (pageSize over the cap → 400)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/items?pageSize=999'), { headers: KEY_HEADERS });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as ErrBody).error.code).toBe('VALIDATION_ERROR');
+      expect(inventoryItemService.listItems).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /items with a valid body → 201 (was: 501 after validation)', async () => {
+    (inventoryItemService.createItem as jest.Mock).mockResolvedValue(itemResponse);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/items'), {
+        method: 'POST',
+        headers: KEY_HEADERS,
+        body: JSON.stringify({ name: 'Medidor', domain: 'PRODUCT' }),
+      });
+      expect(res.status).toBe(201);
+      expect(((await res.json()) as OkBody<typeof itemResponse>).data.id).toBe(ITEM_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /items with a bad body → 400 VALIDATION_ERROR (unchanged)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/items'), {
+        method: 'POST',
+        headers: KEY_HEADERS,
+        body: JSON.stringify({ domain: 'PRODUCT' }), // missing name
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryItemService.createItem).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('a duplicate name surfaces as 409 CONFLICT at the HTTP boundary', async () => {
+    (inventoryItemService.createItem as jest.Mock).mockRejectedValue(
+      new ConflictError('Já existe um item com o nome "Medidor" no domínio PRODUCT'),
+    );
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/items'), {
+        method: 'POST',
+        headers: KEY_HEADERS,
+        body: JSON.stringify({ name: 'Medidor', domain: 'PRODUCT' }),
+      });
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as ErrBody).error.code).toBe('CONFLICT');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /items/:id → 404 NOT_FOUND propagates from the service', async () => {
+    (inventoryItemService.getItem as jest.Mock).mockRejectedValue(new NotFoundError('Item not found'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}`), { headers: KEY_HEADERS });
+      expect(res.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /items/:id with x-confirmation-token → 204 (was: 501 past the guard)', async () => {
+    (inventoryItemService.deleteItem as jest.Mock).mockResolvedValue(undefined);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}`), {
+        method: 'DELETE',
+        headers: { ...KEY_HEADERS, 'x-confirmation-token': 'excluir' },
+      });
+      expect(res.status).toBe(204);
+      expect(inventoryItemService.deleteItem).toHaveBeenCalledWith(TENANT, ITEM_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /items/:id without a token still 428s BEFORE reaching the service', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}`), { method: 'DELETE', headers: KEY_HEADERS });
+      expect(res.status).toBe(428);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(inventoryItemService.deleteItem).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /items/:id/stock → 200 with the per-location balance rows', async () => {
+    (inventoryItemService.getItemStock as jest.Mock).mockResolvedValue([
+      { itemId: ITEM_ID, itemName: 'Medidor V6', domain: 'PRODUCT', location: 'FABRICA', balance: 7, totalIn: 10, totalOut: 3, lastMovementAt: null },
+    ]);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}/stock`), { headers: KEY_HEADERS });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<Array<{ location: string; balance: number }>>;
+      expect(body.data[0]).toMatchObject({ location: 'FABRICA', balance: 7 });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('PUT /items/:id/bom validates the DTO then hits the service → 200', async () => {
+    (inventoryItemService.putBom as jest.Mock).mockResolvedValue({
+      productItemId: ITEM_ID,
+      components: [{ componentItemId: TENANT, componentName: 'Sensor', quantity: 2 }],
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}/bom`), {
+        method: 'PUT',
+        headers: KEY_HEADERS,
+        body: JSON.stringify({ components: [{ componentItemId: TENANT, quantity: 2 }] }),
+      });
+      expect(res.status).toBe(200);
+      expect(inventoryItemService.putBom).toHaveBeenCalledWith(
+        TENANT, ITEM_ID, { components: [{ componentItemId: TENANT, quantity: 2 }] }, expect.anything(),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('PUT /items/:id/bom with a 4-decimal quantity → 400 (numeric(12,3) grain)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/items/${ITEM_ID}/bom`), {
+        method: 'PUT',
+        headers: KEY_HEADERS,
+        body: JSON.stringify({ components: [{ componentItemId: TENANT, quantity: 0.0001 }] }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryItemService.putBom).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});


### PR DESCRIPTION
## RFC-0061 — M1 Catálogo & BOM (P0)

Implementa o módulo M1 concreto sobre o kickoff contract-first: os defers 501 de `src/controllers/inventory/catalog.controller.ts` foram substituídos pelas chamadas reais.

### O que entra

| Camada | Arquivo | Conteúdo |
|---|---|---|
| Repository | `src/repositories/inventory/InventoryItemRepository.ts` | CRUD `inv_items` + `inv_boms` (Drizzle); saldo agregado por location derivado de `inv_stock_movements` para `GET /items/:id/stock` |
| Service | `src/services/inventory/InventoryItemService.ts` | regras de negócio M1 (abaixo) |
| Controller | `src/controllers/inventory/catalog.controller.ts` | rotas reais, Zod na borda, `sendSuccess`/`sendCreated`/`sendNoContent`, tenant de `req.context` |
| Testes | `tests/unit/inventory/m1-*.test.ts` | 35 testes, sem banco |

### Decisões

- **Unicidade** `(tenant, domain, normalized_name)`: violação 23505 → **409 CONFLICT genérico** com mensagem clara (`Já existe um item com o nome "X" no domínio Y`). Appendix D não tem code específico para nome duplicado (INV_QR_DUPLICATE é de QR), então usei o `ConflictError` padrão do `AppError` — o errorHandler já serializa como `code: CONFLICT`.
- **Gotcha Drizzle** respeitado: SQLSTATE lido caminhando `err.cause` (DrizzleQueryError envelopa o erro do driver) — nunca `err.code` do wrapper.
- **Invariante W4** `is_manufactured=true ⇒ domain='PRODUCT'` validada no service (400), inclusive no PATCH com o valor **efetivo** (dto ?? atual); domain é imutável no PATCH (o DTO não expõe).
- **BOM PUT = replace-all** em uma transação (delete-all + insert; lista vazia limpa o BOM). Validações: `component != product`, `quantity > 0`, sem componentes duplicados no payload, componentes existentes no tenant (400 listando os ids ausentes), item alvo precisa ser `PRODUCT`.
- **DELETE** de item referenciado pelo ledger/pedidos (FK RESTRICT, 23503) → 409 amigável; BOM não bloqueia (FK CASCADE). Guard de `confirmationToken` (428) mantido.
- **Saldo** (`GET /items/:id/stock`): `SUM` por location — `ENTRADA`+`AJUSTE`+`TRANSFERENCIA_IN` somam, `SAIDA`+`TRANSFERENCIA_OUT` subtraem (AJUSTE conta como entrada, semântica da fonte); `total_in`/`total_out`/`balance`/`last_movement_at` com `COALESCE` para ledger vazio.
- `created_by`/`updated_by`: `req.context.userId` só é gravado quando é UUID (o default `'system'` vira NULL — colunas são `uuid`).

### Verificação

- `npx tsc --noEmit` — **limpo**
- `npx eslint` (arquivos novos + controller + testes) `--max-warnings 0` — **limpo**
- `npx jest tests/unit/inventory` — **35/35 verdes** (service com repo mockado; SQL-shape via `PgDialect.sqlToQuery` no padrão `CentralReplacementRepository.sql.test.ts`; contrato M1 com router+auth reais e service mockado — sem banco)
- `npx jest tests/unit/controllers/inventory.contract.test.ts` — **9/12**: falham exatamente os 3 casos M1 que esperavam 501 (`GET /items` stub, `POST /items` válido, `DELETE /items/:id` com token). **Contract test M1 cases superseded** por `tests/unit/inventory/m1-contract.test.ts` — **remover na integração** (não editei o arquivo compartilhado para evitar conflito com os agentes dos outros módulos). Casos dos demais módulos continuam verdes.

### Follow-ups

- Remover/ajustar os 3 casos M1 de `tests/unit/controllers/inventory.contract.test.ts` na branch de integração (superseded).
- `InvBomResponse` não existia em `src/dto/response/InventoryResponseDTO.ts` (arquivo congelado para M1) — o read model do BOM (`{ productItemId, components: [{componentItemId, componentName, quantity}] }`) está tipado no service; considerar movê-lo para o response DTO na integração.
- OpenAPI (`openapi.yaml`) não foi tocado (fora da fronteira M1) — atualizar exemplos das rotas `/items*` quando a integração consolidar.
- RBAC fino (roles `inventory-*` do RFC) fica para M10; hoje vale o gate `inventory:read`/`inventory:write` do app.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
