### PR TITLE
feat(inventory): M9 projects (P1)

### DIFF
--- a/src/controllers/inventory/projects.controller.ts
+++ b/src/controllers/inventory/projects.controller.ts
@@ -1,17 +1,69 @@
-import { Router } from 'express';
-import { defer, requireUuid, requireConfirmation } from './shared';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireConfirmation } from './shared';
 import {
   CreateProjectSchema,
   UpdateProjectSchema,
   PaginationQuerySchema,
 } from '../../dto/request/InventoryDTO';
+import { sendSuccess, sendCreated } from '../../middleware/response';
+import { inventoryProjectService } from '../../services/inventory/InventoryProjectService';
 
-// M9 — Projetos (P1)
+// M9 — Projetos (P1). Auth (hybridAuthByMethod inventory:read/inventory:write)
+// is mounted in app.ts; this router only validates, delegates and responds.
 const router = Router();
 
-router.get('/projects', defer('M9', 'P1', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.post('/projects', defer('M9', 'P1', (req) => { CreateProjectSchema.parse(req.body ?? {}); }));
-router.patch('/projects/:id', defer('M9', 'P1', (req) => { requireUuid('id', req.params.id); UpdateProjectSchema.parse(req.body ?? {}); }));
-router.delete('/projects/:id', defer('M9', 'P1', (req) => { requireUuid('id', req.params.id); requireConfirmation(req); }));
+/** GET /projects — paginated list (total/totalPages per convention). */
+router.get('/projects', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = PaginationQuerySchema.parse(req.query);
+
+    const result = await inventoryProjectService.listProjects(tenantId, query);
+    sendSuccess(res, result, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** POST /projects — create (customerId, when present, must exist in tenant). */
+router.post('/projects', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const data = CreateProjectSchema.parse(req.body ?? {});
+
+    const project = await inventoryProjectService.createProject(tenantId, data, userId);
+    sendCreated(res, project, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** PATCH /projects/:id — partial update. */
+router.patch('/projects/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const data = UpdateProjectSchema.parse(req.body ?? {});
+
+    const project = await inventoryProjectService.updateProject(tenantId, req.params.id, data, userId);
+    sendSuccess(res, project, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/** DELETE /projects/:id — destructive; requires confirmation token (S3). */
+router.delete('/projects/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    requireConfirmation(req);
+
+    await inventoryProjectService.deleteProject(tenantId, req.params.id);
+    sendSuccess(res, { id: req.params.id, deleted: true }, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryProjectRepository.ts
+++ b/src/repositories/inventory/InventoryProjectRepository.ts
@@ -1,0 +1,141 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+import { countWhere } from '../helpers/countQuery';
+import { CreateProjectDTO, UpdateProjectDTO } from '../../dto/request/InventoryDTO';
+import { InvProjectResponse } from '../../dto/response/InventoryResponseDTO';
+
+const { invProjects } = schema;
+
+// =============================================================================
+// RFC-0061 M9 — inv_projects data access (tenant-scoped CRUD, offset paging).
+// Rows map straight onto the InvProjectResponse read model — the table has no
+// derived fields, so repository and response shapes coincide.
+// =============================================================================
+
+export interface InventoryProjectListParams {
+  page: number;
+  pageSize: number;
+}
+
+export interface IInventoryProjectRepository {
+  list(
+    tenantId: string,
+    params: InventoryProjectListParams,
+  ): Promise<{ items: InvProjectResponse[]; total: number }>;
+  getById(tenantId: string, id: string): Promise<InvProjectResponse | null>;
+  create(tenantId: string, data: CreateProjectDTO, createdBy?: string): Promise<InvProjectResponse>;
+  update(
+    tenantId: string,
+    id: string,
+    data: UpdateProjectDTO,
+    updatedBy?: string,
+  ): Promise<InvProjectResponse | null>;
+  delete(tenantId: string, id: string): Promise<boolean>;
+}
+
+type InvProjectRow = typeof invProjects.$inferSelect;
+
+export class InventoryProjectRepository implements IInventoryProjectRepository {
+
+  async list(
+    tenantId: string,
+    params: InventoryProjectListParams,
+  ): Promise<{ items: InvProjectResponse[]; total: number }> {
+    const { page, pageSize } = params;
+    const where = eq(invProjects.tenantId, tenantId);
+
+    const [rows, total] = await Promise.all([
+      db
+        .select()
+        .from(invProjects)
+        .where(where)
+        .orderBy(desc(invProjects.createdAt), desc(invProjects.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize),
+      countWhere(invProjects, [where]),
+    ]);
+
+    return { items: rows.map(this.mapRow), total };
+  }
+
+  async getById(tenantId: string, id: string): Promise<InvProjectResponse | null> {
+    const [row] = await db
+      .select()
+      .from(invProjects)
+      .where(and(eq(invProjects.tenantId, tenantId), eq(invProjects.id, id)))
+      .limit(1);
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async create(
+    tenantId: string,
+    data: CreateProjectDTO,
+    createdBy?: string,
+  ): Promise<InvProjectResponse> {
+    const [row] = await db
+      .insert(invProjects)
+      .values({
+        tenantId,
+        name: data.name,
+        description: data.description ?? null,
+        customerId: data.customerId ?? null,
+        legacyClientName: data.legacyClientName ?? null,
+        legacyClientCnpj: data.legacyClientCnpj ?? null,
+        createdBy: createdBy ?? null,
+        updatedBy: createdBy ?? null,
+      })
+      .returning();
+
+    return this.mapRow(row);
+  }
+
+  async update(
+    tenantId: string,
+    id: string,
+    data: UpdateProjectDTO,
+    updatedBy?: string,
+  ): Promise<InvProjectResponse | null> {
+    const patch: Partial<typeof invProjects.$inferInsert> = {
+      updatedAt: new Date(),
+      updatedBy: updatedBy ?? null,
+    };
+    if (data.name !== undefined) patch.name = data.name;
+    if (data.description !== undefined) patch.description = data.description;
+    if (data.customerId !== undefined) patch.customerId = data.customerId;
+    if (data.legacyClientName !== undefined) patch.legacyClientName = data.legacyClientName;
+    if (data.legacyClientCnpj !== undefined) patch.legacyClientCnpj = data.legacyClientCnpj;
+
+    const [row] = await db
+      .update(invProjects)
+      .set(patch)
+      .where(and(eq(invProjects.tenantId, tenantId), eq(invProjects.id, id)))
+      .returning();
+
+    return row ? this.mapRow(row) : null;
+  }
+
+  async delete(tenantId: string, id: string): Promise<boolean> {
+    const rows = await db
+      .delete(invProjects)
+      .where(and(eq(invProjects.tenantId, tenantId), eq(invProjects.id, id)))
+      .returning({ id: invProjects.id });
+
+    return rows.length > 0;
+  }
+
+  private mapRow(row: InvProjectRow): InvProjectResponse {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      customerId: row.customerId,
+      legacyClientName: row.legacyClientName,
+      legacyClientCnpj: row.legacyClientCnpj,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+}
+
+export const inventoryProjectRepository = new InventoryProjectRepository();

--- a/src/services/inventory/InventoryProjectService.ts
+++ b/src/services/inventory/InventoryProjectService.ts
@@ -1,0 +1,123 @@
+import {
+  IInventoryProjectRepository,
+  InventoryProjectRepository,
+} from '../../repositories/inventory/InventoryProjectRepository';
+import { CustomerRepository } from '../../repositories/CustomerRepository';
+import { ICustomerRepository } from '../../repositories/interfaces/ICustomerRepository';
+import { CreateProjectDTO, UpdateProjectDTO, PaginationQuery } from '../../dto/request/InventoryDTO';
+import { InvPaginatedResponse, InvProjectResponse } from '../../dto/response/InventoryResponseDTO';
+import { AppError, ConflictError, NotFoundError, ValidationError } from '../../shared/errors/AppError';
+
+// =============================================================================
+// RFC-0061 M9 — Projetos. Business rules on top of inv_projects:
+//   - `customerId` is optional; when present it must reference an existing
+//     customer in the same tenant (the source's `clients` map onto GCDR
+//     customers — no new clients table).
+//   - Delete is guarded by the controller's confirmation token (S3); FK
+//     RESTRICT from inv_purchase_orders / inv_expedition_orders surfaces as a
+//     friendly 409 instead of a raw 23503.
+// =============================================================================
+
+export class InventoryProjectService {
+  private projectRepository: IInventoryProjectRepository;
+  private customerRepository: ICustomerRepository;
+
+  constructor(
+    projectRepo?: IInventoryProjectRepository,
+    customerRepo?: ICustomerRepository,
+  ) {
+    this.projectRepository = projectRepo || new InventoryProjectRepository();
+    this.customerRepository = customerRepo || new CustomerRepository();
+  }
+
+  async listProjects(
+    tenantId: string,
+    query: PaginationQuery,
+  ): Promise<InvPaginatedResponse<InvProjectResponse>> {
+    const { page, pageSize } = query;
+    const { items, total } = await this.projectRepository.list(tenantId, { page, pageSize });
+
+    return {
+      items,
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async createProject(
+    tenantId: string,
+    data: CreateProjectDTO,
+    createdBy?: string,
+  ): Promise<InvProjectResponse> {
+    await this.assertCustomerExists(tenantId, data.customerId);
+    return this.projectRepository.create(tenantId, data, createdBy);
+  }
+
+  async updateProject(
+    tenantId: string,
+    id: string,
+    data: UpdateProjectDTO,
+    updatedBy?: string,
+  ): Promise<InvProjectResponse> {
+    await this.assertCustomerExists(tenantId, data.customerId);
+
+    const updated = await this.projectRepository.update(tenantId, id, data, updatedBy);
+    if (!updated) {
+      throw new NotFoundError(`Project ${id} not found`);
+    }
+    return updated;
+  }
+
+  /**
+   * Delete a project. The confirmation token was already enforced by the
+   * controller guard (S3); here we only translate the FK RESTRICT from
+   * inv_purchase_orders / inv_expedition_orders into a friendly 409.
+   */
+  async deleteProject(tenantId: string, id: string): Promise<void> {
+    const deleted = await this.projectRepository
+      .delete(tenantId, id)
+      .catch((err: unknown) => this.mapDeleteError(err));
+    if (!deleted) {
+      throw new NotFoundError(`Project ${id} not found`);
+    }
+  }
+
+  /** When a customerId is provided (non-null), it must exist in the tenant. */
+  private async assertCustomerExists(
+    tenantId: string,
+    customerId: string | null | undefined,
+  ): Promise<void> {
+    if (customerId === undefined || customerId === null) return;
+
+    const customer = await this.customerRepository.getById(tenantId, customerId);
+    if (!customer) {
+      throw new ValidationError(`Customer ${customerId} not found in tenant`);
+    }
+  }
+
+  /**
+   * Map the DB error from a blocked delete. Drizzle wraps the driver error in
+   * a DrizzleQueryError: the real PostgresError (SQLSTATE on `.code`) lives on
+   * `.cause`, while the top-level `.message` is a "Failed query: …" wrapper —
+   * inspect both so the mapping fires regardless of wrapping.
+   */
+  private mapDeleteError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ConflictError(
+        'Projeto possui pedidos de compra ou expedições vinculados e não pode ser excluído',
+      );
+    }
+    throw err;
+  }
+}
+
+export const inventoryProjectService = new InventoryProjectService();

--- a/tests/unit/inventory/m9-contract.test.ts
+++ b/tests/unit/inventory/m9-contract.test.ts
@@ -1,0 +1,248 @@
+// RFC-0061 M9 — projects contract test. Supersedes the M9 cases of the frozen
+// tests/unit/controllers/inventory.contract.test.ts: the module now answers
+// concretely instead of the 501 INV_NOT_IMPLEMENTED marker. Mounts the REAL
+// router behind the REAL auth chain (contextMiddleware → hybridAuthByMethod)
+// with only the auth leaves and the M9 service mocked.
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/services/inventory/InventoryProjectService', () => ({
+  inventoryProjectService: {
+    listProjects: jest.fn(),
+    createProject: jest.fn(),
+    updateProject: jest.fn(),
+    deleteProject: jest.fn(),
+  },
+}));
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryProjectService } from '../../../src/services/inventory/InventoryProjectService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+import { ConflictError, NotFoundError } from '../../../src/shared/errors/AppError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+
+const project = {
+  id: PROJECT_ID,
+  name: 'Projeto Moxuara',
+  description: null,
+  customerId: null,
+  legacyClientName: null,
+  legacyClientCnpj: null,
+  createdAt: '2026-08-26T00:00:00.000Z',
+  updatedAt: '2026-08-26T00:00:00.000Z',
+};
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+const KEY = { 'x-api-key': 'gcdr_cust_x' };
+const JSON_KEY = { ...KEY, 'content-type': 'application/json' };
+
+type ErrBody = { success: boolean; error: { code: string; message?: string } };
+type OkBody<T> = { success: boolean; data: T; meta: { requestId: string } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue({
+    keyId: 'key-1',
+    tenantId: TENANT,
+    customerId: TENANT,
+    scopes: ['inventory:read', 'inventory:write'],
+    name: 'inv-key',
+    hierarchyAccess: 'SELF',
+  });
+});
+
+describe('GET /projects', () => {
+  it('returns the paginated list (200) with tenant from the auth context', async () => {
+    (inventoryProjectService.listProjects as jest.Mock).mockResolvedValue({
+      items: [project], page: 1, pageSize: 20, total: 1, totalPages: 1,
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/projects?page=1&pageSize=20'), { headers: KEY });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: unknown[]; total: number; totalPages: number }>;
+      expect(body.success).toBe(true);
+      expect(body.data.items).toHaveLength(1);
+      expect(body.data.total).toBe(1);
+      expect(inventoryProjectService.listProjects).toHaveBeenCalledWith(TENANT, { page: 1, pageSize: 20 });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects an out-of-range pageSize (400 VALIDATION_ERROR)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/projects?pageSize=999'), { headers: KEY });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as ErrBody).error.code).toBe('VALIDATION_ERROR');
+      expect(inventoryProjectService.listProjects).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('POST /projects', () => {
+  it('creates and answers 201 with the row', async () => {
+    (inventoryProjectService.createProject as jest.Mock).mockResolvedValue(project);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/projects'), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ name: 'Projeto Moxuara' }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<typeof project>;
+      expect(body.data.id).toBe(PROJECT_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects a body without name (400) before reaching the service', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/projects'), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ description: 'sem nome' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryProjectService.createProject).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('PATCH /projects/:id', () => {
+  it('updates and answers 200', async () => {
+    (inventoryProjectService.updateProject as jest.Mock).mockResolvedValue({ ...project, name: 'Novo' });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/projects/${PROJECT_ID}`), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ name: 'Novo' }),
+      });
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as OkBody<typeof project>).data.name).toBe('Novo');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects a malformed id (400) before reaching the service', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/projects/not-a-uuid'), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ name: 'X' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryProjectService.updateProject).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('propagates NotFoundError from the service (404)', async () => {
+    (inventoryProjectService.updateProject as jest.Mock).mockRejectedValue(new NotFoundError('Project not found'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/projects/${PROJECT_ID}`), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ name: 'X' }),
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('DELETE /projects/:id', () => {
+  it('still enforces the confirmation guard (428) without a token', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/projects/${PROJECT_ID}`), { method: 'DELETE', headers: KEY });
+      expect(res.status).toBe(428);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(inventoryProjectService.deleteProject).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('deletes with x-confirmation-token (200)', async () => {
+    (inventoryProjectService.deleteProject as jest.Mock).mockResolvedValue(undefined);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/projects/${PROJECT_ID}`), {
+        method: 'DELETE',
+        headers: { ...KEY, 'x-confirmation-token': 'excluir' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ id: string; deleted: boolean }>;
+      expect(body.data).toEqual({ id: PROJECT_ID, deleted: true });
+      expect(inventoryProjectService.deleteProject).toHaveBeenCalledWith(TENANT, PROJECT_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('surfaces the friendly FK conflict as 409', async () => {
+    (inventoryProjectService.deleteProject as jest.Mock).mockRejectedValue(
+      new ConflictError('Projeto possui pedidos de compra ou expedições vinculados e não pode ser excluído'),
+    );
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/projects/${PROJECT_ID}`), {
+        method: 'DELETE',
+        headers: { ...KEY, 'x-confirmation-token': 'excluir' },
+      });
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as ErrBody).error.code).toBe('CONFLICT');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m9-project-service.test.ts
+++ b/tests/unit/inventory/m9-project-service.test.ts
@@ -1,0 +1,194 @@
+// RFC-0061 M9 — InventoryProjectService unit tests (repos mocked).
+import { InventoryProjectService } from '../../../src/services/inventory/InventoryProjectService';
+import { IInventoryProjectRepository } from '../../../src/repositories/inventory/InventoryProjectRepository';
+import { ICustomerRepository } from '../../../src/repositories/interfaces/ICustomerRepository';
+import { InvProjectResponse } from '../../../src/dto/response/InventoryResponseDTO';
+import { Customer } from '../../../src/domain/entities/Customer';
+import {
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../../src/shared/errors/AppError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const PROJECT_ID = '22222222-2222-2222-2222-222222222222';
+const CUSTOMER_ID = '33333333-3333-3333-3333-333333333333';
+
+const project: InvProjectResponse = {
+  id: PROJECT_ID,
+  name: 'Projeto Moxuara',
+  description: null,
+  customerId: null,
+  legacyClientName: null,
+  legacyClientCnpj: null,
+  createdAt: '2026-08-26T00:00:00.000Z',
+  updatedAt: '2026-08-26T00:00:00.000Z',
+};
+
+/** A Drizzle-style wrapped Postgres error: SQLSTATE lives on `.cause`, not `.code`. */
+function drizzleFkError(): Error {
+  const err = new Error('Failed query: delete from "inv_projects" where ...');
+  (err as Error & { cause: unknown }).cause = {
+    code: '23503',
+    message:
+      'update or delete on table "inv_projects" violates foreign key constraint ' +
+      '"inv_purchase_orders_project_id_inv_projects_id_fk" on table "inv_purchase_orders"',
+  };
+  return err;
+}
+
+describe('InventoryProjectService', () => {
+  let projectRepo: jest.Mocked<IInventoryProjectRepository>;
+  let customerRepo: jest.Mocked<ICustomerRepository>;
+  let service: InventoryProjectService;
+
+  beforeEach(() => {
+    projectRepo = {
+      list: jest.fn(),
+      getById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<IInventoryProjectRepository>;
+    customerRepo = { getById: jest.fn() } as unknown as jest.Mocked<ICustomerRepository>;
+    service = new InventoryProjectService(projectRepo, customerRepo);
+  });
+
+  describe('listProjects', () => {
+    it('returns the paginated envelope with total/totalPages', async () => {
+      projectRepo.list.mockResolvedValue({ items: [project], total: 41 });
+
+      const result = await service.listProjects(TENANT, { page: 2, pageSize: 20 });
+
+      expect(projectRepo.list).toHaveBeenCalledWith(TENANT, { page: 2, pageSize: 20 });
+      expect(result).toEqual({
+        items: [project],
+        page: 2,
+        pageSize: 20,
+        total: 41,
+        totalPages: 3,
+      });
+    });
+
+    it('reports totalPages 0 for an empty tenant', async () => {
+      projectRepo.list.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await service.listProjects(TENANT, { page: 1, pageSize: 20 });
+
+      expect(result.total).toBe(0);
+      expect(result.totalPages).toBe(0);
+    });
+  });
+
+  describe('createProject', () => {
+    it('creates without touching the customer repo when customerId is absent', async () => {
+      projectRepo.create.mockResolvedValue(project);
+
+      const result = await service.createProject(TENANT, { name: 'Projeto Moxuara' }, 'user-1');
+
+      expect(customerRepo.getById).not.toHaveBeenCalled();
+      expect(projectRepo.create).toHaveBeenCalledWith(TENANT, { name: 'Projeto Moxuara' }, 'user-1');
+      expect(result).toEqual(project);
+    });
+
+    it('validates the customer exists in the tenant when customerId is provided', async () => {
+      customerRepo.getById.mockResolvedValue({ id: CUSTOMER_ID } as unknown as Customer);
+      projectRepo.create.mockResolvedValue({ ...project, customerId: CUSTOMER_ID });
+
+      await service.createProject(TENANT, { name: 'P', customerId: CUSTOMER_ID }, 'user-1');
+
+      expect(customerRepo.getById).toHaveBeenCalledWith(TENANT, CUSTOMER_ID);
+      expect(projectRepo.create).toHaveBeenCalled();
+    });
+
+    it('rejects with 400 when the referenced customer does not exist', async () => {
+      customerRepo.getById.mockResolvedValue(null);
+
+      await expect(
+        service.createProject(TENANT, { name: 'P', customerId: CUSTOMER_ID }, 'user-1'),
+      ).rejects.toThrow(ValidationError);
+      expect(projectRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('accepts an explicit customerId: null without a customer lookup', async () => {
+      projectRepo.create.mockResolvedValue(project);
+
+      await service.createProject(TENANT, { name: 'P', customerId: null }, 'user-1');
+
+      expect(customerRepo.getById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateProject', () => {
+    it('updates and returns the row', async () => {
+      projectRepo.update.mockResolvedValue({ ...project, name: 'Novo nome' });
+
+      const result = await service.updateProject(TENANT, PROJECT_ID, { name: 'Novo nome' }, 'user-1');
+
+      expect(projectRepo.update).toHaveBeenCalledWith(TENANT, PROJECT_ID, { name: 'Novo nome' }, 'user-1');
+      expect(result.name).toBe('Novo nome');
+    });
+
+    it('throws NotFoundError when the project does not exist', async () => {
+      projectRepo.update.mockResolvedValue(null);
+
+      await expect(
+        service.updateProject(TENANT, PROJECT_ID, { name: 'X' }, 'user-1'),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('validates a newly linked customer on update', async () => {
+      customerRepo.getById.mockResolvedValue(null);
+
+      await expect(
+        service.updateProject(TENANT, PROJECT_ID, { customerId: CUSTOMER_ID }, 'user-1'),
+      ).rejects.toThrow(ValidationError);
+      expect(projectRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('allows unlinking the customer (customerId: null) without a lookup', async () => {
+      projectRepo.update.mockResolvedValue({ ...project, customerId: null });
+
+      await service.updateProject(TENANT, PROJECT_ID, { customerId: null }, 'user-1');
+
+      expect(customerRepo.getById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteProject', () => {
+    it('deletes an existing project', async () => {
+      projectRepo.delete.mockResolvedValue(true);
+
+      await expect(service.deleteProject(TENANT, PROJECT_ID)).resolves.toBeUndefined();
+      expect(projectRepo.delete).toHaveBeenCalledWith(TENANT, PROJECT_ID);
+    });
+
+    it('throws NotFoundError when nothing was deleted', async () => {
+      projectRepo.delete.mockResolvedValue(false);
+
+      await expect(service.deleteProject(TENANT, PROJECT_ID)).rejects.toThrow(NotFoundError);
+    });
+
+    it('maps a Drizzle-wrapped FK 23503 (code on err.cause) to a friendly 409', async () => {
+      projectRepo.delete.mockRejectedValue(drizzleFkError());
+
+      const err: unknown = await service.deleteProject(TENANT, PROJECT_ID).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ConflictError);
+      expect((err as ConflictError).statusCode).toBe(409);
+      expect((err as ConflictError).message).toContain('pedidos');
+    });
+
+    it('maps a bare postgres 23503 (code top-level) to 409 as well', async () => {
+      const bare = Object.assign(new Error('violates foreign key constraint'), { code: '23503' });
+      projectRepo.delete.mockRejectedValue(bare);
+
+      await expect(service.deleteProject(TENANT, PROJECT_ID)).rejects.toThrow(ConflictError);
+    });
+
+    it('re-throws unrelated repo errors unchanged', async () => {
+      projectRepo.delete.mockRejectedValue(new Error('connection refused'));
+
+      await expect(service.deleteProject(TENANT, PROJECT_ID)).rejects.toThrow('connection refused');
+    });
+  });
+});


### PR DESCRIPTION
## RFC-0061 — M9 Projetos (P1)

Implements the M9 module concretely, replacing the 501 `INV_NOT_IMPLEMENTED` stubs in `src/controllers/inventory/projects.controller.ts`.

### What's in

- **`src/repositories/inventory/InventoryProjectRepository.ts`** — tenant-scoped CRUD over `inv_projects` with offset pagination (`page`/`pageSize` → `items`/`total`), ordered by `created_at desc`. Rows map directly onto the `InvProjectResponse` read model.
- **`src/services/inventory/InventoryProjectService.ts`**
  - `customerId` is optional; when present (non-null) it must reference an existing customer in the tenant (`CustomerRepository.getById`, read-only) — otherwise 400 `VALIDATION_ERROR`. `customerId: null` unlinks without a lookup.
  - `PATCH` is dirty-only (`undefined` fields untouched); missing project → 404.
  - `DELETE` translates the FK RESTRICT from `inv_purchase_orders` / `inv_expedition_orders` into a friendly **409 CONFLICT** ("Projeto possui pedidos de compra ou expedições vinculados..."), unwrapping the SQLSTATE from `err.cause` (DrizzleQueryError wrapping) with a top-level fallback.
- **Controller** — keeps the S3 confirmation guard (428 without `x-confirmation-token`) and uuid/Zod boundary validation; responses via `sendSuccess`/`sendCreated` with `req.context`, list payload follows the `total`/`totalPages` convention. DELETE answers 200 `{ id, deleted: true }` per the OpenAPI contract.

### Tests

- `tests/unit/inventory/m9-project-service.test.ts` — service with mocked repos, incl. pagination math, customer validation branches, and the `err.cause` 23503 → 409 mapping (Drizzle-wrapped **and** bare postgres error).
- `tests/unit/inventory/m9-contract.test.ts` — real router + real auth chain (`contextMiddleware` → `hybridAuthByMethod`), M9 service mocked. **Supersedes the M9 501-marker expectations** of the frozen `tests/unit/controllers/inventory.contract.test.ts` (left untouched; its 12 cases still pass — its only M9 case, the 403 write-scope check, is unaffected).

### Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on the 5 touched files with `--max-warnings 0` — clean
- `npx jest tests/unit/inventory` — 25/25 pass
- `npx jest tests/unit/controllers/inventory.contract.test.ts` — 12/12 pass

### Boundary

Only `projects.controller.ts` edited; new files confined to `src/repositories/inventory/`, `src/services/inventory/`, `tests/unit/inventory/` (m9- prefix). No changes to app.ts, schema, DTOs, errors, shared guards, or other modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvWKPT4KpwdZYVNVAis2qK
