### PR TITLE
feat(inventory): M2 stock ledger (P0)

### DIFF
--- a/src/controllers/inventory/stock.controller.ts
+++ b/src/controllers/inventory/stock.controller.ts
@@ -1,5 +1,5 @@
-import { Router } from 'express';
-import { defer, requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
 import {
   StockBalancesQuerySchema,
   CreateMovementSchema,
@@ -7,16 +7,102 @@ import {
   StockResetSchema,
   PaginationQuerySchema,
 } from '../../dto/request/InventoryDTO';
+import { inventoryStockService } from '../../services/inventory/InventoryStockService';
+import { sendSuccess, sendCreated } from '../../middleware/response';
 
-// M2 — Livro-razão de estoque (P0)
+// M2 — Livro-razão de estoque (P0). Real routes (RFC-0061 §M2):
+// balance is derived from inv_stock_movements (DEC-2); mutations run inside a
+// service transaction with a FOR UPDATE item lock; POSTs that create movements
+// require an Idempotency-Key (S1); /stock/reset is destructive and requires a
+// confirmationToken (S3).
 const router = Router();
 
-router.get('/stock/balances', defer('M2', 'P0', (req) => { StockBalancesQuerySchema.parse(req.query); }));
-router.get('/stock/consistency', defer('M2', 'P0'));
-router.get('/stock/movements', defer('M2', 'P0', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.get('/stock/movements/:id', defer('M2', 'P0', (req) => { requireUuid('id', req.params.id); }));
-router.post('/stock/movements', defer('M2', 'P0', (req) => { requireIdempotencyKey(req); CreateMovementSchema.parse(req.body ?? {}); }));
-router.post('/stock/transfers', defer('M2', 'P0', (req) => { requireIdempotencyKey(req); CreateTransferSchema.parse(req.body ?? {}); }));
-router.post('/stock/reset', defer('M2', 'P0', (req) => { requireConfirmation(req); StockResetSchema.parse(req.body ?? {}); }));
+// GET /stock/balances — per-(item, location) derived balances.
+router.get('/stock/balances', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const q = StockBalancesQuerySchema.parse(req.query);
+    const data = await inventoryStockService.getBalances(tenantId, q);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /stock/consistency — ledger vs active-QR drift report (W1, AC-10).
+router.get('/stock/consistency', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const rows = await inventoryStockService.getConsistency(tenantId);
+    sendSuccess(res, { rows, driftCount: rows.filter((r) => r.drift !== 0).length }, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /stock/movements — paginated ledger history (newest first).
+router.get('/stock/movements', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryStockService.listMovements(tenantId, page, pageSize);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /stock/movements/:id — one movement with its QR links.
+router.get('/stock/movements/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const data = await inventoryStockService.getMovement(tenantId, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /stock/movements — ENTRADA | SAIDA | AJUSTE (transfers have their own
+// endpoint). Exit guards + W4 matrix live in the service transaction.
+router.post('/stock/movements', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateMovementSchema.parse(req.body ?? {});
+    const data = await inventoryStockService.createMovement({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /stock/transfers — two legs (OUT with guard + IN) in ONE transaction.
+router.post('/stock/transfers', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateTransferSchema.parse(req.body ?? {});
+    const data = await inventoryStockService.createTransfer({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /stock/reset — destructive ledger wipe (whole tenant or one location).
+// The confirmation token may come via X-Confirmation-Token header or body.
+router.post('/stock/reset', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const confirmationToken = requireConfirmation(req);
+    const dto = StockResetSchema.parse({ ...(req.body ?? {}), confirmationToken });
+    const data = await inventoryStockService.reset({ tenantId, userId }, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryStockRepository.ts
+++ b/src/repositories/inventory/InventoryStockRepository.ts
@@ -1,0 +1,381 @@
+// =============================================================================
+// RFC-0061 M2 — Stock ledger repository (data access only).
+//
+// Owns `inv_stock_movements` + `inv_movement_qrs` and the aggregate views over
+// them. Balance is ALWAYS derived from the movements (DEC-2, never stored):
+//   in  = ENTRADA + AJUSTE + TRANSFERENCIA_IN
+//   out = SAIDA + TRANSFERENCIA_OUT
+//
+// Conventions (matched from consumptionGoalRepository / CentralReplacement-
+// Repository): shared `db` client, tenant-scoped reads, every mutating method
+// accepts an optional executor so the service composes them inside ONE
+// transaction; `withTransaction` exposes the boundary; row locking of the item
+// (`SELECT … FOR UPDATE` on inv_items) serializes concurrent movements per
+// item so the service's negative-stock guard is race-free (§M2).
+//
+// Query builders are public so SQL-shape tests can assert the generated SQL
+// (PgDialect.sqlToQuery) without a database.
+// =============================================================================
+
+import { and, desc, eq, inArray, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+
+const { invItems, invStockMovements, invMovementQrs } = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as consumptionGoalRepository)
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type StockTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type StockDbClient = typeof db | StockTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvItemRow = typeof invItems.$inferSelect;
+export type InvStockMovementRow = typeof invStockMovements.$inferSelect;
+export type InvMovementQrRow = typeof invMovementQrs.$inferSelect;
+
+/** Movement insert payload (quantity as string — numeric(12,3) column). */
+export interface NewMovementInput {
+  tenantId: string;
+  itemId: string;
+  location: string;
+  quantity: string;
+  type: string;
+  reason?: string | null;
+  responsible?: string | null;
+  photoFileId?: string | null;
+  purchaseOrderId?: string | null;
+  transferGroupId?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewMovementQrInput {
+  qrValue?: string;
+  boxQr?: string;
+  homologationUnitId?: string;
+}
+
+/** Aggregate totals for one (item, location). Numerics come back as strings. */
+export interface BalanceTotals {
+  balance: string;
+  totalIn: string;
+  totalOut: string;
+  lastMovementAt: Date | null;
+}
+
+/** One row of the grouped balances listing (joined with the catalog). */
+export interface BalanceListRow extends BalanceTotals {
+  itemId: string;
+  itemName: string;
+  domain: string;
+  location: string;
+}
+
+export interface BalanceListFilters {
+  location?: string;
+  domain?: string;
+}
+
+/** Ledger-vs-QR consistency row (W1) for manufactured products. */
+export interface ConsistencyRow {
+  itemId: string;
+  location: string;
+  ledgerBalance: string;
+  activeQrCount: number;
+}
+
+const IN_TYPES = ['ENTRADA', 'AJUSTE', 'TRANSFERENCIA_IN'] as const;
+const OUT_TYPES = ['SAIDA', 'TRANSFERENCIA_OUT'] as const;
+
+// Signed-quantity SQL fragments shared by the aggregate builders.
+const totalInExpr = sql<string>`coalesce(sum(${invStockMovements.quantity}) filter (where ${invStockMovements.type} in ('ENTRADA','AJUSTE','TRANSFERENCIA_IN')), 0)::text`;
+const totalOutExpr = sql<string>`coalesce(sum(${invStockMovements.quantity}) filter (where ${invStockMovements.type} in ('SAIDA','TRANSFERENCIA_OUT')), 0)::text`;
+const balanceExpr = sql<string>`coalesce(sum(case when ${invStockMovements.type} in ('ENTRADA','AJUSTE','TRANSFERENCIA_IN') then ${invStockMovements.quantity} else -${invStockMovements.quantity} end), 0)::text`;
+const lastMovementExpr = sql<Date | null>`max(${invStockMovements.createdAt})`;
+
+export class InventoryStockRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  /** Runs `fn` inside one DB transaction (movement + QR links + guards). */
+  async withTransaction<T>(fn: (tx: StockTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Query builders (public for SQL-shape tests)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Lock the item row for the whole transaction (`SELECT … FOR UPDATE`).
+   * Serializes concurrent movements on the same item so the derived-balance
+   * guard cannot race (§M2 — the source's trigger summed without a lock).
+   */
+  lockItemQuery(tenantId: string, itemId: string, client: StockDbClient = db) {
+    return client
+      .select()
+      .from(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), eq(invItems.id, itemId)))
+      .limit(1)
+      .for('update');
+  }
+
+  /** Aggregate totals for one (item, location). */
+  balanceQuery(tenantId: string, itemId: string, location: string, client: StockDbClient = db) {
+    return client
+      .select({
+        balance: balanceExpr,
+        totalIn: totalInExpr,
+        totalOut: totalOutExpr,
+        lastMovementAt: lastMovementExpr,
+      })
+      .from(invStockMovements)
+      .where(
+        and(
+          eq(invStockMovements.tenantId, tenantId),
+          eq(invStockMovements.itemId, itemId),
+          eq(invStockMovements.location, location),
+        ),
+      );
+  }
+
+  /** Grouped balances per (item, location), joined with the catalog. */
+  listBalancesQuery(tenantId: string, filters: BalanceListFilters = {}, client: StockDbClient = db) {
+    const conditions: (SQL | undefined)[] = [eq(invStockMovements.tenantId, tenantId)];
+    if (filters.location) conditions.push(eq(invStockMovements.location, filters.location));
+    if (filters.domain) conditions.push(eq(invItems.domain, filters.domain));
+
+    return client
+      .select({
+        itemId: invStockMovements.itemId,
+        itemName: invItems.name,
+        domain: invItems.domain,
+        location: invStockMovements.location,
+        balance: balanceExpr,
+        totalIn: totalInExpr,
+        totalOut: totalOutExpr,
+        lastMovementAt: lastMovementExpr,
+      })
+      .from(invStockMovements)
+      .innerJoin(invItems, eq(invItems.id, invStockMovements.itemId))
+      .where(and(...conditions))
+      .groupBy(invStockMovements.itemId, invItems.name, invItems.domain, invStockMovements.location)
+      .orderBy(invItems.name, invStockMovements.location);
+  }
+
+  /** Paginated movement history (newest first). */
+  listMovementsQuery(tenantId: string, page: number, pageSize: number, client: StockDbClient = db) {
+    return client
+      .select()
+      .from(invStockMovements)
+      .where(eq(invStockMovements.tenantId, tenantId))
+      .orderBy(desc(invStockMovements.createdAt), desc(invStockMovements.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+  }
+
+  /**
+   * W1 consistency report (manufactured PRODUCTs): ledger balance vs count of
+   * ACTIVE QRs per item×location. A QR is active at the location of its LATEST
+   * ledger event when that event is not an exit (anti-double-exit ledger).
+   * v1 approximation: unit QRs only (`qr_value`); box QRs are an M5/M6 concern.
+   */
+  consistencyQuery(tenantId: string): SQL {
+    return sql`
+      WITH ledger AS (
+        SELECT m.item_id, m.location,
+               COALESCE(SUM(CASE WHEN m.type IN ('ENTRADA','AJUSTE','TRANSFERENCIA_IN')
+                                 THEN m.quantity ELSE -m.quantity END), 0) AS ledger_balance
+        FROM inv_stock_movements m
+        JOIN inv_items i ON i.id = m.item_id
+        WHERE m.tenant_id = ${tenantId} AND i.is_manufactured
+        GROUP BY m.item_id, m.location
+      ), latest_qr AS (
+        SELECT DISTINCT ON (mq.qr_value) mq.qr_value, m.item_id, m.location, m.type
+        FROM inv_movement_qrs mq
+        JOIN inv_stock_movements m ON m.id = mq.movement_id
+        JOIN inv_items i ON i.id = m.item_id
+        WHERE mq.tenant_id = ${tenantId} AND mq.qr_value IS NOT NULL AND i.is_manufactured
+        ORDER BY mq.qr_value, m.created_at DESC, m.id DESC
+      ), active_qrs AS (
+        SELECT item_id, location, COUNT(*)::int AS active_qr_count
+        FROM latest_qr
+        WHERE type NOT IN ('SAIDA','TRANSFERENCIA_OUT')
+        GROUP BY item_id, location
+      )
+      SELECT COALESCE(l.item_id, a.item_id)::text        AS item_id,
+             COALESCE(l.location, a.location)            AS location,
+             COALESCE(l.ledger_balance, 0)::text         AS ledger_balance,
+             COALESCE(a.active_qr_count, 0)              AS active_qr_count
+      FROM ledger l
+      FULL OUTER JOIN active_qrs a
+        ON a.item_id = l.item_id AND a.location = l.location
+      ORDER BY 1, 2
+    `;
+  }
+
+  /** Scope-delete of the ledger (POST /stock/reset). QR links CASCADE. */
+  deleteMovementsQuery(tenantId: string, location?: string, client: StockDbClient = db) {
+    const conditions: (SQL | undefined)[] = [eq(invStockMovements.tenantId, tenantId)];
+    if (location) conditions.push(eq(invStockMovements.location, location));
+    return client
+      .delete(invStockMovements)
+      .where(and(...conditions))
+      .returning({ id: invStockMovements.id });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Executors
+  // ---------------------------------------------------------------------------
+
+  /** Lock + load the item row (null when absent in this tenant). */
+  async lockItem(tenantId: string, itemId: string, client: StockDbClient = db): Promise<InvItemRow | null> {
+    const [row] = await this.lockItemQuery(tenantId, itemId, client);
+    return row ?? null;
+  }
+
+  async getBalance(
+    tenantId: string,
+    itemId: string,
+    location: string,
+    client: StockDbClient = db,
+  ): Promise<BalanceTotals> {
+    const [row] = await this.balanceQuery(tenantId, itemId, location, client);
+    return row ?? { balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null };
+  }
+
+  async listBalances(
+    tenantId: string,
+    filters: BalanceListFilters = {},
+    client: StockDbClient = db,
+  ): Promise<BalanceListRow[]> {
+    return this.listBalancesQuery(tenantId, filters, client);
+  }
+
+  async listMovements(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    client: StockDbClient = db,
+  ): Promise<{ rows: InvStockMovementRow[]; total: number }> {
+    const rows = await this.listMovementsQuery(tenantId, page, pageSize, client);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invStockMovements)
+      .where(eq(invStockMovements.tenantId, tenantId));
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  async getMovementById(
+    tenantId: string,
+    id: string,
+    client: StockDbClient = db,
+  ): Promise<{ movement: InvStockMovementRow; qrs: InvMovementQrRow[] } | null> {
+    const [movement] = await client
+      .select()
+      .from(invStockMovements)
+      .where(and(eq(invStockMovements.tenantId, tenantId), eq(invStockMovements.id, id)))
+      .limit(1);
+    if (!movement) return null;
+    const qrs = await client
+      .select()
+      .from(invMovementQrs)
+      .where(eq(invMovementQrs.movementId, movement.id));
+    return { movement, qrs };
+  }
+
+  async insertMovement(input: NewMovementInput, client: StockDbClient = db): Promise<InvStockMovementRow> {
+    const [row] = await client
+      .insert(invStockMovements)
+      .values({
+        tenantId: input.tenantId,
+        itemId: input.itemId,
+        location: input.location,
+        quantity: input.quantity,
+        type: input.type,
+        reason: input.reason ?? null,
+        responsible: input.responsible ?? null,
+        photoFileId: input.photoFileId ?? null,
+        purchaseOrderId: input.purchaseOrderId ?? null,
+        transferGroupId: input.transferGroupId ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async insertMovementQrs(
+    tenantId: string,
+    movementId: string,
+    qrs: NewMovementQrInput[],
+    client: StockDbClient = db,
+  ): Promise<InvMovementQrRow[]> {
+    if (qrs.length === 0) return [];
+    return client
+      .insert(invMovementQrs)
+      .values(
+        qrs.map((q) => ({
+          tenantId,
+          movementId,
+          qrValue: q.qrValue ?? null,
+          boxQr: q.boxQr ?? null,
+          homologationUnitId: q.homologationUnitId ?? null,
+        })),
+      )
+      .returning();
+  }
+
+  /**
+   * Latest ledger event type per QR value (anti-double-exit). Rows come back
+   * newest-first per QR; the first occurrence wins. Called under the item lock
+   * so two concurrent exits of the same QR serialize on the item row.
+   */
+  async latestQrEventTypes(
+    tenantId: string,
+    qrValues: string[],
+    client: StockDbClient = db,
+  ): Promise<Map<string, string>> {
+    if (qrValues.length === 0) return new Map();
+    const rows = await client
+      .select({ qrValue: invMovementQrs.qrValue, type: invStockMovements.type })
+      .from(invMovementQrs)
+      .innerJoin(invStockMovements, eq(invStockMovements.id, invMovementQrs.movementId))
+      .where(and(eq(invMovementQrs.tenantId, tenantId), inArray(invMovementQrs.qrValue, qrValues)))
+      .orderBy(invMovementQrs.qrValue, desc(invStockMovements.createdAt), desc(invStockMovements.id));
+
+    const latest = new Map<string, string>();
+    for (const row of rows) {
+      if (row.qrValue && !latest.has(row.qrValue)) latest.set(row.qrValue, row.type);
+    }
+    return latest;
+  }
+
+  async consistencyReport(tenantId: string, client: StockDbClient = db): Promise<ConsistencyRow[]> {
+    const result = await client.execute(this.consistencyQuery(tenantId));
+    const rows = result as unknown as Array<Record<string, unknown>>;
+    return rows.map((r) => ({
+      itemId: String(r.item_id),
+      location: String(r.location),
+      ledgerBalance: String(r.ledger_balance),
+      activeQrCount: Number(r.active_qr_count),
+    }));
+  }
+
+  async deleteMovements(tenantId: string, location?: string, client: StockDbClient = db): Promise<number> {
+    const rows = await this.deleteMovementsQuery(tenantId, location, client);
+    return rows.length;
+  }
+}
+
+export const inventoryStockRepository = new InventoryStockRepository();
+
+/** Movement direction sets, exported for the service/tests. */
+export const STOCK_IN_TYPES = IN_TYPES;
+export const STOCK_OUT_TYPES = OUT_TYPES;

--- a/src/services/inventory/InventoryStockService.ts
+++ b/src/services/inventory/InventoryStockService.ts
@@ -1,0 +1,483 @@
+// =============================================================================
+// RFC-0061 M2 — Stock ledger service (business rules).
+//
+// Owns the movement transaction (§M2):
+//   lock item (FOR UPDATE) → derived balance → negative-stock guard →
+//   exit-requirements matrix (W4) → anti-double-exit QR check → insert
+//   movement (+ QR links) — all inside ONE repository transaction.
+//
+// Transfers are two legs (OUT with the guard + IN) in the SAME transaction
+// sharing a transfer_group_id.
+//
+// Idempotency (S1/AC-9): the schema has NO durable idempotency storage for
+// generic movements (only the M3 receipt-entry partial UNIQUE on
+// (tenant_id, purchase_order_id) WHERE type='ENTRADA', enforced in the DB).
+// Until an `inv_idempotency_keys` table lands (Follow-up in the M2 PR), the
+// service keeps a best-effort per-process cache keyed by tenant+Idempotency-Key
+// that replays the original result within a TTL. In-flight promises are
+// shared, so a same-key retry racing the original does not double-insert
+// within this process.
+// =============================================================================
+
+import { randomUUID } from 'crypto';
+import {
+  InventoryStockRepository,
+  inventoryStockRepository,
+  StockDbClient,
+  InvItemRow,
+  InvStockMovementRow,
+  InvMovementQrRow,
+  NewMovementQrInput,
+  BalanceListFilters,
+  BalanceListRow,
+  ConsistencyRow,
+} from '../../repositories/inventory/InventoryStockRepository';
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../shared/errors/AppError';
+import { insufficientStock, qrAlreadyUsed } from '../../shared/errors/InventoryError';
+import type { CreateMovementDTO, CreateTransferDTO, StockResetDTO } from '../../dto/request/InventoryDTO';
+import type {
+  InvStockBalanceResponse,
+  InvStockConsistencyRow,
+  InvPaginatedResponse,
+} from '../../dto/response/InventoryResponseDTO';
+import type { InvItemDomain, InvStockLocation } from '../../domain/entities/Inventory';
+
+// -----------------------------------------------------------------------------
+// Repository seam (mocked in unit tests)
+// -----------------------------------------------------------------------------
+
+export type IInventoryStockRepository = Pick<
+  InventoryStockRepository,
+  | 'withTransaction'
+  | 'lockItem'
+  | 'getBalance'
+  | 'listBalances'
+  | 'listMovements'
+  | 'getMovementById'
+  | 'insertMovement'
+  | 'insertMovementQrs'
+  | 'latestQrEventTypes'
+  | 'consistencyReport'
+  | 'deleteMovements'
+>;
+
+/** Caller identity from `req.context`. */
+export interface StockContext {
+  tenantId: string;
+  userId?: string;
+}
+
+/** Read model for one movement (+ linked QRs). */
+export interface InvMovementResponse {
+  id: string;
+  itemId: string;
+  location: string;
+  quantity: number;
+  type: string;
+  reason: string | null;
+  responsible: string | null;
+  photoFileId: string | null;
+  purchaseOrderId: string | null;
+  transferGroupId: string | null;
+  imported: boolean;
+  createdAt: string;
+  createdBy: string | null;
+  qrs: Array<{ qrValue: string | null; boxQr: string | null; homologationUnitId: string | null }>;
+}
+
+export interface InvTransferResponse {
+  transferGroupId: string;
+  out: InvMovementResponse;
+  in: InvMovementResponse;
+}
+
+export interface InvStockResetResponse {
+  deletedMovements: number;
+  location: string | null;
+}
+
+const EXIT_TYPES = new Set(['SAIDA', 'TRANSFERENCIA_OUT']);
+
+// Idempotency cache tuning (best-effort, per-process — see header).
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_MAX_ENTRIES = 5000;
+
+/** Ledger grain is numeric(12,3): compare in integer thousandths (no FP drift). */
+function thousandths(n: number): number {
+  return Math.round(n * 1000);
+}
+
+export class InventoryStockService {
+  private repository: IInventoryStockRepository;
+
+  private idempotencyCache = new Map<string, { at: number; promise: Promise<unknown> }>();
+
+  constructor(repository?: IInventoryStockRepository) {
+    this.repository = repository ?? inventoryStockRepository;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
+
+  async getBalances(
+    tenantId: string,
+    filters: BalanceListFilters = {},
+  ): Promise<InvStockBalanceResponse[]> {
+    const rows = await this.repository.listBalances(tenantId, filters);
+    return rows.map((r: BalanceListRow) => ({
+      itemId: r.itemId,
+      itemName: r.itemName,
+      domain: r.domain as InvItemDomain,
+      location: r.location as InvStockLocation,
+      balance: Number(r.balance),
+      totalIn: Number(r.totalIn),
+      totalOut: Number(r.totalOut),
+      lastMovementAt: r.lastMovementAt ? new Date(r.lastMovementAt).toISOString() : null,
+    }));
+  }
+
+  async listMovements(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvMovementResponse>> {
+    const { rows, total } = await this.repository.listMovements(tenantId, page, pageSize);
+    return {
+      items: rows.map((row) => this.toMovementResponse(row, [])),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async getMovement(tenantId: string, id: string): Promise<InvMovementResponse> {
+    const found = await this.repository.getMovementById(tenantId, id);
+    if (!found) throw new NotFoundError(`Stock movement ${id} not found`);
+    return this.toMovementResponse(found.movement, found.qrs);
+  }
+
+  /**
+   * W1 consistency: ledger balance vs active-QR count per item×location for
+   * manufactured PRODUCTs (QR registry is the authority there; the ledger is a
+   * projection). drift = ledgerBalance − activeQrCount; non-zero is a defect.
+   */
+  async getConsistency(tenantId: string): Promise<InvStockConsistencyRow[]> {
+    const rows = await this.repository.consistencyReport(tenantId);
+    return rows.map((r: ConsistencyRow) => ({
+      itemId: r.itemId,
+      location: r.location as InvStockLocation,
+      ledgerBalance: Number(r.ledgerBalance),
+      activeQrCount: r.activeQrCount,
+      drift: Number(r.ledgerBalance) - r.activeQrCount,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  async createMovement(
+    ctx: StockContext,
+    dto: CreateMovementDTO,
+    idempotencyKey: string,
+  ): Promise<InvMovementResponse> {
+    return this.idempotent(ctx.tenantId, `movement:${idempotencyKey}`, () =>
+      this.doCreateMovement(ctx, dto),
+    );
+  }
+
+  async createTransfer(
+    ctx: StockContext,
+    dto: CreateTransferDTO,
+    idempotencyKey: string,
+  ): Promise<InvTransferResponse> {
+    return this.idempotent(ctx.tenantId, `transfer:${idempotencyKey}`, () =>
+      this.doCreateTransfer(ctx, dto),
+    );
+  }
+
+  /** Destructive: wipes the ledger (whole tenant or one location) in one tx. */
+  async reset(ctx: StockContext, dto: StockResetDTO): Promise<InvStockResetResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const deleted = await this.repository.deleteMovements(ctx.tenantId, dto.location, tx);
+        return { deletedMovements: deleted, location: dto.location ?? null };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Movement transaction
+  // ---------------------------------------------------------------------------
+
+  private async doCreateMovement(ctx: StockContext, dto: CreateMovementDTO): Promise<InvMovementResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const item = await this.lockItemOr404(ctx.tenantId, dto.itemId, tx);
+
+        if (EXIT_TYPES.has(dto.type)) {
+          this.assertExitRequirements(item, dto.quantity, dto.photoFileId, dto.qrs, dto.responsible);
+          await this.assertSufficientBalance(ctx.tenantId, dto.itemId, dto.location, dto.quantity, tx);
+          await this.assertQrsNotExited(ctx.tenantId, dto.qrs, tx);
+        }
+
+        const movement = await this.repository.insertMovement(
+          {
+            tenantId: ctx.tenantId,
+            itemId: dto.itemId,
+            location: dto.location,
+            quantity: String(dto.quantity),
+            type: dto.type,
+            reason: dto.reason ?? null,
+            responsible: dto.responsible ?? null,
+            photoFileId: dto.photoFileId ?? null,
+            purchaseOrderId: dto.purchaseOrderId ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        const qrs = dto.qrs?.length
+          ? await this.repository.insertMovementQrs(ctx.tenantId, movement.id, dto.qrs, tx)
+          : [];
+
+        return this.toMovementResponse(movement, qrs);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  private async doCreateTransfer(ctx: StockContext, dto: CreateTransferDTO): Promise<InvTransferResponse> {
+    const transferGroupId = randomUUID();
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        await this.lockItemOr404(ctx.tenantId, dto.itemId, tx);
+        await this.assertSufficientBalance(ctx.tenantId, dto.itemId, dto.fromLocation, dto.quantity, tx);
+
+        const base = {
+          tenantId: ctx.tenantId,
+          itemId: dto.itemId,
+          quantity: String(dto.quantity),
+          reason: dto.reason ?? null,
+          transferGroupId,
+          createdBy: ctx.userId ?? null,
+        };
+        const outLeg = await this.repository.insertMovement(
+          { ...base, location: dto.fromLocation, type: 'TRANSFERENCIA_OUT' },
+          tx,
+        );
+        const inLeg = await this.repository.insertMovement(
+          { ...base, location: dto.toLocation, type: 'TRANSFERENCIA_IN' },
+          tx,
+        );
+
+        return {
+          transferGroupId,
+          out: this.toMovementResponse(outLeg, []),
+          in: this.toMovementResponse(inLeg, []),
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Guards
+  // ---------------------------------------------------------------------------
+
+  private async lockItemOr404(tenantId: string, itemId: string, tx: StockDbClient): Promise<InvItemRow> {
+    const item = await this.repository.lockItem(tenantId, itemId, tx);
+    if (!item) throw new NotFoundError(`Item ${itemId} not found`);
+    return item;
+  }
+
+  /** Negative-stock guard — derived balance under the item lock (§M2/AC-2). */
+  private async assertSufficientBalance(
+    tenantId: string,
+    itemId: string,
+    location: string,
+    requested: number,
+    tx: StockDbClient,
+  ): Promise<void> {
+    const totals = await this.repository.getBalance(tenantId, itemId, location, tx);
+    const balance = Number(totals.balance);
+    if (thousandths(balance) < thousandths(requested)) {
+      throw insufficientStock(itemId, location, balance, requested);
+    }
+  }
+
+  /**
+   * Exit-requirements matrix (W4), enforced server-side:
+   *
+   * | Domain            | is_manufactured | Exit requires                       |
+   * |-------------------|-----------------|-------------------------------------|
+   * | PRODUCT           | true            | QRs (count = quantity) AND photo    |
+   * | PRODUCT/COMPONENT | false           | QR OR photo                         |
+   * | THIRD_PARTY       | —               | photo (no QRs)                      |
+   * | TOOL              | —               | destination (photo optional)        |
+   *
+   * The movement DTO has no dedicated `destination` field (schema/DTO are
+   * frozen for this PR): TOOL destination rides on `responsible` — Follow-up.
+   */
+  private assertExitRequirements(
+    item: InvItemRow,
+    quantity: number,
+    photoFileId: string | undefined,
+    qrs: NewMovementQrInput[] | undefined,
+    responsible: string | undefined,
+  ): void {
+    const qrCount = qrs?.length ?? 0;
+    const domain = item.domain as InvItemDomain;
+
+    if (domain === 'PRODUCT' && item.isManufactured) {
+      if (qrCount === 0) {
+        throw new ValidationError('Saída de produto manufaturado exige QRs vinculados');
+      }
+      if (thousandths(quantity) !== qrCount * 1000) {
+        throw new ValidationError(
+          `Saída de produto manufaturado: quantidade (${quantity}) deve igualar o número de QRs (${qrCount})`,
+        );
+      }
+      if (!photoFileId) {
+        throw new ValidationError('Saída de produto manufaturado exige foto');
+      }
+      return;
+    }
+
+    if (domain === 'PRODUCT' || domain === 'COMPONENT') {
+      if (qrCount === 0 && !photoFileId) {
+        throw new ValidationError('Saída exige QR ou foto');
+      }
+      return;
+    }
+
+    if (domain === 'THIRD_PARTY') {
+      if (qrCount > 0) {
+        throw new ValidationError('Saída de item de terceiros não aceita QRs');
+      }
+      if (!photoFileId) {
+        throw new ValidationError('Saída de item de terceiros exige foto');
+      }
+      return;
+    }
+
+    // TOOL
+    if (!responsible || responsible.trim() === '') {
+      throw new ValidationError('Saída de ferramenta exige destino (responsible)');
+    }
+  }
+
+  /** Anti-double-exit: a QR whose latest ledger event is an exit is spent. */
+  private async assertQrsNotExited(
+    tenantId: string,
+    qrs: NewMovementQrInput[] | undefined,
+    tx: StockDbClient,
+  ): Promise<void> {
+    const values = (qrs ?? []).map((q) => q.qrValue).filter((v): v is string => !!v);
+    if (values.length === 0) return;
+    const latest = await this.repository.latestQrEventTypes(tenantId, values, tx);
+    for (const value of values) {
+      const lastType = latest.get(value);
+      if (lastType && EXIT_TYPES.has(lastType)) throw qrAlreadyUsed(value);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotency (best-effort, per-process — see header)
+  // ---------------------------------------------------------------------------
+
+  private async idempotent<T>(tenantId: string, key: string, run: () => Promise<T>): Promise<T> {
+    const cacheKey = `${tenantId}:${key}`;
+    const now = Date.now();
+    const hit = this.idempotencyCache.get(cacheKey);
+    if (hit && now - hit.at < IDEMPOTENCY_TTL_MS) {
+      return hit.promise as Promise<T>;
+    }
+
+    const promise = run();
+    this.idempotencyCache.set(cacheKey, { at: now, promise });
+    // A failed attempt must NOT poison the key — the client retries with the
+    // same Idempotency-Key precisely because the first try failed.
+    promise.catch(() => this.idempotencyCache.delete(cacheKey));
+    this.evictStaleIdempotencyEntries(now);
+    return promise;
+  }
+
+  private evictStaleIdempotencyEntries(now: number): void {
+    if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    for (const [key, entry] of this.idempotencyCache) {
+      if (now - entry.at >= IDEMPOTENCY_TTL_MS) this.idempotencyCache.delete(key);
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    }
+    // Still over cap after TTL sweep: drop oldest-inserted first (Map order).
+    for (const key of this.idempotencyCache.keys()) {
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+      this.idempotencyCache.delete(key);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------------
+
+  private toMovementResponse(row: InvStockMovementRow, qrs: InvMovementQrRow[]): InvMovementResponse {
+    return {
+      id: row.id,
+      itemId: row.itemId,
+      location: row.location,
+      quantity: Number(row.quantity),
+      type: row.type,
+      reason: row.reason ?? null,
+      responsible: row.responsible ?? null,
+      photoFileId: row.photoFileId ?? null,
+      purchaseOrderId: row.purchaseOrderId ?? null,
+      transferGroupId: row.transferGroupId ?? null,
+      imported: row.imported ?? false,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+      createdBy: row.createdBy ?? null,
+      qrs: qrs.map((q) => ({
+        qrValue: q.qrValue ?? null,
+        boxQr: q.boxQr ?? null,
+        homologationUnitId: q.homologationUnitId ?? null,
+      })),
+    };
+  }
+
+  /**
+   * Map low-level DB errors to the RFC contract. Drizzle wraps the driver
+   * error (DrizzleQueryError): the real SQLSTATE lives on `err.cause.code`,
+   * not `err.code`/`err.message` — inspect both (same pattern as
+   * EntityService.mapRepoError).
+   */
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      throw new ConflictError('Movimento duplicado (violação de unicidade)');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (item, foto, OC ou unidade homologada)');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+export const inventoryStockService = new InventoryStockService();

--- a/tests/integration/inventory/m2-concurrency.test.ts
+++ b/tests/integration/inventory/m2-concurrency.test.ts
@@ -1,0 +1,121 @@
+/**
+ * RFC-0061 M2 — REAL concurrency harness (AC-2, A6): stock can never go
+ * negative under concurrent exits. Requires a live PostgreSQL with migration
+ * 0067 applied and is gated behind INV_IT_DB — it is SKIPPED otherwise (the
+ * default unit/CI runs never touch a database).
+ *
+ * Run with:
+ *   INV_IT_DB=1 DATABASE_URL=postgres://... npx jest tests/integration/inventory
+ *
+ * The suite opens TWO independent postgres connections (two drizzle clients
+ * over two sockets) and races two exits whose sum exceeds the balance: the
+ * FOR UPDATE item lock must serialize them — exactly one succeeds, the loser
+ * gets INV_INSUFFICIENT_STOCK — and the final derived balance stays
+ * non-negative.
+ *
+ * NOTE: a `describe.skip` body still executes at collection time, so every
+ * import/connection happens lazily inside beforeAll.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { Sql } from 'postgres';
+import type { InventoryStockService as ServiceT } from '../../../src/services/inventory/InventoryStockService';
+import type { InventoryStockRepository as RepositoryT } from '../../../src/repositories/inventory/InventoryStockRepository';
+
+type Schema = typeof import('../../../src/infrastructure/database/drizzle/schema');
+type Db = PostgresJsDatabase<Schema>;
+
+const gate = process.env.INV_IT_DB ? describe : describe.skip;
+
+gate('M2 concurrency (two real pg connections)', () => {
+  jest.setTimeout(30_000);
+
+  const TENANT = 'eeeeeeee-0000-4000-8000-000000000001';
+
+  let sqlA: Sql;
+  let sqlB: Sql;
+  let dbA: Db;
+  let dbB: Db;
+  let schema: Schema;
+  let repoA: RepositoryT;
+  let svcA: ServiceT;
+  let svcB: ServiceT;
+  let itemId: string;
+
+  /** Repository whose withTransaction is pinned to one connection. */
+  function repoOn(db: Db, Repository: new () => RepositoryT): RepositoryT {
+    const repo = new Repository();
+    (repo as { withTransaction: unknown }).withTransaction = <T>(fn: (tx: never) => Promise<T>) =>
+      db.transaction(fn as never) as Promise<T>;
+    return repo;
+  }
+
+  beforeAll(async () => {
+    const { drizzle } = await import('drizzle-orm/postgres-js');
+    const { default: postgres } = await import('postgres');
+    schema = await import('../../../src/infrastructure/database/drizzle/schema');
+    const { InventoryStockService } = await import('../../../src/services/inventory/InventoryStockService');
+    const { InventoryStockRepository } = await import('../../../src/repositories/inventory/InventoryStockRepository');
+
+    const url = process.env.DATABASE_URL as string;
+    sqlA = postgres(url, { max: 1 });
+    sqlB = postgres(url, { max: 1 });
+    dbA = drizzle(sqlA, { schema }) as never;
+    dbB = drizzle(sqlB, { schema }) as never;
+
+    repoA = repoOn(dbA, InventoryStockRepository);
+    svcA = new InventoryStockService(repoA);
+    svcB = new InventoryStockService(repoOn(dbB, InventoryStockRepository));
+
+    const [item] = await dbA
+      .insert(schema.invItems)
+      .values({ tenantId: TENANT, name: `conc-test-${Date.now()}`, domain: 'TOOL' })
+      .returning();
+    itemId = item.id;
+
+    // Seed balance 10 at FABRICA.
+    await dbA.insert(schema.invStockMovements).values({
+      tenantId: TENANT,
+      itemId,
+      location: 'FABRICA',
+      quantity: '10',
+      type: 'ENTRADA',
+    });
+  });
+
+  afterAll(async () => {
+    if (!sqlA) return;
+    await dbA.delete(schema.invStockMovements).where(eq(schema.invStockMovements.tenantId, TENANT));
+    await dbA.delete(schema.invItems).where(eq(schema.invItems.id, itemId));
+    await sqlA.end({ timeout: 5 });
+    await sqlB.end({ timeout: 5 });
+  });
+
+  it('two concurrent exits of 7 against a balance of 10: exactly one wins', async () => {
+    const ctx = { tenantId: TENANT };
+    const dto = {
+      itemId,
+      location: 'FABRICA',
+      quantity: 7,
+      type: 'SAIDA',
+      responsible: 'Técnico A', // TOOL exit: destination required
+    } as never;
+
+    const outcomes = await Promise.allSettled([
+      svcA.createMovement(ctx, dto, `conc-a-${Date.now()}`),
+      svcB.createMovement(ctx, dto, `conc-b-${Date.now()}`),
+    ]);
+
+    const wins = outcomes.filter((o) => o.status === 'fulfilled');
+    const losses = outcomes.filter((o): o is PromiseRejectedResult => o.status === 'rejected');
+
+    expect(wins).toHaveLength(1);
+    expect(losses).toHaveLength(1);
+    expect((losses[0].reason as { code?: string }).code).toBe('INV_INSUFFICIENT_STOCK');
+
+    // Final derived balance: 10 − 7 = 3, never negative.
+    const totals = await repoA.getBalance(TENANT, itemId, 'FABRICA', dbA as never);
+    expect(Number(totals.balance)).toBe(3);
+  });
+});

--- a/tests/unit/inventory/m2-contract.test.ts
+++ b/tests/unit/inventory/m2-contract.test.ts
@@ -1,0 +1,272 @@
+/**
+ * RFC-0061 M2 — wired-contract test for the REAL stock routes.
+ *
+ * Supersedes the M2 cases of tests/unit/controllers/inventory.contract.test.ts
+ * that asserted the 501 INV_NOT_IMPLEMENTED marker ("POST /stock/movements
+ * with key + valid body → 501"): M2 now serves real handlers, so a valid
+ * movement POST is a 201. Auth chain and guard behavior (missing
+ * Idempotency-Key → 400, missing confirmationToken → 428) are unchanged.
+ *
+ * Same harness as the original contract test: real router + real auth
+ * middleware, auth leaves mocked — plus the M2 service mocked (no DB).
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryStockService', () => ({
+  inventoryStockService: {
+    getBalances: jest.fn(),
+    getConsistency: jest.fn(),
+    listMovements: jest.fn(),
+    getMovement: jest.fn(),
+    createMovement: jest.fn(),
+    createTransfer: jest.fn(),
+    reset: jest.fn(),
+  },
+}));
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryStockService } from '../../../src/services/inventory/InventoryStockService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T };
+
+const svc = inventoryStockService as jest.Mocked<typeof inventoryStockService>;
+
+const goodMovement = { itemId: ITEM_ID, location: 'FABRICA', quantity: 3, type: 'ENTRADA' };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M2 stock routes — real contract (supersedes the 501 cases)', () => {
+  it('POST /stock/movements with key + valid body → 201 with the movement (was 501)', async () => {
+    const movement = { id: 'mov-1', itemId: ITEM_ID, location: 'FABRICA', quantity: 3, type: 'ENTRADA', qrs: [] };
+    svc.createMovement.mockResolvedValue(movement as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/movements'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'abc-123' },
+        body: JSON.stringify(goodMovement),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<typeof movement>;
+      expect(body.success).toBe(true);
+      expect(body.data.id).toBe('mov-1');
+      expect(svc.createMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        expect.objectContaining({ itemId: ITEM_ID, type: 'ENTRADA' }),
+        'abc-123',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /stock/movements without Idempotency-Key → still 400 INV_IDEMPOTENCY_KEY_MISSING', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/movements'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify(goodMovement),
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(svc.createMovement).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /stock/movements with a transfer type → 400 (transfers have their own endpoint)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/movements'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'k' },
+        body: JSON.stringify({ ...goodMovement, type: 'TRANSFERENCIA_OUT' }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.createMovement).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /stock/transfers → 201 with both legs', async () => {
+    svc.createTransfer.mockResolvedValue({
+      transferGroupId: 'tg-1',
+      out: { id: 'a', type: 'TRANSFERENCIA_OUT' },
+      in: { id: 'b', type: 'TRANSFERENCIA_IN' },
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/transfers'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 't-1' },
+        body: JSON.stringify({ itemId: ITEM_ID, fromLocation: 'FABRICA', toLocation: 'ALMOXARIFADO', quantity: 2 }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<{ transferGroupId: string }>;
+      expect(body.data.transferGroupId).toBe('tg-1');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /stock/balances → 200 with the derived balances', async () => {
+    svc.getBalances.mockResolvedValue([
+      { itemId: ITEM_ID, itemName: 'X', domain: 'PRODUCT', location: 'FABRICA', balance: 7, totalIn: 10, totalOut: 3, lastMovementAt: null },
+    ] as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/balances?location=FABRICA'), {
+        headers: { 'x-api-key': 'gcdr_cust_x' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<Array<{ balance: number }>>;
+      expect(body.data[0].balance).toBe(7);
+      expect(svc.getBalances).toHaveBeenCalledWith(TENANT, expect.objectContaining({ location: 'FABRICA' }));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /stock/movements → 200 paginated envelope (total/totalPages)', async () => {
+    svc.listMovements.mockResolvedValue({ items: [], page: 2, pageSize: 10, total: 25, totalPages: 3 } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/movements?page=2&pageSize=10'), {
+        headers: { 'x-api-key': 'gcdr_cust_x' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ total: number; totalPages: number }>;
+      expect(body.data.total).toBe(25);
+      expect(body.data.totalPages).toBe(3);
+      expect(svc.listMovements).toHaveBeenCalledWith(TENANT, 2, 10);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /stock/consistency → 200 with rows + driftCount', async () => {
+    svc.getConsistency.mockResolvedValue([
+      { itemId: ITEM_ID, location: 'FABRICA', ledgerBalance: 5, activeQrCount: 4, drift: 1 },
+    ] as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/consistency'), { headers: { 'x-api-key': 'gcdr_cust_x' } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ driftCount: number }>;
+      expect(body.data.driftCount).toBe(1);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /stock/reset without confirmationToken → 428 (guard unchanged)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/reset'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(428);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(svc.reset).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /stock/reset with X-Confirmation-Token header → 200', async () => {
+    svc.reset.mockResolvedValue({ deletedMovements: 12, location: null } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/reset'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'x-confirmation-token': 'excluir' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ deletedMovements: number }>;
+      expect(body.data.deletedMovements).toBe(12);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('service InventoryError surfaces its code + details through the errorHandler', async () => {
+    const { insufficientStock } = jest.requireActual<
+      typeof import('../../../src/shared/errors/InventoryError')
+    >('../../../src/shared/errors/InventoryError');
+    svc.createMovement.mockRejectedValue(insufficientStock(ITEM_ID, 'FABRICA', 1, 5));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/stock/movements'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'k9' },
+        body: JSON.stringify(goodMovement),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_INSUFFICIENT_STOCK');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m2-exit-matrix.test.ts
+++ b/tests/unit/inventory/m2-exit-matrix.test.ts
@@ -1,0 +1,146 @@
+/**
+ * RFC-0061 M2 — exit-requirements matrix (W4), full combination coverage.
+ *
+ * | Domain            | is_manufactured | Exit requires                    |
+ * |-------------------|-----------------|----------------------------------|
+ * | PRODUCT           | true            | QRs (count = quantity) AND photo |
+ * | PRODUCT/COMPONENT | false           | QR OR photo                      |
+ * | THIRD_PARTY       | —               | photo (no QRs)                   |
+ * | TOOL              | —               | destination (responsible)        |
+ *
+ * Service with mocked repository — no DB.
+ */
+
+import { InventoryStockService } from '../../../src/services/inventory/InventoryStockService';
+import type { CreateMovementDTO } from '../../../src/dto/request/InventoryDTO';
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import { CTX, ITEM_ID, PHOTO_ID, makeItem, makeRepo } from './m2-helpers';
+
+const KEY = 'idem-key-1';
+
+function exitDto(overrides: Partial<CreateMovementDTO> = {}): CreateMovementDTO {
+  return {
+    itemId: ITEM_ID,
+    location: 'FABRICA',
+    quantity: 2,
+    type: 'SAIDA',
+    ...overrides,
+  } as CreateMovementDTO;
+}
+
+const qrs = (n: number) => Array.from({ length: n }, (_, i) => ({ qrValue: `QR-${i}` }));
+
+describe('M2 exit-requirements matrix (W4)', () => {
+  describe('PRODUCT manufactured — QRs (count = quantity) AND photo', () => {
+    const item = makeItem({ domain: 'PRODUCT', isManufactured: true });
+
+    it('rejects an exit without QRs', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto({ photoFileId: PHOTO_ID }), KEY)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it('rejects an exit whose QR count differs from quantity', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(
+        svc.createMovement(CTX, exitDto({ quantity: 3, qrs: qrs(2), photoFileId: PHOTO_ID }), KEY),
+      ).rejects.toThrow(/quantidade.*QRs|QRs.*quantidade/i);
+    });
+
+    it('rejects an exit with QRs but no photo', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto({ qrs: qrs(2) }), KEY)).rejects.toThrow(/foto/i);
+    });
+
+    it('accepts QRs (count = quantity) + photo, persisting the QR links', async () => {
+      const repo = makeRepo({ lockItem: jest.fn(async () => item) });
+      const svc = new InventoryStockService(repo);
+      const result = await svc.createMovement(
+        CTX,
+        exitDto({ quantity: 2, qrs: qrs(2), photoFileId: PHOTO_ID }),
+        KEY,
+      );
+      expect(result.type).toBe('SAIDA');
+      expect(result.qrs).toHaveLength(2);
+      expect(repo.insertMovementQrs).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe.each(['PRODUCT', 'COMPONENT'] as const)('%s non-manufactured — QR OR photo', (domain) => {
+    const item = makeItem({ domain, isManufactured: false });
+
+    it('rejects an exit with neither QR nor photo', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto(), KEY)).rejects.toThrow(/QR ou foto/i);
+    });
+
+    it('accepts an exit with a QR only', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      const result = await svc.createMovement(CTX, exitDto({ qrs: qrs(1) }), KEY);
+      expect(result.type).toBe('SAIDA');
+    });
+
+    it('accepts an exit with a photo only', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      const result = await svc.createMovement(CTX, exitDto({ photoFileId: PHOTO_ID }), KEY);
+      expect(result.photoFileId).toBe(PHOTO_ID);
+    });
+  });
+
+  describe('THIRD_PARTY — photo required, QRs not accepted', () => {
+    const item = makeItem({ domain: 'THIRD_PARTY' });
+
+    it('rejects an exit without photo', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto(), KEY)).rejects.toThrow(/foto/i);
+    });
+
+    it('rejects an exit carrying QRs', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(
+        svc.createMovement(CTX, exitDto({ qrs: qrs(1), photoFileId: PHOTO_ID }), KEY),
+      ).rejects.toThrow(/QR/i);
+    });
+
+    it('accepts an exit with a photo', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      const result = await svc.createMovement(CTX, exitDto({ photoFileId: PHOTO_ID }), KEY);
+      expect(result.type).toBe('SAIDA');
+    });
+  });
+
+  describe('TOOL — destination (responsible) required, photo optional', () => {
+    const item = makeItem({ domain: 'TOOL' });
+
+    it('rejects an exit without responsible/destination', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto(), KEY)).rejects.toThrow(/destino/i);
+    });
+
+    it('rejects a blank responsible', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      await expect(svc.createMovement(CTX, exitDto({ responsible: '   ' }), KEY)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it('accepts an exit with responsible and no photo', async () => {
+      const svc = new InventoryStockService(makeRepo({ lockItem: jest.fn(async () => item) }));
+      const result = await svc.createMovement(CTX, exitDto({ responsible: 'Bancada 3' }), KEY);
+      expect(result.responsible).toBe('Bancada 3');
+    });
+  });
+
+  describe('non-exit movements skip the matrix', () => {
+    it.each(['ENTRADA', 'AJUSTE'] as const)('%s needs neither QR, photo nor responsible', async (type) => {
+      const item = makeItem({ domain: 'PRODUCT', isManufactured: true });
+      const repo = makeRepo({ lockItem: jest.fn(async () => item) });
+      const svc = new InventoryStockService(repo);
+      const result = await svc.createMovement(CTX, exitDto({ type }), `${KEY}:${type}`);
+      expect(result.type).toBe(type);
+      // No balance guard on additive movements either.
+      expect(repo.getBalance).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/inventory/m2-helpers.ts
+++ b/tests/unit/inventory/m2-helpers.ts
@@ -1,0 +1,102 @@
+// Shared fixtures/mocks for the RFC-0061 M2 unit suites (service with a
+// mocked repository — no DB).
+
+import type {
+  IInventoryStockRepository,
+} from '../../../src/services/inventory/InventoryStockService';
+import type {
+  InvItemRow,
+  InvStockMovementRow,
+  InvMovementQrRow,
+  NewMovementInput,
+  NewMovementQrInput,
+} from '../../../src/repositories/inventory/InventoryStockRepository';
+
+export const TENANT = '11111111-1111-1111-1111-111111111111';
+export const USER = '22222222-2222-2222-2222-222222222222';
+export const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+export const PHOTO_ID = '44444444-4444-4444-4444-444444444444';
+
+export const CTX = { tenantId: TENANT, userId: USER };
+
+let movementSeq = 0;
+
+export function makeItem(overrides: Partial<InvItemRow> = {}): InvItemRow {
+  return {
+    id: ITEM_ID,
+    tenantId: TENANT,
+    name: 'Item de teste',
+    normalizedName: 'item de teste',
+    domain: 'COMPONENT',
+    link: null,
+    description: null,
+    isManufactured: false,
+    lossPercent: '0',
+    lotQuantity: null,
+    purchaseType: null,
+    photoFileId: null,
+    active: true,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    createdBy: null,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    updatedBy: null,
+    ...overrides,
+  } as InvItemRow;
+}
+
+export function movementRowFrom(input: NewMovementInput): InvStockMovementRow {
+  movementSeq += 1;
+  return {
+    id: `00000000-0000-0000-0000-${String(movementSeq).padStart(12, '0')}`,
+    tenantId: input.tenantId,
+    itemId: input.itemId,
+    location: input.location,
+    quantity: input.quantity,
+    type: input.type,
+    reason: input.reason ?? null,
+    responsible: input.responsible ?? null,
+    photoFileId: input.photoFileId ?? null,
+    purchaseOrderId: input.purchaseOrderId ?? null,
+    transferGroupId: input.transferGroupId ?? null,
+    imported: false,
+    createdAt: new Date(),
+    createdBy: input.createdBy ?? null,
+  } as InvStockMovementRow;
+}
+
+export type MockRepo = jest.Mocked<IInventoryStockRepository>;
+
+/**
+ * Repo mock: withTransaction just runs the callback with a fake tx.
+ * Overrides are intentionally loose-typed — jest.fn() literals with narrower
+ * signatures (e.g. `jest.fn(async () => item)`) stay ergonomic in the suites.
+ */
+export function makeRepo(overrides: Record<string, jest.Mock> = {}): MockRepo {
+  const repo = {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    lockItem: jest.fn(async () => makeItem()),
+    getBalance: jest.fn(async () => ({ balance: '100', totalIn: '100', totalOut: '0', lastMovementAt: null })),
+    listBalances: jest.fn(async () => []),
+    listMovements: jest.fn(async () => ({ rows: [], total: 0 })),
+    getMovementById: jest.fn(async () => null),
+    insertMovement: jest.fn(async (input: NewMovementInput) => movementRowFrom(input)),
+    insertMovementQrs: jest.fn(
+      async (tenantId: string, movementId: string, qrs: NewMovementQrInput[]) =>
+        qrs.map(
+          (q, i) =>
+            ({
+              id: `55555555-0000-0000-0000-${String(i).padStart(12, '0')}`,
+              tenantId,
+              movementId,
+              qrValue: q.qrValue ?? null,
+              boxQr: q.boxQr ?? null,
+              homologationUnitId: q.homologationUnitId ?? null,
+            }) as InvMovementQrRow,
+        ),
+    ),
+    latestQrEventTypes: jest.fn(async () => new Map<string, string>()),
+    consistencyReport: jest.fn(async () => []),
+    deleteMovements: jest.fn(async () => 0),
+  } as unknown as MockRepo;
+  return Object.assign(repo, overrides);
+}

--- a/tests/unit/inventory/m2-idempotency.test.ts
+++ b/tests/unit/inventory/m2-idempotency.test.ts
@@ -1,0 +1,86 @@
+/**
+ * RFC-0061 M2 — Idempotency-Key replay (S1/AC-9), best-effort per-process
+ * cache (the schema has no durable idempotency storage yet — PR Follow-up).
+ */
+
+import { InventoryStockService } from '../../../src/services/inventory/InventoryStockService';
+import type { CreateMovementDTO } from '../../../src/dto/request/InventoryDTO';
+import { CTX, ITEM_ID, makeRepo } from './m2-helpers';
+
+function entradaDto(): CreateMovementDTO {
+  return { itemId: ITEM_ID, location: 'FABRICA', quantity: 3, type: 'ENTRADA' } as CreateMovementDTO;
+}
+
+describe('M2 idempotency replay', () => {
+  it('replaying the same Idempotency-Key returns the original result and creates nothing', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+
+    const first = await svc.createMovement(CTX, entradaDto(), 'same-key');
+    const replay = await svc.createMovement(CTX, entradaDto(), 'same-key');
+
+    expect(replay).toEqual(first);
+    expect(replay.id).toBe(first.id);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('different keys create distinct movements', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+    const a = await svc.createMovement(CTX, entradaDto(), 'key-a');
+    const b = await svc.createMovement(CTX, entradaDto(), 'key-b');
+    expect(a.id).not.toBe(b.id);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys are scoped per tenant', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+    await svc.createMovement(CTX, entradaDto(), 'shared-key');
+    await svc.createMovement(
+      { tenantId: '99999999-9999-9999-9999-999999999999', userId: CTX.userId },
+      entradaDto(),
+      'shared-key',
+    );
+    expect(repo.insertMovement).toHaveBeenCalledTimes(2);
+  });
+
+  it('movement and transfer keys do not collide', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+    await svc.createMovement(CTX, entradaDto(), 'k');
+    await svc.createTransfer(
+      CTX,
+      { itemId: ITEM_ID, fromLocation: 'FABRICA', toLocation: 'ALMOXARIFADO', quantity: 1 } as never,
+      'k',
+    );
+    // 1 movement + 2 transfer legs — the transfer was NOT swallowed as a replay.
+    expect(repo.insertMovement).toHaveBeenCalledTimes(3);
+  });
+
+  it('a failed attempt does not poison the key (retry after failure re-executes)', async () => {
+    const repo = makeRepo();
+    repo.insertMovement.mockRejectedValueOnce(new Error('transient'));
+    const svc = new InventoryStockService(repo);
+
+    await expect(svc.createMovement(CTX, entradaDto(), 'retry-key')).rejects.toThrow('transient');
+    // Let the microtask that evicts the failed entry run.
+    await new Promise((r) => setImmediate(r));
+
+    const retry = await svc.createMovement(CTX, entradaDto(), 'retry-key');
+    expect(retry.type).toBe('ENTRADA');
+    expect(repo.insertMovement).toHaveBeenCalledTimes(2);
+  });
+
+  it('two concurrent requests with the same key share ONE execution', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+    const [a, b] = await Promise.all([
+      svc.createMovement(CTX, entradaDto(), 'race-key'),
+      svc.createMovement(CTX, entradaDto(), 'race-key'),
+    ]);
+    expect(a.id).toBe(b.id);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/inventory/m2-repository.sql.test.ts
+++ b/tests/unit/inventory/m2-repository.sql.test.ts
@@ -1,0 +1,125 @@
+/**
+ * RFC-0061 M2 — SQL-shape tests for InventoryStockRepository (no DB).
+ * Same pattern as CentralCommandRepository.claim.sql.test.ts: assert the
+ * generated SQL via PgDialect.sqlToQuery, most importantly the item-row
+ * FOR UPDATE lock the negative-stock guard depends on (§M2).
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { InventoryStockRepository } from '../../../src/repositories/inventory/InventoryStockRepository';
+
+const dialect = new PgDialect();
+
+function queryOf(builder: unknown): { sql: string; params: unknown[] } {
+  const sqlObj = (builder as { getSQL: () => SQL }).getSQL();
+  const q = dialect.sqlToQuery(sqlObj);
+  return { sql: q.sql, params: q.params };
+}
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM = '33333333-3333-3333-3333-333333333333';
+
+const repo = new InventoryStockRepository();
+
+describe('InventoryStockRepository.lockItemQuery SQL shape', () => {
+  const { sql, params } = queryOf(repo.lockItemQuery(TENANT, ITEM));
+
+  it('selects the item row from inv_items scoped by tenant + id', () => {
+    expect(sql).toMatch(/from\s+"inv_items"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/"id"\s*=/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, ITEM]));
+  });
+
+  it('locks the row with FOR UPDATE (serializes concurrent movements per item)', () => {
+    expect(sql).toMatch(/for\s+update/i);
+    expect(sql).toMatch(/limit\s+/i);
+  });
+});
+
+describe('InventoryStockRepository.balanceQuery SQL shape', () => {
+  const { sql, params } = queryOf(repo.balanceQuery(TENANT, ITEM, 'FABRICA'));
+
+  it('aggregates over inv_stock_movements scoped by tenant + item + location', () => {
+    expect(sql).toMatch(/from\s+"inv_stock_movements"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/"item_id"\s*=/i);
+    expect(sql).toMatch(/"location"\s*=/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, ITEM, 'FABRICA']));
+  });
+
+  it('derives balance as in-types minus out-types (DEC-2 — never stored)', () => {
+    expect(sql).toMatch(/case\s+when\s+"type"\s+in\s+\('ENTRADA','AJUSTE','TRANSFERENCIA_IN'\)/i);
+    expect(sql).toMatch(/else\s+-\s*"quantity"/i);
+    expect(sql).toMatch(/coalesce\(sum/i);
+  });
+
+  it('splits totalIn/totalOut with FILTER clauses and takes max(created_at)', () => {
+    expect(sql).toMatch(/filter\s*\(where\s+"type"\s+in\s+\('ENTRADA','AJUSTE','TRANSFERENCIA_IN'\)\)/i);
+    expect(sql).toMatch(/filter\s*\(where\s+"type"\s+in\s+\('SAIDA','TRANSFERENCIA_OUT'\)\)/i);
+    expect(sql).toMatch(/max\("created_at"\)/i);
+  });
+});
+
+describe('InventoryStockRepository.listBalancesQuery SQL shape', () => {
+  it('groups by (item, location) joined with the catalog', () => {
+    const { sql } = queryOf(repo.listBalancesQuery(TENANT, {}));
+    expect(sql).toMatch(/inner\s+join\s+"inv_items"/i);
+    expect(sql).toMatch(/group\s+by/i);
+    expect(sql).toMatch(/"inv_stock_movements"\."item_id"/i);
+    expect(sql).toMatch(/"inv_stock_movements"\."location"/i);
+  });
+
+  it('applies location and domain filters when given', () => {
+    const { sql, params } = queryOf(
+      repo.listBalancesQuery(TENANT, { location: 'ALMOXARIFADO', domain: 'PRODUCT' }),
+    );
+    expect(sql).toMatch(/"inv_stock_movements"\."location"\s*=/i);
+    expect(sql).toMatch(/"inv_items"\."domain"\s*=/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, 'ALMOXARIFADO', 'PRODUCT']));
+  });
+});
+
+describe('InventoryStockRepository.listMovementsQuery SQL shape', () => {
+  const { sql, params } = queryOf(repo.listMovementsQuery(TENANT, 2, 20));
+
+  it('paginates the tenant ledger newest-first', () => {
+    expect(sql).toMatch(/from\s+"inv_stock_movements"/i);
+    expect(sql).toMatch(/order\s+by\s+"inv_stock_movements"\."created_at"\s+desc/i);
+    expect(sql).toMatch(/limit\s+/i);
+    expect(sql).toMatch(/offset\s+/i);
+    // page 2, pageSize 20 → limit 20 offset 20
+    expect(params).toEqual(expect.arrayContaining([TENANT, 20, 20]));
+  });
+});
+
+describe('InventoryStockRepository.consistencyQuery SQL shape', () => {
+  const q = dialect.sqlToQuery(repo.consistencyQuery(TENANT));
+
+  it('compares ledger balance vs latest-event active QRs for manufactured items (W1)', () => {
+    expect(q.sql).toMatch(/inv_stock_movements/);
+    expect(q.sql).toMatch(/inv_movement_qrs/);
+    expect(q.sql).toMatch(/is_manufactured/);
+    expect(q.sql).toMatch(/DISTINCT ON \(mq\.qr_value\)/);
+    expect(q.sql).toMatch(/type NOT IN \('SAIDA','TRANSFERENCIA_OUT'\)/);
+    expect(q.sql).toMatch(/FULL OUTER JOIN/);
+    expect(q.params).toEqual([TENANT, TENANT]);
+  });
+});
+
+describe('InventoryStockRepository.deleteMovementsQuery SQL shape', () => {
+  it('deletes the tenant ledger (QR links cascade via FK)', () => {
+    const { sql, params } = queryOf(repo.deleteMovementsQuery(TENANT));
+    expect(sql).toMatch(/delete\s+from\s+"inv_stock_movements"/i);
+    expect(sql).toMatch(/"tenant_id"\s*=/i);
+    expect(sql).toMatch(/returning/i);
+    expect(params).toEqual([TENANT]);
+  });
+
+  it('narrows to one location when given', () => {
+    const { sql, params } = queryOf(repo.deleteMovementsQuery(TENANT, 'FABRICA'));
+    expect(sql).toMatch(/"location"\s*=/i);
+    expect(params).toEqual(expect.arrayContaining([TENANT, 'FABRICA']));
+  });
+});

--- a/tests/unit/inventory/m2-stock-guard.test.ts
+++ b/tests/unit/inventory/m2-stock-guard.test.ts
@@ -1,0 +1,110 @@
+/**
+ * RFC-0061 M2 — negative-stock guard (AC-2) and anti-double-exit QR check,
+ * all inside the movement transaction (mocked repository — no DB).
+ */
+
+import { InventoryStockService } from '../../../src/services/inventory/InventoryStockService';
+import type { CreateMovementDTO } from '../../../src/dto/request/InventoryDTO';
+import { InventoryError } from '../../../src/shared/errors/InventoryError';
+import { NotFoundError } from '../../../src/shared/errors/AppError';
+import { CTX, ITEM_ID, PHOTO_ID, makeItem, makeRepo } from './m2-helpers';
+
+function exitDto(overrides: Partial<CreateMovementDTO> = {}): CreateMovementDTO {
+  return {
+    itemId: ITEM_ID,
+    location: 'ALMOXARIFADO',
+    quantity: 5,
+    type: 'SAIDA',
+    photoFileId: PHOTO_ID,
+    ...overrides,
+  } as CreateMovementDTO;
+}
+
+describe('M2 negative-stock guard', () => {
+  it('rejects an exit that would drive the balance negative — INV_INSUFFICIENT_STOCK with params', async () => {
+    const repo = makeRepo({
+      getBalance: jest.fn(async () => ({ balance: '3', totalIn: '3', totalOut: '0', lastMovementAt: null })),
+    });
+    const svc = new InventoryStockService(repo);
+
+    const err = await svc.createMovement(CTX, exitDto({ quantity: 5 }), 'k1').catch((e) => e);
+    expect(err).toBeInstanceOf(InventoryError);
+    expect(err.code).toBe('INV_INSUFFICIENT_STOCK');
+    expect(err.statusCode).toBe(409);
+    expect(err.details).toEqual({ itemId: ITEM_ID, location: 'ALMOXARIFADO', balance: 3, requested: 5 });
+    expect(repo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('allows an exit that consumes exactly the whole balance', async () => {
+    const repo = makeRepo({
+      getBalance: jest.fn(async () => ({ balance: '5', totalIn: '5', totalOut: '0', lastMovementAt: null })),
+    });
+    const svc = new InventoryStockService(repo);
+    const result = await svc.createMovement(CTX, exitDto({ quantity: 5 }), 'k2');
+    expect(result.quantity).toBe(5);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(1);
+  });
+
+  it('compares fractional quantities at the numeric(12,3) grain', async () => {
+    const repo = makeRepo({
+      getBalance: jest.fn(async () => ({ balance: '0.3', totalIn: '0.3', totalOut: '0', lastMovementAt: null })),
+    });
+    const svc = new InventoryStockService(repo);
+    // 0.1 + 0.2 !== 0.3 in floats; at the thousandths grain 0.300 covers it.
+    const result = await svc.createMovement(CTX, exitDto({ quantity: 0.3 }), 'k3');
+    expect(result.quantity).toBe(0.3);
+  });
+
+  it('locks the item before reading the balance (FOR UPDATE ordering)', async () => {
+    const order: string[] = [];
+    const repo = makeRepo({
+      lockItem: jest.fn(async () => {
+        order.push('lock');
+        return makeItem();
+      }),
+      getBalance: jest.fn(async () => {
+        order.push('balance');
+        return { balance: '10', totalIn: '10', totalOut: '0', lastMovementAt: null };
+      }),
+    });
+    const svc = new InventoryStockService(repo);
+    await svc.createMovement(CTX, exitDto(), 'k4');
+    expect(order).toEqual(['lock', 'balance']);
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('404s when the item does not exist in the tenant', async () => {
+    const repo = makeRepo({ lockItem: jest.fn(async () => null) });
+    const svc = new InventoryStockService(repo);
+    await expect(svc.createMovement(CTX, exitDto(), 'k5')).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('M2 anti-double-exit QR check', () => {
+  const item = makeItem({ domain: 'PRODUCT', isManufactured: true });
+
+  it('rejects an exit whose QR was already exited — INV_QR_ALREADY_USED', async () => {
+    const repo = makeRepo({
+      lockItem: jest.fn(async () => item),
+      latestQrEventTypes: jest.fn(async () => new Map([['QR-1', 'SAIDA']])),
+    });
+    const svc = new InventoryStockService(repo);
+    const err = await svc
+      .createMovement(CTX, exitDto({ quantity: 1, qrs: [{ qrValue: 'QR-1' }] }), 'k6')
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(InventoryError);
+    expect(err.code).toBe('INV_QR_ALREADY_USED');
+    expect(err.details).toEqual({ qrValue: 'QR-1' });
+    expect(repo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('accepts a QR whose latest event brought it back in (re-entry then exit)', async () => {
+    const repo = makeRepo({
+      lockItem: jest.fn(async () => item),
+      latestQrEventTypes: jest.fn(async () => new Map([['QR-1', 'ENTRADA']])),
+    });
+    const svc = new InventoryStockService(repo);
+    const result = await svc.createMovement(CTX, exitDto({ quantity: 1, qrs: [{ qrValue: 'QR-1' }] }), 'k7');
+    expect(result.qrs).toHaveLength(1);
+  });
+});

--- a/tests/unit/inventory/m2-transfer.test.ts
+++ b/tests/unit/inventory/m2-transfer.test.ts
@@ -1,0 +1,81 @@
+/**
+ * RFC-0061 M2 — transfers: two legs (OUT with the guard + IN) inside ONE
+ * repository transaction, sharing a transfer_group_id (mocked repo — no DB).
+ */
+
+import { InventoryStockService } from '../../../src/services/inventory/InventoryStockService';
+import type { CreateTransferDTO } from '../../../src/dto/request/InventoryDTO';
+import { InventoryError } from '../../../src/shared/errors/InventoryError';
+import type { NewMovementInput } from '../../../src/repositories/inventory/InventoryStockRepository';
+import { CTX, ITEM_ID, makeRepo, movementRowFrom } from './m2-helpers';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function transferDto(overrides: Partial<CreateTransferDTO> = {}): CreateTransferDTO {
+  return {
+    itemId: ITEM_ID,
+    fromLocation: 'FABRICA',
+    toLocation: 'ALMOXARIFADO',
+    quantity: 4,
+    ...overrides,
+  } as CreateTransferDTO;
+}
+
+describe('M2 transfers', () => {
+  it('creates OUT + IN legs in the same transaction with a shared transferGroupId', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+
+    const result = await svc.createTransfer(CTX, transferDto(), 'tk1');
+
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(2);
+
+    const inputs = repo.insertMovement.mock.calls.map((c) => c[0] as NewMovementInput);
+    const out = inputs.find((i) => i.type === 'TRANSFERENCIA_OUT');
+    const inn = inputs.find((i) => i.type === 'TRANSFERENCIA_IN');
+    expect(out).toMatchObject({ location: 'FABRICA', quantity: '4', transferGroupId: result.transferGroupId });
+    expect(inn).toMatchObject({ location: 'ALMOXARIFADO', quantity: '4', transferGroupId: result.transferGroupId });
+
+    expect(result.transferGroupId).toMatch(UUID_RE);
+    expect(result.out.type).toBe('TRANSFERENCIA_OUT');
+    expect(result.in.type).toBe('TRANSFERENCIA_IN');
+    expect(result.out.transferGroupId).toBe(result.in.transferGroupId);
+  });
+
+  it('guards the OUT leg against negative stock and inserts NOTHING on failure', async () => {
+    const repo = makeRepo({
+      getBalance: jest.fn(async () => ({ balance: '2', totalIn: '2', totalOut: '0', lastMovementAt: null })),
+    });
+    const svc = new InventoryStockService(repo);
+
+    const err = await svc.createTransfer(CTX, transferDto({ quantity: 4 }), 'tk2').catch((e) => e);
+    expect(err).toBeInstanceOf(InventoryError);
+    expect(err.code).toBe('INV_INSUFFICIENT_STOCK');
+    expect(err.details).toMatchObject({ location: 'FABRICA', balance: 2, requested: 4 });
+    expect(repo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('reads the balance at the FROM location', async () => {
+    const repo = makeRepo();
+    const svc = new InventoryStockService(repo);
+    await svc.createTransfer(CTX, transferDto(), 'tk3');
+    expect(repo.getBalance).toHaveBeenCalledWith(CTX.tenantId, ITEM_ID, 'FABRICA', expect.anything());
+  });
+
+  it('bubbles a mid-transfer insert failure (atomicity: tx rolls back both legs)', async () => {
+    const repo = makeRepo();
+    repo.insertMovement
+      .mockImplementationOnce(async (input) => movementRowFrom(input as NewMovementInput))
+      .mockImplementationOnce(async () => {
+        throw new Error('boom on IN leg');
+      });
+    const svc = new InventoryStockService(repo);
+
+    await expect(svc.createTransfer(CTX, transferDto(), 'tk4')).rejects.toThrow('boom on IN leg');
+    // Both inserts were attempted inside ONE withTransaction call — the real
+    // Drizzle transaction rolls back the successful OUT leg with the failure.
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+    expect(repo.insertMovement).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## RFC-0061 M2 — Stock ledger (P0)

Implements the M2 module (Livro-razão de estoque) against the **real** migration-0067 schema: `inv_stock_movements` + `inv_movement_qrs`, balance always derived (DEC-2), locations on the movement (DEC-3).

### What's in

**`src/repositories/inventory/InventoryStockRepository.ts`**
- Derived balance per (item, location): `balance` / `totalIn` / `totalOut` / `lastMovementAt` — ENTRADA+AJUSTE+TRANSFERENCIA_IN add, SAIDA+TRANSFERENCIA_OUT subtract.
- Item row lock (`SELECT … FOR UPDATE` on `inv_items`) exposed to the service; `withTransaction` boundary (consumptionGoalRepository pattern).
- Paginated movement history (newest first), movement + QR-link inserts, latest-QR-event lookup (anti-double-exit), W1 consistency query, scope-delete for `/stock/reset` (QR links cascade).
- Query builders are public for SQL-shape tests (PgDialect pattern).

**`src/services/inventory/InventoryStockService.ts`**
- `createMovement`: ONE transaction — lock item → derived balance → negative-stock guard (`INV_INSUFFICIENT_STOCK` with `{itemId, location, balance, requested}`) → **W4 exit-requirements matrix** → anti-double-exit QR check (`INV_QR_ALREADY_USED`) → insert movement + `inv_movement_qrs`.
  - Matrix as enforced: manufactured PRODUCT = QRs (count == quantity) AND photo; PRODUCT/COMPONENT non-manufactured = QR OR photo; THIRD_PARTY = photo (QRs rejected); TOOL = destination.
- `createTransfer`: OUT (guarded at `fromLocation`) + IN legs in the SAME transaction, shared `transfer_group_id`.
- `reset`: transactional scope-delete (tenant-wide or one location), controller guard requires `confirmationToken` (header or body).
- Drizzle gotcha honored: SQLSTATE unwrapped from `err.cause` (DrizzleQueryError) for 23505 → 409, 23503 → 400, 40001/40P01 → 409.

**`src/controllers/inventory/stock.controller.ts`** — the 7 deferred M2 routes are now real: `GET /stock/balances`, `GET /stock/consistency`, `GET /stock/movements` (paginated `total`/`totalPages`), `GET /stock/movements/:id`, `POST /stock/movements`, `POST /stock/transfers` (201, `Idempotency-Key` required), `POST /stock/reset` (428 without confirmation).

### Tests (all green — 56 unit + 1 gated integration)
- `m2-exit-matrix.test.ts` — every W4 combination (accept + reject paths per domain).
- `m2-stock-guard.test.ts` — anti-negative guard (params asserted), thousandths-grain comparison, lock-before-balance ordering, QR double-exit.
- `m2-transfer.test.ts` — atomic two-leg transfer, shared group id, nothing inserted on guard failure.
- `m2-idempotency.test.ts` — replay returns original result and creates nothing (AC-9), tenant scoping, failed-attempt retry, concurrent same-key coalescing.
- `m2-repository.sql.test.ts` — SQL shape incl. the `FOR UPDATE` item lock (CentralCommandRepository pattern).
- `m2-contract.test.ts` — wired contract (real router + real auth middleware, service mocked).
- `tests/integration/inventory/m2-concurrency.test.ts` — REAL two-pg-connection race (AC-2/A6), gated by `INV_IT_DB` (skipped by default; **never touches a local DB**).

### Superseded contract-test case
`tests/unit/controllers/inventory.contract.test.ts` › "idempotency guard (S1) › POST /stock/movements with key + valid body → 501" now fails by design (the endpoint is real). **Contract test M2 cases superseded** by `tests/unit/inventory/m2-contract.test.ts`; that file was intentionally left untouched (module-boundary rule) — suggest updating/removing the stale case when merging into the integration branch.

### Follow-ups (schema/DTO gaps — no schema.ts/DTO changes in this PR)
1. **Durable idempotency**: the schema has no `inv_idempotency_keys` table or key column; `Idempotency-Key` replay is a best-effort per-process cache (TTL 24h, in-flight promise sharing). Needs a durable table (or Redis) for multi-instance correctness. The M3 receipt-entry partial UNIQUE `(tenant_id, purchase_order_id) WHERE type='ENTRADA'` remains the only DB-level idempotency.
2. **TOOL destination**: `CreateMovementSchema` has no `destination` field; the TOOL exit requirement rides on `responsible` (free text). Consider a dedicated column/DTO field.
3. **Consistency v1 approximation**: active-QR is computed from the latest `inv_movement_qrs` event per unit `qr_value` (box QRs excluded); once M5 homologation ships, `inv_qr_registry`/`inv_homologation_units` should become the authoritative source (W1).
4. `GET /stock/movements` accepts only `page`/`pageSize` (the P0 DTO has no item/location/type filters); add a filtered query DTO in a later phase if the frontend needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
