### PR TITLE
feat(inventory): M3 purchases (P1)

### DIFF
--- a/src/controllers/inventory/purchases.controller.ts
+++ b/src/controllers/inventory/purchases.controller.ts
@@ -1,24 +1,148 @@
-import { Router } from 'express';
-import { defer, requireUuid, requireConfirmation } from './shared';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireConfirmation } from './shared';
 import {
   CreatePurchaseOrderSchema,
   UpdatePurchaseOrderSchema,
   PurchaseOrderStatusSchema,
   PurchaseOrderListQuerySchema,
   PurchaseOrderFilesSchema,
+  PaginationQuerySchema,
 } from '../../dto/request/InventoryDTO';
+import { sendSuccess, sendCreated } from '../../middleware/response';
+import { inventoryPurchaseOrderService } from '../../services/inventory/InventoryPurchaseOrderService';
 
-// M3 — Compras (P1)
+// M3 — Compras (P1). Real routes (RFC-0061 §M3): purchase requests + buyer
+// queue. Auth (hybridAuthByMethod inventory:read/inventory:write) is mounted
+// in app.ts. The state machine (PURCHASE_ORDER_TRANSITIONS) is enforced in the
+// service under a row lock (DEC-4); reads include allowedTransitions (S3);
+// RECEBIDO_OK triggers the exactly-once automatic ENTRADA (A1). Fine-grained
+// role gating (requester/buyer/admin) arrives with M10.
 const router = Router();
 
-router.get('/purchase-orders', defer('M3', 'P1', (req) => { PurchaseOrderListQuerySchema.parse(req.query); }));
-router.post('/purchase-orders', defer('M3', 'P1', (req) => { CreatePurchaseOrderSchema.parse(req.body ?? {}); }));
-router.get('/purchase-orders/:id', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); }));
-router.patch('/purchase-orders/:id', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); UpdatePurchaseOrderSchema.parse(req.body ?? {}); }));
-router.post('/purchase-orders/:id/status', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); PurchaseOrderStatusSchema.parse(req.body ?? {}); }));
-router.get('/purchase-orders/:id/events', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); }));
-router.post('/purchase-orders/:id/files', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); PurchaseOrderFilesSchema.parse(req.body ?? {}); }));
-router.delete('/purchase-orders/:id/files', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); }));
-router.delete('/purchase-orders/:id', defer('M3', 'P1', (req) => { requireUuid('id', req.params.id); requireConfirmation(req); }));
+// GET /purchase-orders — paginated listing = buyer queue with server-side
+// filters (status, projectId, purchaseType via the item, groupByProject).
+router.get('/purchase-orders', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const query = PurchaseOrderListQuerySchema.parse(req.query);
+    const data = await inventoryPurchaseOrderService.list({ tenantId, userId }, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /purchase-orders — create; requester = req.context.userId; item/link
+// snapshot happens in the service; CUSTOMIZADO deadline requires deadlineDate.
+router.post('/purchase-orders', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const dto = CreatePurchaseOrderSchema.parse(req.body ?? {});
+    const data = await inventoryPurchaseOrderService.create({ tenantId, userId }, dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /purchase-orders/:id — detail incl. files + allowedTransitions.
+router.get('/purchase-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const data = await inventoryPurchaseOrderService.getById({ tenantId, userId }, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PATCH /purchase-orders/:id — requester fields only while PENDENTE
+// (INV_EDIT_LOCKED_STATE 409); buyerNotes/passphrase/deliveryForecast anytime.
+router.patch('/purchase-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = UpdatePurchaseOrderSchema.parse(req.body ?? {});
+    const data = await inventoryPurchaseOrderService.update({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /purchase-orders/:id/status — DEC-4 state machine; illegal transition →
+// INV_ILLEGAL_TRANSITION 409 (current + allowedTransitions in the body),
+// repeat → INV_ALREADY_IN_STATE 409; RECEBIDO_OK creates the single ENTRADA.
+router.post('/purchase-orders/:id/status', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = PurchaseOrderStatusSchema.parse(req.body ?? {});
+    const data = await inventoryPurchaseOrderService.changeStatus({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /purchase-orders/:id/events — paginated WO-style timeline (DEC-9).
+router.get('/purchase-orders/:id/events', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryPurchaseOrderService.listEvents(
+      { tenantId, userId },
+      req.params.id,
+      page,
+      pageSize,
+    );
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /purchase-orders/:id/files — link existing file_assets by id (two-phase
+// upload: the asset is uploaded first via the file_assets flow, DEC-8).
+router.post('/purchase-orders/:id/files', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = PurchaseOrderFilesSchema.parse(req.body ?? {});
+    const data = await inventoryPurchaseOrderService.addFiles({ tenantId, userId }, req.params.id, dto.fileIds);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /purchase-orders/:id/files — unlink (the file_asset itself remains).
+router.delete('/purchase-orders/:id/files', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = PurchaseOrderFilesSchema.parse(req.body ?? {});
+    const data = await inventoryPurchaseOrderService.removeFiles({ tenantId, userId }, req.params.id, dto.fileIds);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /purchase-orders/:id — destructive; confirmation token (S3).
+// TODO(M10): admin-only.
+router.delete('/purchase-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    requireConfirmation(req);
+    await inventoryPurchaseOrderService.delete({ tenantId, userId }, req.params.id);
+    sendSuccess(res, { id: req.params.id, deleted: true }, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryPurchaseOrderRepository.ts
+++ b/src/repositories/inventory/InventoryPurchaseOrderRepository.ts
@@ -1,0 +1,395 @@
+// =============================================================================
+// RFC-0061 M3 — Purchase orders repository (data access only).
+//
+// Owns `inv_purchase_orders` + `inv_purchase_order_events` +
+// `inv_purchase_order_files`. Business rules (state machine, edit locks,
+// receipt entry) live in InventoryPurchaseOrderService; every mutating method
+// accepts an optional executor so the service composes order + events + files
+// inside ONE transaction (same convention as InventoryStockRepository).
+//
+// The buyer-queue listing joins `inv_items` so `purchaseType`
+// (NACIONAL/IMPORTACAO) can filter and ride on each row (§M3 buyer queue).
+// =============================================================================
+
+import { and, asc, desc, eq, inArray, isNull, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+
+const {
+  invPurchaseOrders,
+  invPurchaseOrderEvents,
+  invPurchaseOrderFiles,
+  invStockMovements,
+  invItems,
+  fileAssets,
+} = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as InventoryStockRepository)
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type PurchaseOrderTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type PurchaseOrderDbClient = typeof db | PurchaseOrderTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvPurchaseOrderRow = typeof invPurchaseOrders.$inferSelect;
+export type InvPurchaseOrderEventRow = typeof invPurchaseOrderEvents.$inferSelect;
+export type InvPurchaseOrderFileRow = typeof invPurchaseOrderFiles.$inferSelect;
+
+/** Listing row: the order plus the item's purchase_type (buyer queue filter). */
+export interface InvPurchaseOrderListRow {
+  order: InvPurchaseOrderRow;
+  purchaseType: string | null;
+}
+
+export interface NewPurchaseOrderInput {
+  tenantId: string;
+  projectId: string;
+  requesterId?: string | null;
+  itemId: string;
+  itemNameSnapshot?: string | null;
+  itemLink?: string | null;
+  quantity: number;
+  recipient?: string | null;
+  deliveryPoint?: string | null;
+  deadlineType?: string | null;
+  deadlineDate?: Date | null;
+  requesterNotes?: string | null;
+  createdBy?: string | null;
+}
+
+/** Column patch for PATCH /purchase-orders/:id (service decides what goes in). */
+export interface PurchaseOrderPatch {
+  quantity?: number;
+  recipient?: string | null;
+  deliveryPoint?: string | null;
+  deadlineType?: string | null;
+  deadlineDate?: Date | null;
+  requesterNotes?: string | null;
+  buyerNotes?: string | null;
+  passphrase?: string | null;
+  deliveryForecast?: Date | null;
+  status?: string;
+  updatedBy?: string | null;
+}
+
+export interface NewPurchaseOrderEventInput {
+  tenantId: string;
+  orderId: string;
+  actorId?: string | null;
+  eventType: string; // CRIADO | STATUS_ALTERADO | OBSERVACAO_ATUALIZADA
+  details?: Record<string, unknown>;
+}
+
+export interface PurchaseOrderListFilters {
+  page: number;
+  pageSize: number;
+  status?: string;
+  projectId?: string;
+  purchaseType?: string;
+  groupByProject?: boolean;
+}
+
+export class InventoryPurchaseOrderRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  /** Runs `fn` inside one DB transaction (order + events + files). */
+  async withTransaction<T>(fn: (tx: PurchaseOrderTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orders
+  // ---------------------------------------------------------------------------
+
+  private listConditions(tenantId: string, filters: PurchaseOrderListFilters): SQL[] {
+    const conditions: SQL[] = [eq(invPurchaseOrders.tenantId, tenantId)];
+    if (filters.status) conditions.push(eq(invPurchaseOrders.status, filters.status));
+    if (filters.projectId) conditions.push(eq(invPurchaseOrders.projectId, filters.projectId));
+    if (filters.purchaseType) conditions.push(eq(invItems.purchaseType, filters.purchaseType));
+    return conditions;
+  }
+
+  /**
+   * Paginated listing joined with the catalog (purchase_type rides along for
+   * the buyer queue). `groupByProject` orders by project first so the frontend
+   * can render project sections without re-sorting.
+   */
+  async list(
+    tenantId: string,
+    filters: PurchaseOrderListFilters,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<{ rows: InvPurchaseOrderListRow[]; total: number }> {
+    const conditions = this.listConditions(tenantId, filters);
+    const orderBy = filters.groupByProject
+      ? [asc(invPurchaseOrders.projectId), desc(invPurchaseOrders.createdAt), desc(invPurchaseOrders.id)]
+      : [desc(invPurchaseOrders.createdAt), desc(invPurchaseOrders.id)];
+
+    const [rows, counts] = await Promise.all([
+      client
+        .select({ order: invPurchaseOrders, purchaseType: invItems.purchaseType })
+        .from(invPurchaseOrders)
+        .innerJoin(invItems, eq(invItems.id, invPurchaseOrders.itemId))
+        .where(and(...conditions))
+        .orderBy(...orderBy)
+        .limit(filters.pageSize)
+        .offset((filters.page - 1) * filters.pageSize),
+      client
+        .select({ total: sql<number>`count(*)::int` })
+        .from(invPurchaseOrders)
+        .innerJoin(invItems, eq(invItems.id, invPurchaseOrders.itemId))
+        .where(and(...conditions)),
+    ]);
+
+    return { rows, total: counts[0]?.total ?? 0 };
+  }
+
+  async getById(
+    tenantId: string,
+    id: string,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderRow | null> {
+    const [row] = await client
+      .select()
+      .from(invPurchaseOrders)
+      .where(and(eq(invPurchaseOrders.tenantId, tenantId), eq(invPurchaseOrders.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /**
+   * Lock the order row for the whole transaction (`SELECT … FOR UPDATE`) so
+   * concurrent status changes / edits serialize — the loser of a race sees the
+   * winner's committed state and gets the correct 409 (AC-1).
+   */
+  async lockById(
+    tenantId: string,
+    id: string,
+    client: PurchaseOrderDbClient,
+  ): Promise<InvPurchaseOrderRow | null> {
+    const [row] = await client
+      .select()
+      .from(invPurchaseOrders)
+      .where(and(eq(invPurchaseOrders.tenantId, tenantId), eq(invPurchaseOrders.id, id)))
+      .limit(1)
+      .for('update');
+    return row ?? null;
+  }
+
+  async insert(
+    input: NewPurchaseOrderInput,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderRow> {
+    const [row] = await client
+      .insert(invPurchaseOrders)
+      .values({
+        tenantId: input.tenantId,
+        projectId: input.projectId,
+        requesterId: input.requesterId ?? null,
+        itemId: input.itemId,
+        itemNameSnapshot: input.itemNameSnapshot ?? null,
+        itemLink: input.itemLink ?? null,
+        quantity: input.quantity,
+        recipient: input.recipient ?? null,
+        deliveryPoint: input.deliveryPoint ?? null,
+        deadlineType: input.deadlineType ?? null,
+        deadlineDate: input.deadlineDate ?? null,
+        requesterNotes: input.requesterNotes ?? null,
+        createdBy: input.createdBy ?? null,
+        updatedBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async update(
+    tenantId: string,
+    id: string,
+    patch: PurchaseOrderPatch,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderRow | null> {
+    const { updatedBy, ...columns } = patch;
+    const [row] = await client
+      .update(invPurchaseOrders)
+      .set({ ...columns, updatedAt: new Date(), updatedBy: updatedBy ?? null })
+      .where(and(eq(invPurchaseOrders.tenantId, tenantId), eq(invPurchaseOrders.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  /** Hard delete; events/files CASCADE, ledger FK is SET NULL. */
+  async delete(tenantId: string, id: string, client: PurchaseOrderDbClient = db): Promise<boolean> {
+    const rows = await client
+      .delete(invPurchaseOrders)
+      .where(and(eq(invPurchaseOrders.tenantId, tenantId), eq(invPurchaseOrders.id, id)))
+      .returning({ id: invPurchaseOrders.id });
+    return rows.length > 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Events (WO-style timeline, DEC-9)
+  // ---------------------------------------------------------------------------
+
+  async insertEvent(
+    input: NewPurchaseOrderEventInput,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderEventRow> {
+    const [row] = await client
+      .insert(invPurchaseOrderEvents)
+      .values({
+        tenantId: input.tenantId,
+        orderId: input.orderId,
+        actorId: input.actorId ?? null,
+        eventType: input.eventType,
+        details: input.details ?? {},
+      })
+      .returning();
+    return row;
+  }
+
+  /** Chronological (oldest-first) paginated timeline for GET /events. */
+  async listEvents(
+    tenantId: string,
+    orderId: string,
+    page: number,
+    pageSize: number,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<{ rows: InvPurchaseOrderEventRow[]; total: number }> {
+    const where = and(
+      eq(invPurchaseOrderEvents.tenantId, tenantId),
+      eq(invPurchaseOrderEvents.orderId, orderId),
+    );
+    const [rows, counts] = await Promise.all([
+      client
+        .select()
+        .from(invPurchaseOrderEvents)
+        .where(where)
+        .orderBy(asc(invPurchaseOrderEvents.createdAt), asc(invPurchaseOrderEvents.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize),
+      client
+        .select({ total: sql<number>`count(*)::int` })
+        .from(invPurchaseOrderEvents)
+        .where(where),
+    ]);
+    return { rows, total: counts[0]?.total ?? 0 };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Files (link table → file_assets, annotation_attachments pattern)
+  // ---------------------------------------------------------------------------
+
+  /** Ids from `fileIds` that exist in the tenant and are not deleted. */
+  async findExistingFileAssetIds(
+    tenantId: string,
+    fileIds: string[],
+    client: PurchaseOrderDbClient = db,
+  ): Promise<string[]> {
+    if (fileIds.length === 0) return [];
+    const rows = await client
+      .select({ id: fileAssets.id })
+      .from(fileAssets)
+      .where(
+        and(
+          eq(fileAssets.tenantId, tenantId),
+          inArray(fileAssets.id, fileIds),
+          isNull(fileAssets.deletedAt),
+        ),
+      );
+    return rows.map((r) => r.id);
+  }
+
+  async listFiles(
+    tenantId: string,
+    orderId: string,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderFileRow[]> {
+    return client
+      .select()
+      .from(invPurchaseOrderFiles)
+      .where(
+        and(
+          eq(invPurchaseOrderFiles.tenantId, tenantId),
+          eq(invPurchaseOrderFiles.orderId, orderId),
+        ),
+      )
+      .orderBy(asc(invPurchaseOrderFiles.createdAt), asc(invPurchaseOrderFiles.id));
+  }
+
+  /** Insert links, skipping fileIds already linked (idempotent attach). */
+  async insertFiles(
+    tenantId: string,
+    orderId: string,
+    fileIds: string[],
+    createdBy: string | null,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<InvPurchaseOrderFileRow[]> {
+    if (fileIds.length === 0) return [];
+    const existing = await this.listFiles(tenantId, orderId, client);
+    const linked = new Set(existing.map((f) => f.fileId));
+    const fresh = [...new Set(fileIds)].filter((id) => !linked.has(id));
+    if (fresh.length === 0) return [];
+    return client
+      .insert(invPurchaseOrderFiles)
+      .values(fresh.map((fileId) => ({ tenantId, orderId, fileId, createdBy })))
+      .returning();
+  }
+
+  /** Remove links for the given fileIds; returns how many were removed. */
+  async deleteFiles(
+    tenantId: string,
+    orderId: string,
+    fileIds: string[],
+    client: PurchaseOrderDbClient = db,
+  ): Promise<number> {
+    if (fileIds.length === 0) return 0;
+    const rows = await client
+      .delete(invPurchaseOrderFiles)
+      .where(
+        and(
+          eq(invPurchaseOrderFiles.tenantId, tenantId),
+          eq(invPurchaseOrderFiles.orderId, orderId),
+          inArray(invPurchaseOrderFiles.fileId, fileIds),
+        ),
+      )
+      .returning({ id: invPurchaseOrderFiles.id });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Receipt-entry guard (A1)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * True when the exactly-one ENTRADA for this order already exists in the
+   * ledger (partial UNIQUE (tenant_id, purchase_order_id) WHERE type='ENTRADA'
+   * — migration 0067 `inv_stock_movements_po_entry_uq`).
+   */
+  async hasReceiptEntry(
+    tenantId: string,
+    orderId: string,
+    client: PurchaseOrderDbClient = db,
+  ): Promise<boolean> {
+    const [row] = await client
+      .select({ id: invStockMovements.id })
+      .from(invStockMovements)
+      .where(
+        and(
+          eq(invStockMovements.tenantId, tenantId),
+          eq(invStockMovements.purchaseOrderId, orderId),
+          eq(invStockMovements.type, 'ENTRADA'),
+        ),
+      )
+      .limit(1);
+    return !!row;
+  }
+}
+
+export const inventoryPurchaseOrderRepository = new InventoryPurchaseOrderRepository();

--- a/src/services/inventory/InventoryPurchaseOrderService.ts
+++ b/src/services/inventory/InventoryPurchaseOrderService.ts
@@ -1,0 +1,629 @@
+// =============================================================================
+// RFC-0061 M3 — Purchase orders service (business rules).
+//
+// Owns the §M3 rules on top of InventoryPurchaseOrderRepository:
+//   - create: requester = req.context.userId; item is a required catalog FK
+//     with name/link snapshotted at request time; CUSTOMIZADO deadline needs a
+//     date (double-checked here — the Zod DTO enforces it on create only).
+//   - PATCH: requester fields only while PENDENTE (INV_EDIT_LOCKED_STATE 409);
+//     buyer fields (buyerNotes, passphrase, deliveryForecast) in any state.
+//   - status: PURCHASE_ORDER_TRANSITIONS enforced server-side (DEC-4) under a
+//     FOR UPDATE row lock — illegal → INV_ILLEGAL_TRANSITION 409 (body carries
+//     current + allowedTransitions), repeat → INV_ALREADY_IN_STATE 409.
+//   - RECEBIDO_OK: exactly ONE idempotent ENTRADA via the M2 stock service.
+//     `createMovement` owns its own transaction (it cannot join an external
+//     tx), so the entry is created AFTER the status commit; the DB partial
+//     UNIQUE (tenant_id, purchase_order_id) WHERE type='ENTRADA' (A1,
+//     migration 0067) makes the entry exactly-once even across racing
+//     processes — a duplicate insert is re-checked and treated as idempotent
+//     success. Trade-off documented in the M3 PR.
+//   - events: CRIADO / STATUS_ALTERADO {from,to} / OBSERVACAO_ATUALIZADA are
+//     written in the SAME transaction as the mutation (WO-style model, DEC-9).
+//   - reads include allowedTransitions (S3).
+//
+// RBAC (M10 — not yet wired): fine-grained role gating (requester-only edits,
+// requester-only receipt confirmation, buyer statuses, admin-only delete) is
+// centralized in the assertCallerMay* hooks below so M10 only fills them in.
+// =============================================================================
+
+import {
+  InventoryPurchaseOrderRepository,
+  inventoryPurchaseOrderRepository,
+  PurchaseOrderTx,
+  InvPurchaseOrderRow,
+  InvPurchaseOrderEventRow,
+  InvPurchaseOrderFileRow,
+} from '../../repositories/inventory/InventoryPurchaseOrderRepository';
+import {
+  InventoryItemRepository,
+  inventoryItemRepository,
+} from '../../repositories/inventory/InventoryItemRepository';
+import {
+  InventoryProjectRepository,
+  inventoryProjectRepository,
+} from '../../repositories/inventory/InventoryProjectRepository';
+import { InventoryStockService, inventoryStockService } from './InventoryStockService';
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../shared/errors/AppError';
+import { alreadyInState, editLockedState, illegalTransition } from '../../shared/errors/InventoryError';
+import {
+  PURCHASE_ORDER_TRANSITIONS,
+  InvPurchaseOrderStatus,
+} from '../../domain/entities/Inventory';
+import type {
+  CreatePurchaseOrderDTO,
+  UpdatePurchaseOrderDTO,
+  PurchaseOrderStatusDTO,
+  PurchaseOrderListQuery,
+} from '../../dto/request/InventoryDTO';
+import type {
+  InvPaginatedResponse,
+  InvPurchaseOrderResponse,
+} from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Seams (mocked in unit tests)
+// -----------------------------------------------------------------------------
+
+export type IInventoryPurchaseOrderRepository = Pick<
+  InventoryPurchaseOrderRepository,
+  | 'withTransaction'
+  | 'list'
+  | 'getById'
+  | 'lockById'
+  | 'insert'
+  | 'update'
+  | 'delete'
+  | 'insertEvent'
+  | 'listEvents'
+  | 'findExistingFileAssetIds'
+  | 'listFiles'
+  | 'insertFiles'
+  | 'deleteFiles'
+  | 'hasReceiptEntry'
+>;
+
+export type IPurchaseItemRepository = Pick<InventoryItemRepository, 'getById'>;
+export type IPurchaseProjectRepository = Pick<InventoryProjectRepository, 'getById'>;
+export type IPurchaseStockService = Pick<InventoryStockService, 'createMovement'>;
+
+/** Caller identity from `req.context`. */
+export interface PurchaseOrderContext {
+  tenantId: string;
+  userId?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Read models (extend the frozen InvPurchaseOrderResponse with the remaining
+// row columns — the response DTO file is frozen for this PR)
+// -----------------------------------------------------------------------------
+
+export interface InvPurchaseOrderFileResponse {
+  id: string;
+  fileId: string;
+  createdAt: string;
+}
+
+export interface InvPurchaseOrderDetailResponse extends InvPurchaseOrderResponse {
+  requesterId: string | null;
+  itemLink: string | null;
+  recipient: string | null;
+  deliveryPoint: string | null;
+  passphrase: string | null;
+  /** Item's NACIONAL/IMPORTACAO — present on listing rows (buyer queue). */
+  purchaseType?: string | null;
+  /** Linked file_assets — present on detail reads and file mutations. */
+  files?: InvPurchaseOrderFileResponse[];
+}
+
+export interface InvPurchaseOrderEventResponse {
+  id: string;
+  orderId: string;
+  actorId: string | null;
+  eventType: string;
+  details: Record<string, unknown>;
+  createdAt: string;
+}
+
+/** Receipt entry constants (source trigger `stock_entry_on_receipt`, §M3). */
+export const RECEIPT_ENTRY_LOCATION = 'FABRICA';
+export const RECEIPT_ENTRY_REASON = 'Entrada automática — recebimento de compra';
+
+/** Fields only the requester may edit, and only while PENDENTE. */
+const REQUESTER_FIELDS = [
+  'quantity',
+  'recipient',
+  'deliveryPoint',
+  'deadlineType',
+  'deadlineDate',
+  'requesterNotes',
+] as const;
+
+/** Buyer/admin-managed fields, editable in any state. */
+const BUYER_FIELDS = ['buyerNotes', 'passphrase', 'deliveryForecast'] as const;
+
+export class InventoryPurchaseOrderService {
+  private repository: IInventoryPurchaseOrderRepository;
+  private itemRepository: IPurchaseItemRepository;
+  private projectRepository: IPurchaseProjectRepository;
+  private stockService: IPurchaseStockService;
+
+  constructor(
+    repository?: IInventoryPurchaseOrderRepository,
+    itemRepository?: IPurchaseItemRepository,
+    projectRepository?: IPurchaseProjectRepository,
+    stockService?: IPurchaseStockService,
+  ) {
+    this.repository = repository ?? inventoryPurchaseOrderRepository;
+    this.itemRepository = itemRepository ?? inventoryItemRepository;
+    this.projectRepository = projectRepository ?? inventoryProjectRepository;
+    this.stockService = stockService ?? inventoryStockService;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
+
+  async list(
+    ctx: PurchaseOrderContext,
+    query: PurchaseOrderListQuery,
+  ): Promise<InvPaginatedResponse<InvPurchaseOrderDetailResponse>> {
+    const { page, pageSize } = query;
+    const { rows, total } = await this.repository.list(ctx.tenantId, {
+      page,
+      pageSize,
+      status: query.status,
+      projectId: query.projectId,
+      purchaseType: query.purchaseType,
+      groupByProject: query.groupByProject,
+    });
+    return {
+      items: rows.map((r) => ({ ...this.toDetail(r.order), purchaseType: r.purchaseType ?? null })),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async getById(ctx: PurchaseOrderContext, id: string): Promise<InvPurchaseOrderDetailResponse> {
+    const order = await this.repository.getById(ctx.tenantId, id);
+    if (!order) throw new NotFoundError(`Purchase order ${id} not found`);
+    const files = await this.repository.listFiles(ctx.tenantId, id);
+    return { ...this.toDetail(order), files: files.map(this.toFileResponse) };
+  }
+
+  async listEvents(
+    ctx: PurchaseOrderContext,
+    id: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvPurchaseOrderEventResponse>> {
+    const order = await this.repository.getById(ctx.tenantId, id);
+    if (!order) throw new NotFoundError(`Purchase order ${id} not found`);
+    const { rows, total } = await this.repository.listEvents(ctx.tenantId, id, page, pageSize);
+    return {
+      items: rows.map(this.toEventResponse),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create
+  // ---------------------------------------------------------------------------
+
+  async create(
+    ctx: PurchaseOrderContext,
+    dto: CreatePurchaseOrderDTO,
+  ): Promise<InvPurchaseOrderDetailResponse> {
+    const item = await this.itemRepository.getById(ctx.tenantId, dto.itemId);
+    if (!item) throw new ValidationError(`Item ${dto.itemId} not found in tenant`);
+
+    const project = await this.projectRepository.getById(ctx.tenantId, dto.projectId);
+    if (!project) throw new ValidationError(`Project ${dto.projectId} not found in tenant`);
+
+    const fileIds = dto.fileIds ?? [];
+    await this.assertFileAssetsExist(ctx.tenantId, fileIds);
+
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.repository.insert(
+          {
+            tenantId: ctx.tenantId,
+            projectId: dto.projectId,
+            requesterId: ctx.userId ?? null,
+            itemId: dto.itemId,
+            // Snapshot at request time — later catalog edits must not rewrite
+            // what was asked for (§M3).
+            itemNameSnapshot: item.name,
+            itemLink: item.link ?? null,
+            quantity: dto.quantity,
+            recipient: dto.recipient ?? null,
+            deliveryPoint: dto.deliveryPoint ?? null,
+            deadlineType: dto.deadlineType,
+            deadlineDate: dto.deadlineDate ? new Date(dto.deadlineDate) : null,
+            requesterNotes: dto.requesterNotes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        await this.repository.insertEvent(
+          {
+            tenantId: ctx.tenantId,
+            orderId: order.id,
+            actorId: ctx.userId ?? null,
+            eventType: 'CRIADO',
+            details: { status: order.status },
+          },
+          tx,
+        );
+
+        const files = fileIds.length
+          ? await this.repository.insertFiles(ctx.tenantId, order.id, fileIds, ctx.userId ?? null, tx)
+          : [];
+
+        return { ...this.toDetail(order), files: files.map(this.toFileResponse) };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Update (PATCH)
+  // ---------------------------------------------------------------------------
+
+  async update(
+    ctx: PurchaseOrderContext,
+    id: string,
+    dto: UpdatePurchaseOrderDTO,
+  ): Promise<InvPurchaseOrderDetailResponse> {
+    const touchesRequesterFields = REQUESTER_FIELDS.some((f) => dto[f] !== undefined);
+    const touchesBuyerFields = BUYER_FIELDS.some((f) => dto[f] !== undefined);
+
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, id, tx);
+        const current = order.status as InvPurchaseOrderStatus;
+
+        if (touchesRequesterFields) {
+          this.assertCallerMayEditRequesterFields(ctx, order);
+          if (current !== 'PENDENTE') throw editLockedState(current);
+        }
+        if (touchesBuyerFields) {
+          this.assertCallerMayEditBuyerFields(ctx, order);
+        }
+
+        this.assertDeadlineConsistent(order, dto);
+
+        const updated = await this.repository.update(
+          ctx.tenantId,
+          id,
+          {
+            ...(dto.quantity !== undefined && { quantity: dto.quantity }),
+            ...(dto.recipient !== undefined && { recipient: dto.recipient }),
+            ...(dto.deliveryPoint !== undefined && { deliveryPoint: dto.deliveryPoint }),
+            ...(dto.deadlineType !== undefined && { deadlineType: dto.deadlineType }),
+            ...(dto.deadlineDate !== undefined && {
+              deadlineDate: dto.deadlineDate ? new Date(dto.deadlineDate) : null,
+            }),
+            ...(dto.requesterNotes !== undefined && { requesterNotes: dto.requesterNotes }),
+            ...(dto.buyerNotes !== undefined && { buyerNotes: dto.buyerNotes }),
+            ...(dto.passphrase !== undefined && { passphrase: dto.passphrase }),
+            ...(dto.deliveryForecast !== undefined && {
+              deliveryForecast: dto.deliveryForecast ? new Date(dto.deliveryForecast) : null,
+            }),
+            updatedBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        if (!updated) throw new NotFoundError(`Purchase order ${id} not found`);
+
+        // Notes edits get their own timeline entry (§M3 event model). The
+        // passphrase is deliberately NOT echoed into details (DEC-10).
+        const notedFields = (['requesterNotes', 'buyerNotes'] as const).filter(
+          (f) => dto[f] !== undefined,
+        );
+        if (notedFields.length > 0) {
+          await this.repository.insertEvent(
+            {
+              tenantId: ctx.tenantId,
+              orderId: id,
+              actorId: ctx.userId ?? null,
+              eventType: 'OBSERVACAO_ATUALIZADA',
+              details: { fields: notedFields },
+            },
+            tx,
+          );
+        }
+
+        return this.toDetail(updated);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Status (DEC-4 state machine)
+  // ---------------------------------------------------------------------------
+
+  async changeStatus(
+    ctx: PurchaseOrderContext,
+    id: string,
+    dto: PurchaseOrderStatusDTO,
+  ): Promise<InvPurchaseOrderDetailResponse> {
+    let updated: InvPurchaseOrderRow;
+    try {
+      updated = await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, id, tx);
+        const current = order.status as InvPurchaseOrderStatus;
+        const target = dto.status as InvPurchaseOrderStatus;
+
+        if (target === current) throw alreadyInState(current);
+        const allowed = PURCHASE_ORDER_TRANSITIONS[current] ?? [];
+        if (!allowed.includes(target)) throw illegalTransition(current, allowed);
+        this.assertCallerMayTransition(ctx, order, target);
+
+        const row = await this.repository.update(
+          ctx.tenantId,
+          id,
+          { status: target, updatedBy: ctx.userId ?? null },
+          tx,
+        );
+        if (!row) throw new NotFoundError(`Purchase order ${id} not found`);
+
+        await this.repository.insertEvent(
+          {
+            tenantId: ctx.tenantId,
+            orderId: id,
+            actorId: ctx.userId ?? null,
+            eventType: 'STATUS_ALTERADO',
+            details: { from: current, to: target, ...(dto.note ? { note: dto.note } : {}) },
+          },
+          tx,
+        );
+
+        return row;
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+
+    // Exactly-one automatic ENTRADA on receipt (§M3, AC-1). Runs after the
+    // status commit because the M2 service owns its own transaction — the
+    // partial UNIQUE (A1) still guarantees at-most-one entry per order.
+    if (updated.status === 'RECEBIDO_OK') {
+      await this.createReceiptEntry(ctx, updated);
+    }
+
+    return this.toDetail(updated);
+  }
+
+  /**
+   * Idempotent receipt entry. `Idempotency-Key` is derived from the order id
+   * (same-process replays short-circuit in the M2 cache); the durable guard is
+   * the DB partial UNIQUE — when it fires (or any race loses), we re-check the
+   * ledger and treat an existing entry as success.
+   */
+  private async createReceiptEntry(ctx: PurchaseOrderContext, order: InvPurchaseOrderRow): Promise<void> {
+    try {
+      await this.stockService.createMovement(
+        { tenantId: ctx.tenantId, userId: ctx.userId },
+        {
+          itemId: order.itemId,
+          location: RECEIPT_ENTRY_LOCATION,
+          quantity: order.quantity,
+          type: 'ENTRADA',
+          reason: RECEIPT_ENTRY_REASON,
+          purchaseOrderId: order.id,
+        },
+        `po-receipt:${order.id}`,
+      );
+    } catch (err) {
+      const exists = await this.repository
+        .hasReceiptEntry(ctx.tenantId, order.id)
+        .catch(() => false);
+      if (!exists) throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Files (link table → file_assets)
+  // ---------------------------------------------------------------------------
+
+  async addFiles(
+    ctx: PurchaseOrderContext,
+    id: string,
+    fileIds: string[],
+  ): Promise<{ orderId: string; files: InvPurchaseOrderFileResponse[] }> {
+    const order = await this.repository.getById(ctx.tenantId, id);
+    if (!order) throw new NotFoundError(`Purchase order ${id} not found`);
+    await this.assertFileAssetsExist(ctx.tenantId, fileIds);
+
+    try {
+      await this.repository.insertFiles(ctx.tenantId, id, fileIds, ctx.userId ?? null);
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+    const files = await this.repository.listFiles(ctx.tenantId, id);
+    return { orderId: id, files: files.map(this.toFileResponse) };
+  }
+
+  async removeFiles(
+    ctx: PurchaseOrderContext,
+    id: string,
+    fileIds: string[],
+  ): Promise<{ orderId: string; removed: number }> {
+    const order = await this.repository.getById(ctx.tenantId, id);
+    if (!order) throw new NotFoundError(`Purchase order ${id} not found`);
+    const removed = await this.repository.deleteFiles(ctx.tenantId, id, fileIds);
+    return { orderId: id, removed };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delete (destructive — confirmation guard enforced by the controller, S3)
+  // ---------------------------------------------------------------------------
+
+  async delete(ctx: PurchaseOrderContext, id: string): Promise<void> {
+    this.assertCallerMayDelete(ctx);
+    try {
+      const deleted = await this.repository.delete(ctx.tenantId, id);
+      if (!deleted) throw new NotFoundError(`Purchase order ${id} not found`);
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // RBAC hooks — M10 fills these in (no fine-grained roles yet: any principal
+  // holding inventory:write may do everything, per the phased plan).
+  // ---------------------------------------------------------------------------
+
+  /** TODO(M10): only the requester may edit requester fields (and only PENDENTE). */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private assertCallerMayEditRequesterFields(_ctx: PurchaseOrderContext, _order: InvPurchaseOrderRow): void {
+    /* no-op until M10 RBAC lands */
+  }
+
+  /** TODO(M10): only buyer/admin may edit buyerNotes/passphrase/deliveryForecast. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private assertCallerMayEditBuyerFields(_ctx: PurchaseOrderContext, _order: InvPurchaseOrderRow): void {
+    /* no-op until M10 RBAC lands */
+  }
+
+  /**
+   * TODO(M10): ENTREGUE → RECEBIDO_OK|RECEBIDO_PROBLEMA is requester-only;
+   * the other transitions are buyer/admin (§M3, RBAC mapping).
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private assertCallerMayTransition(
+    _ctx: PurchaseOrderContext,
+    _order: InvPurchaseOrderRow,
+    _target: InvPurchaseOrderStatus,
+  ): void {
+    /* no-op until M10 RBAC lands */
+  }
+
+  /** TODO(M10): DELETE /purchase-orders/:id is admin-only. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private assertCallerMayDelete(_ctx: PurchaseOrderContext): void {
+    /* no-op until M10 RBAC lands */
+  }
+
+  // ---------------------------------------------------------------------------
+  // Guards & helpers
+  // ---------------------------------------------------------------------------
+
+  private async lockOr404(tenantId: string, id: string, tx: PurchaseOrderTx): Promise<InvPurchaseOrderRow> {
+    const order = await this.repository.lockById(tenantId, id, tx);
+    if (!order) throw new NotFoundError(`Purchase order ${id} not found`);
+    return order;
+  }
+
+  /** CUSTOMIZADO deadline must resolve to a concrete date after the patch. */
+  private assertDeadlineConsistent(order: InvPurchaseOrderRow, dto: UpdatePurchaseOrderDTO): void {
+    const effectiveType = dto.deadlineType !== undefined ? dto.deadlineType : order.deadlineType;
+    const effectiveDate =
+      dto.deadlineDate !== undefined ? dto.deadlineDate : order.deadlineDate;
+    if (effectiveType === 'CUSTOMIZADO' && !effectiveDate) {
+      throw new ValidationError('deadlineDate is required when deadlineType=CUSTOMIZADO');
+    }
+  }
+
+  private async assertFileAssetsExist(tenantId: string, fileIds: string[]): Promise<void> {
+    if (fileIds.length === 0) return;
+    const unique = [...new Set(fileIds)];
+    const existing = new Set(await this.repository.findExistingFileAssetIds(tenantId, unique));
+    const missing = unique.filter((id) => !existing.has(id));
+    if (missing.length > 0) {
+      throw new ValidationError(`File asset(s) not found in tenant: ${missing.join(', ')}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------------
+
+  private toDetail(row: InvPurchaseOrderRow): InvPurchaseOrderDetailResponse {
+    const status = row.status as InvPurchaseOrderStatus;
+    return {
+      id: row.id,
+      projectId: row.projectId,
+      itemId: row.itemId,
+      itemNameSnapshot: row.itemNameSnapshot ?? null,
+      quantity: row.quantity,
+      status,
+      deadlineType: row.deadlineType ?? null,
+      deadlineDate: row.deadlineDate ? new Date(row.deadlineDate).toISOString() : null,
+      deliveryForecast: row.deliveryForecast ? new Date(row.deliveryForecast).toISOString() : null,
+      requesterNotes: row.requesterNotes ?? null,
+      buyerNotes: row.buyerNotes ?? null,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+      updatedAt: row.updatedAt ? new Date(row.updatedAt).toISOString() : new Date().toISOString(),
+      // S3 — the server serves the state machine; TODO(M10): trim per role.
+      allowedTransitions: PURCHASE_ORDER_TRANSITIONS[status] ?? [],
+      requesterId: row.requesterId ?? null,
+      itemLink: row.itemLink ?? null,
+      recipient: row.recipient ?? null,
+      deliveryPoint: row.deliveryPoint ?? null,
+      passphrase: row.passphrase ?? null,
+    };
+  }
+
+  private toFileResponse(row: InvPurchaseOrderFileRow): InvPurchaseOrderFileResponse {
+    return {
+      id: row.id,
+      fileId: row.fileId,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    };
+  }
+
+  private toEventResponse(row: InvPurchaseOrderEventRow): InvPurchaseOrderEventResponse {
+    return {
+      id: row.id,
+      orderId: row.orderId,
+      actorId: row.actorId ?? null,
+      eventType: row.eventType,
+      details: (row.details ?? {}) as Record<string, unknown>,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Map low-level DB errors to the RFC contract. Drizzle wraps the driver
+   * error (DrizzleQueryError): the real SQLSTATE lives on `err.cause.code`,
+   * not `err.code`/`err.message` — inspect both (known gotcha).
+   */
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      throw new ConflictError('Registro duplicado (violação de unicidade)');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (projeto, item ou arquivo)');
+    }
+    if (code === '23514' || /check constraint/i.test(message)) {
+      throw new ValidationError('Valor fora do intervalo permitido');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+export const inventoryPurchaseOrderService = new InventoryPurchaseOrderService();

--- a/tests/unit/inventory/m3-contract.test.ts
+++ b/tests/unit/inventory/m3-contract.test.ts
@@ -1,0 +1,501 @@
+// RFC-0061 M3 — purchases contract test. Supersedes the M3 case of the frozen
+// tests/unit/controllers/inventory.contract.test.ts: the module now answers
+// concretely instead of the 501 INV_NOT_IMPLEMENTED marker. Mounts the REAL
+// router behind the REAL auth chain (contextMiddleware → hybridAuthByMethod)
+// with only the auth leaves and the M3 service mocked.
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/services/inventory/InventoryPurchaseOrderService', () => ({
+  inventoryPurchaseOrderService: {
+    list: jest.fn(),
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    changeStatus: jest.fn(),
+    listEvents: jest.fn(),
+    addFiles: jest.fn(),
+    removeFiles: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryPurchaseOrderService } from '../../../src/services/inventory/InventoryPurchaseOrderService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+import { NotFoundError } from '../../../src/shared/errors/AppError';
+import {
+  alreadyInState,
+  editLockedState,
+  illegalTransition,
+} from '../../../src/shared/errors/InventoryError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ORDER_ID = '22222222-2222-2222-2222-222222222222';
+const PROJECT_ID = '33333333-3333-3333-3333-333333333333';
+const ITEM_ID = '44444444-4444-4444-4444-444444444444';
+const FILE_ID = '55555555-5555-5555-5555-555555555555';
+
+const order = {
+  id: ORDER_ID,
+  projectId: PROJECT_ID,
+  itemId: ITEM_ID,
+  itemNameSnapshot: 'Resistor 10k',
+  quantity: 50,
+  status: 'PENDENTE',
+  deadlineType: 'ESTA_SEMANA',
+  deadlineDate: null,
+  deliveryForecast: null,
+  requesterNotes: null,
+  buyerNotes: null,
+  createdAt: '2026-08-26T10:00:00.000Z',
+  updatedAt: '2026-08-26T10:00:00.000Z',
+  allowedTransitions: ['COMPRADO_AGUARDANDO', 'CANCELADO'],
+  requesterId: null,
+  itemLink: null,
+  recipient: null,
+  deliveryPoint: null,
+  passphrase: null,
+};
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+const KEY = { 'x-api-key': 'gcdr_cust_x' };
+const JSON_KEY = { ...KEY, 'content-type': 'application/json' };
+
+type ErrBody = { success: boolean; error: { code: string; message?: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T; meta: { requestId: string } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue({
+    keyId: 'key-1',
+    tenantId: TENANT,
+    customerId: TENANT,
+    scopes: ['inventory:read', 'inventory:write'],
+    name: 'inv-key',
+    hierarchyAccess: 'SELF',
+  });
+});
+
+describe('GET /purchase-orders', () => {
+  it('returns the paginated buyer queue (200) with the parsed filters', async () => {
+    (inventoryPurchaseOrderService.list as jest.Mock).mockResolvedValue({
+      items: [order], page: 1, pageSize: 20, total: 1, totalPages: 1,
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(
+        U(srv.url, `/purchase-orders?status=PENDENTE&projectId=${PROJECT_ID}&purchaseType=NACIONAL&groupByProject=true`),
+        { headers: KEY },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: unknown[]; total: number }>;
+      expect(body.data.items).toHaveLength(1);
+      expect(inventoryPurchaseOrderService.list).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        expect.objectContaining({
+          page: 1,
+          pageSize: 20,
+          status: 'PENDENTE',
+          projectId: PROJECT_ID,
+          purchaseType: 'NACIONAL',
+          groupByProject: true,
+        }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects an unknown status filter (400) before reaching the service', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/purchase-orders?status=EM_ANDAMENTO'), { headers: KEY });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.list).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('POST /purchase-orders', () => {
+  const validBody = {
+    projectId: PROJECT_ID,
+    itemId: ITEM_ID,
+    quantity: 50,
+    deadlineType: 'ESTA_SEMANA',
+  };
+
+  it('creates and answers 201 with allowedTransitions (S3)', async () => {
+    (inventoryPurchaseOrderService.create as jest.Mock).mockResolvedValue(order);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/purchase-orders'), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify(validBody),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<typeof order>;
+      expect(body.data.allowedTransitions).toEqual(['COMPRADO_AGUARDANDO', 'CANCELADO']);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects deadlineType=CUSTOMIZADO without deadlineDate (400) at the DTO', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/purchase-orders'), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ ...validBody, deadlineType: 'CUSTOMIZADO' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.create).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects a body without itemId (400)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/purchase-orders'), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ projectId: PROJECT_ID, quantity: 1, deadlineType: 'URGENTE' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.create).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('GET /purchase-orders/:id', () => {
+  it('returns the detail (200)', async () => {
+    (inventoryPurchaseOrderService.getById as jest.Mock).mockResolvedValue({ ...order, files: [] });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), { headers: KEY });
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as OkBody<typeof order>).data.id).toBe(ORDER_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects a malformed id (400) before reaching the service', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/purchase-orders/not-a-uuid'), { headers: KEY });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.getById).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('propagates NotFoundError (404)', async () => {
+    (inventoryPurchaseOrderService.getById as jest.Mock).mockRejectedValue(new NotFoundError('missing'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), { headers: KEY });
+      expect(res.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('PATCH /purchase-orders/:id', () => {
+  it('updates and answers 200', async () => {
+    (inventoryPurchaseOrderService.update as jest.Mock).mockResolvedValue({ ...order, quantity: 99 });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ quantity: 99 }),
+      });
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as OkBody<typeof order>).data.quantity).toBe(99);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('surfaces INV_EDIT_LOCKED_STATE as 409 with the current state', async () => {
+    (inventoryPurchaseOrderService.update as jest.Mock).mockRejectedValue(editLockedState('ENTREGUE'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ quantity: 99 }),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_EDIT_LOCKED_STATE');
+      expect(body.error.details).toEqual({ current: 'ENTREGUE' });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects unknown body fields (400, strict DTO)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), {
+        method: 'PATCH',
+        headers: JSON_KEY,
+        body: JSON.stringify({ status: 'CANCELADO' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.update).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('POST /purchase-orders/:id/status', () => {
+  it('transitions and answers 200 with the fresh allowedTransitions', async () => {
+    (inventoryPurchaseOrderService.changeStatus as jest.Mock).mockResolvedValue({
+      ...order,
+      status: 'COMPRADO_AGUARDANDO',
+      allowedTransitions: ['ENTREGUE', 'CANCELADO'],
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/status`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ status: 'COMPRADO_AGUARDANDO' }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<typeof order>;
+      expect(body.data.status).toBe('COMPRADO_AGUARDANDO');
+      expect(body.data.allowedTransitions).toEqual(['ENTREGUE', 'CANCELADO']);
+      expect(inventoryPurchaseOrderService.changeStatus).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        ORDER_ID,
+        { status: 'COMPRADO_AGUARDANDO' },
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects PENDENTE as a target (400) — creation-only status', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/status`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ status: 'PENDENTE' }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.changeStatus).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('surfaces INV_ILLEGAL_TRANSITION as 409 carrying current + allowedTransitions', async () => {
+    (inventoryPurchaseOrderService.changeStatus as jest.Mock).mockRejectedValue(
+      illegalTransition('RECEBIDO_OK', []),
+    );
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/status`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ status: 'CANCELADO' }),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_ILLEGAL_TRANSITION');
+      expect(body.error.details).toEqual({ current: 'RECEBIDO_OK', allowedTransitions: [] });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('surfaces INV_ALREADY_IN_STATE as 409 with the standing state (A1)', async () => {
+    (inventoryPurchaseOrderService.changeStatus as jest.Mock).mockRejectedValue(
+      alreadyInState('RECEBIDO_OK'),
+    );
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/status`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ status: 'RECEBIDO_OK' }),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_ALREADY_IN_STATE');
+      expect(body.error.details).toEqual({ current: 'RECEBIDO_OK' });
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('GET /purchase-orders/:id/events', () => {
+  it('returns the paginated timeline (200)', async () => {
+    (inventoryPurchaseOrderService.listEvents as jest.Mock).mockResolvedValue({
+      items: [{ id: 'ev-1', orderId: ORDER_ID, actorId: null, eventType: 'CRIADO', details: {}, createdAt: '2026-08-26T10:00:00.000Z' }],
+      page: 1, pageSize: 20, total: 1, totalPages: 1,
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/events?page=1&pageSize=20`), { headers: KEY });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: Array<{ eventType: string }>; total: number }>;
+      expect(body.data.items[0].eventType).toBe('CRIADO');
+      expect(inventoryPurchaseOrderService.listEvents).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        ORDER_ID,
+        1,
+        20,
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('POST /purchase-orders/:id/files', () => {
+  it('links pre-uploaded file_assets and answers 201', async () => {
+    (inventoryPurchaseOrderService.addFiles as jest.Mock).mockResolvedValue({
+      orderId: ORDER_ID,
+      files: [{ id: 'link-1', fileId: FILE_ID, createdAt: '2026-08-26T10:00:00.000Z' }],
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/files`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ fileIds: [FILE_ID] }),
+      });
+      expect(res.status).toBe(201);
+      expect(inventoryPurchaseOrderService.addFiles).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        ORDER_ID,
+        [FILE_ID],
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects an empty fileIds array (400)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/files`), {
+        method: 'POST',
+        headers: JSON_KEY,
+        body: JSON.stringify({ fileIds: [] }),
+      });
+      expect(res.status).toBe(400);
+      expect(inventoryPurchaseOrderService.addFiles).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('DELETE /purchase-orders/:id/files', () => {
+  it('unlinks the given fileIds (200)', async () => {
+    (inventoryPurchaseOrderService.removeFiles as jest.Mock).mockResolvedValue({ orderId: ORDER_ID, removed: 1 });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}/files`), {
+        method: 'DELETE',
+        headers: JSON_KEY,
+        body: JSON.stringify({ fileIds: [FILE_ID] }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ removed: number }>;
+      expect(body.data.removed).toBe(1);
+      expect(inventoryPurchaseOrderService.removeFiles).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        ORDER_ID,
+        [FILE_ID],
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('DELETE /purchase-orders/:id', () => {
+  it('still enforces the confirmation guard (428) without a token', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), { method: 'DELETE', headers: KEY });
+      expect(res.status).toBe(428);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(inventoryPurchaseOrderService.delete).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('deletes with x-confirmation-token (200)', async () => {
+    (inventoryPurchaseOrderService.delete as jest.Mock).mockResolvedValue(undefined);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/purchase-orders/${ORDER_ID}`), {
+        method: 'DELETE',
+        headers: { ...KEY, 'x-confirmation-token': 'excluir' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ id: string; deleted: boolean }>;
+      expect(body.data).toEqual({ id: ORDER_ID, deleted: true });
+      expect(inventoryPurchaseOrderService.delete).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        ORDER_ID,
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m3-purchase-order-service.test.ts
+++ b/tests/unit/inventory/m3-purchase-order-service.test.ts
@@ -1,0 +1,638 @@
+// RFC-0061 M3 — InventoryPurchaseOrderService unit tests (repos + M2 stock
+// service mocked). Covers the ENTIRE DEC-4 state machine (every legal, illegal
+// and repeated transition), the exactly-once receipt ENTRADA (A1), the
+// PENDENTE edit lock (INV_EDIT_LOCKED_STATE) and the WO-style event writes.
+import {
+  InventoryPurchaseOrderService,
+  IInventoryPurchaseOrderRepository,
+  IPurchaseItemRepository,
+  IPurchaseProjectRepository,
+  IPurchaseStockService,
+  RECEIPT_ENTRY_LOCATION,
+  RECEIPT_ENTRY_REASON,
+} from '../../../src/services/inventory/InventoryPurchaseOrderService';
+import type {
+  InvPurchaseOrderRow,
+  InvPurchaseOrderEventRow,
+  InvPurchaseOrderFileRow,
+  PurchaseOrderTx,
+} from '../../../src/repositories/inventory/InventoryPurchaseOrderRepository';
+import type { InvItemRow } from '../../../src/repositories/inventory/InventoryStockRepository';
+import {
+  PURCHASE_ORDER_TRANSITIONS,
+  InvPurchaseOrderStatus,
+} from '../../../src/domain/entities/Inventory';
+import { InventoryError } from '../../../src/shared/errors/InventoryError';
+import { NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const USER = '99999999-9999-9999-9999-999999999999';
+const ORDER_ID = '22222222-2222-2222-2222-222222222222';
+const PROJECT_ID = '33333333-3333-3333-3333-333333333333';
+const ITEM_ID = '44444444-4444-4444-4444-444444444444';
+const FILE_ID = '55555555-5555-5555-5555-555555555555';
+
+const CTX = { tenantId: TENANT, userId: USER };
+const TX = {} as PurchaseOrderTx;
+
+const ALL_STATUSES: InvPurchaseOrderStatus[] = [
+  'PENDENTE',
+  'COMPRADO_AGUARDANDO',
+  'ENTREGUE',
+  'RECEBIDO_OK',
+  'RECEBIDO_PROBLEMA',
+  'CANCELADO',
+];
+
+/** The 5 targets the status DTO accepts (PENDENTE is creation-only). */
+const API_TARGETS = [
+  'COMPRADO_AGUARDANDO',
+  'ENTREGUE',
+  'RECEBIDO_OK',
+  'RECEBIDO_PROBLEMA',
+  'CANCELADO',
+] as const;
+
+function orderRow(overrides: Partial<InvPurchaseOrderRow> = {}): InvPurchaseOrderRow {
+  return {
+    id: ORDER_ID,
+    tenantId: TENANT,
+    projectId: PROJECT_ID,
+    requesterId: USER,
+    itemId: ITEM_ID,
+    itemNameSnapshot: 'Resistor 10k',
+    itemLink: 'https://fornecedor.example/resistor',
+    quantity: 50,
+    recipient: 'Almoxarifado',
+    deliveryPoint: 'Portaria 2',
+    status: 'PENDENTE',
+    deadlineType: 'ESTA_SEMANA',
+    deadlineDate: null,
+    deliveryForecast: null,
+    requesterNotes: null,
+    buyerNotes: null,
+    passphrase: null,
+    createdAt: new Date('2026-08-26T10:00:00Z'),
+    createdBy: USER,
+    updatedAt: new Date('2026-08-26T10:00:00Z'),
+    updatedBy: USER,
+    ...overrides,
+  } as InvPurchaseOrderRow;
+}
+
+function itemRow(overrides: Partial<InvItemRow> = {}): InvItemRow {
+  return {
+    id: ITEM_ID,
+    tenantId: TENANT,
+    name: 'Resistor 10k',
+    domain: 'COMPONENT',
+    link: 'https://fornecedor.example/resistor',
+    purchaseType: 'NACIONAL',
+    ...overrides,
+  } as InvItemRow;
+}
+
+/** A Drizzle-style wrapped Postgres error: SQLSTATE lives on `.cause`. */
+function drizzleError(code: string, message: string): Error {
+  const err = new Error('Failed query: ...');
+  (err as Error & { cause: unknown }).cause = { code, message };
+  return err;
+}
+
+describe('InventoryPurchaseOrderService', () => {
+  let repo: jest.Mocked<IInventoryPurchaseOrderRepository>;
+  let itemRepo: jest.Mocked<IPurchaseItemRepository>;
+  let projectRepo: jest.Mocked<IPurchaseProjectRepository>;
+  let stockService: jest.Mocked<IPurchaseStockService>;
+  let service: InventoryPurchaseOrderService;
+
+  beforeEach(() => {
+    repo = {
+      withTransaction: jest.fn(async (fn: (tx: PurchaseOrderTx) => Promise<unknown>) => fn(TX)),
+      list: jest.fn(),
+      getById: jest.fn(),
+      lockById: jest.fn(),
+      insert: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      insertEvent: jest.fn().mockResolvedValue({} as InvPurchaseOrderEventRow),
+      listEvents: jest.fn(),
+      findExistingFileAssetIds: jest.fn().mockResolvedValue([]),
+      listFiles: jest.fn().mockResolvedValue([]),
+      insertFiles: jest.fn().mockResolvedValue([]),
+      deleteFiles: jest.fn(),
+      hasReceiptEntry: jest.fn().mockResolvedValue(false),
+    } as unknown as jest.Mocked<IInventoryPurchaseOrderRepository>;
+    itemRepo = { getById: jest.fn().mockResolvedValue(itemRow()) } as unknown as jest.Mocked<IPurchaseItemRepository>;
+    projectRepo = {
+      getById: jest.fn().mockResolvedValue({ id: PROJECT_ID }),
+    } as unknown as jest.Mocked<IPurchaseProjectRepository>;
+    stockService = {
+      createMovement: jest.fn().mockResolvedValue({ id: 'mov-1' }),
+    } as unknown as jest.Mocked<IPurchaseStockService>;
+    service = new InventoryPurchaseOrderService(repo, itemRepo, projectRepo, stockService);
+  });
+
+  // ===========================================================================
+  // State machine (DEC-4) — the whole map
+  // ===========================================================================
+
+  describe('changeStatus — state machine', () => {
+    type ApiTarget = (typeof API_TARGETS)[number];
+    const LEGAL: Array<[InvPurchaseOrderStatus, ApiTarget]> = [];
+    const ILLEGAL: Array<[InvPurchaseOrderStatus, ApiTarget]> = [];
+    for (const from of ALL_STATUSES) {
+      for (const to of API_TARGETS) {
+        if (to === from) continue; // repeated — its own suite below
+        (PURCHASE_ORDER_TRANSITIONS[from].includes(to) ? LEGAL : ILLEGAL).push([from, to]);
+      }
+    }
+
+    it('the fixture covers the entire map (6 legal, 19 illegal, 5 repeats)', () => {
+      expect(LEGAL).toHaveLength(6);
+      expect(ILLEGAL).toHaveLength(19);
+    });
+
+    it.each(LEGAL)('%s → %s is accepted, persisted and logged', async (from, to) => {
+      repo.lockById.mockResolvedValue(orderRow({ status: from }));
+      repo.update.mockResolvedValue(orderRow({ status: to }));
+
+      const result = await service.changeStatus(CTX, ORDER_ID, { status: to });
+
+      expect(result.status).toBe(to);
+      expect(result.allowedTransitions).toEqual(PURCHASE_ORDER_TRANSITIONS[to]);
+      expect(repo.update).toHaveBeenCalledWith(
+        TENANT,
+        ORDER_ID,
+        { status: to, updatedBy: USER },
+        TX,
+      );
+      expect(repo.insertEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: ORDER_ID,
+          actorId: USER,
+          eventType: 'STATUS_ALTERADO',
+          details: { from, to },
+        }),
+        TX,
+      );
+      // The automatic ENTRADA fires only on RECEBIDO_OK (§M3, AC-1).
+      expect(stockService.createMovement).toHaveBeenCalledTimes(to === 'RECEBIDO_OK' ? 1 : 0);
+    });
+
+    it.each(ILLEGAL)(
+      '%s → %s is rejected with INV_ILLEGAL_TRANSITION carrying current + allowedTransitions',
+      async (from, to) => {
+        repo.lockById.mockResolvedValue(orderRow({ status: from }));
+
+        const promise = service.changeStatus(CTX, ORDER_ID, { status: to });
+        await expect(promise).rejects.toBeInstanceOf(InventoryError);
+        const err = (await promise.catch((e) => e)) as InventoryError;
+        expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+        expect(err.statusCode).toBe(409);
+        expect(err.details).toEqual({
+          current: from,
+          allowedTransitions: PURCHASE_ORDER_TRANSITIONS[from],
+        });
+        expect(repo.update).not.toHaveBeenCalled();
+        expect(repo.insertEvent).not.toHaveBeenCalled();
+        expect(stockService.createMovement).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(API_TARGETS.map((s) => [s] as [(typeof API_TARGETS)[number]]))(
+      'repeating %s is rejected with INV_ALREADY_IN_STATE (A1)',
+      async (status) => {
+        repo.lockById.mockResolvedValue(orderRow({ status }));
+
+        const promise = service.changeStatus(CTX, ORDER_ID, { status });
+        await expect(promise).rejects.toBeInstanceOf(InventoryError);
+        const err = (await promise.catch((e) => e)) as InventoryError;
+        expect(err.code).toBe('INV_ALREADY_IN_STATE');
+        expect(err.statusCode).toBe(409);
+        expect(err.details).toEqual({ current: status });
+        expect(repo.update).not.toHaveBeenCalled();
+        expect(stockService.createMovement).not.toHaveBeenCalled();
+      },
+    );
+
+    it('404s when the order does not exist', async () => {
+      repo.lockById.mockResolvedValue(null);
+      await expect(
+        service.changeStatus(CTX, ORDER_ID, { status: 'CANCELADO' }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('includes the note in the STATUS_ALTERADO details when provided', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'ENTREGUE' }));
+      repo.update.mockResolvedValue(orderRow({ status: 'RECEBIDO_PROBLEMA' }));
+
+      await service.changeStatus(CTX, ORDER_ID, { status: 'RECEBIDO_PROBLEMA', note: 'faltou 1 caixa' });
+
+      expect(repo.insertEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: { from: 'ENTREGUE', to: 'RECEBIDO_PROBLEMA', note: 'faltou 1 caixa' },
+        }),
+        TX,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Receipt ENTRADA (A1 — exactly once)
+  // ===========================================================================
+
+  describe('changeStatus — RECEBIDO_OK receipt entry', () => {
+    beforeEach(() => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'ENTREGUE' }));
+      repo.update.mockResolvedValue(orderRow({ status: 'RECEBIDO_OK' }));
+    });
+
+    it('creates exactly ONE ENTRADA via the M2 service with a PO-derived idempotency key', async () => {
+      await service.changeStatus(CTX, ORDER_ID, { status: 'RECEBIDO_OK' });
+
+      expect(stockService.createMovement).toHaveBeenCalledTimes(1);
+      expect(stockService.createMovement).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: USER },
+        {
+          itemId: ITEM_ID,
+          location: RECEIPT_ENTRY_LOCATION,
+          quantity: 50,
+          type: 'ENTRADA',
+          reason: RECEIPT_ENTRY_REASON,
+          purchaseOrderId: ORDER_ID,
+        },
+        `po-receipt:${ORDER_ID}`,
+      );
+    });
+
+    it('treats a duplicate-entry failure as idempotent success when the ledger row exists', async () => {
+      // The DB partial UNIQUE fired (a racing confirmation won) — the entry is
+      // there, so the loser must NOT bubble the conflict (AC-1).
+      stockService.createMovement.mockRejectedValue(drizzleError('23505', 'duplicate key'));
+      repo.hasReceiptEntry.mockResolvedValue(true);
+
+      const result = await service.changeStatus(CTX, ORDER_ID, { status: 'RECEBIDO_OK' });
+
+      expect(result.status).toBe('RECEBIDO_OK');
+      expect(repo.hasReceiptEntry).toHaveBeenCalledWith(TENANT, ORDER_ID);
+    });
+
+    it('re-throws the movement failure when NO entry exists in the ledger', async () => {
+      const boom = new Error('db down');
+      stockService.createMovement.mockRejectedValue(boom);
+      repo.hasReceiptEntry.mockResolvedValue(false);
+
+      await expect(service.changeStatus(CTX, ORDER_ID, { status: 'RECEBIDO_OK' })).rejects.toBe(boom);
+    });
+  });
+
+  // ===========================================================================
+  // Create
+  // ===========================================================================
+
+  describe('create', () => {
+    const dto = {
+      projectId: PROJECT_ID,
+      itemId: ITEM_ID,
+      quantity: 50,
+      deadlineType: 'ESTA_SEMANA',
+    } as Parameters<InventoryPurchaseOrderService['create']>[1];
+
+    beforeEach(() => {
+      repo.insert.mockResolvedValue(orderRow());
+    });
+
+    it('sets the requester from ctx and snapshots the item name/link', async () => {
+      await service.create(CTX, dto);
+
+      expect(repo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: TENANT,
+          requesterId: USER,
+          createdBy: USER,
+          itemId: ITEM_ID,
+          itemNameSnapshot: 'Resistor 10k',
+          itemLink: 'https://fornecedor.example/resistor',
+        }),
+        TX,
+      );
+    });
+
+    it('writes the CRIADO event in the same transaction', async () => {
+      await service.create(CTX, dto);
+
+      expect(repo.insertEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: ORDER_ID, actorId: USER, eventType: 'CRIADO' }),
+        TX,
+      );
+    });
+
+    it('links pre-uploaded file_assets after validating they exist', async () => {
+      repo.findExistingFileAssetIds.mockResolvedValue([FILE_ID]);
+      repo.insertFiles.mockResolvedValue([
+        { id: 'link-1', fileId: FILE_ID, createdAt: new Date() } as InvPurchaseOrderFileRow,
+      ]);
+
+      const result = await service.create(CTX, { ...dto, fileIds: [FILE_ID] });
+
+      expect(repo.insertFiles).toHaveBeenCalledWith(TENANT, ORDER_ID, [FILE_ID], USER, TX);
+      expect(result.files).toEqual([expect.objectContaining({ fileId: FILE_ID })]);
+    });
+
+    it('rejects an unknown item (400) before touching the DB', async () => {
+      itemRepo.getById.mockResolvedValue(null);
+      await expect(service.create(CTX, dto)).rejects.toBeInstanceOf(ValidationError);
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown project (400)', async () => {
+      projectRepo.getById.mockResolvedValue(null);
+      await expect(service.create(CTX, dto)).rejects.toBeInstanceOf(ValidationError);
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects fileIds that do not exist in the tenant (400)', async () => {
+      repo.findExistingFileAssetIds.mockResolvedValue([]);
+      await expect(service.create(CTX, { ...dto, fileIds: [FILE_ID] })).rejects.toBeInstanceOf(
+        ValidationError,
+      );
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('returns allowedTransitions for the fresh PENDENTE order (S3)', async () => {
+      const result = await service.create(CTX, dto);
+      expect(result.allowedTransitions).toEqual(['COMPRADO_AGUARDANDO', 'CANCELADO']);
+    });
+  });
+
+  // ===========================================================================
+  // Update (PATCH) — PENDENTE edit lock + buyer fields + events
+  // ===========================================================================
+
+  describe('update', () => {
+    it.each(['COMPRADO_AGUARDANDO', 'ENTREGUE', 'RECEBIDO_OK', 'RECEBIDO_PROBLEMA', 'CANCELADO'] as const)(
+      'rejects requester-field edits in %s with INV_EDIT_LOCKED_STATE',
+      async (status) => {
+        repo.lockById.mockResolvedValue(orderRow({ status }));
+
+        const promise = service.update(CTX, ORDER_ID, { quantity: 99 });
+        await expect(promise).rejects.toBeInstanceOf(InventoryError);
+        const err = (await promise.catch((e) => e)) as InventoryError;
+        expect(err.code).toBe('INV_EDIT_LOCKED_STATE');
+        expect(err.statusCode).toBe(409);
+        expect(err.details).toEqual({ current: status });
+        expect(repo.update).not.toHaveBeenCalled();
+      },
+    );
+
+    it('accepts requester-field edits while PENDENTE', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'PENDENTE' }));
+      repo.update.mockResolvedValue(orderRow({ quantity: 99 }));
+
+      const result = await service.update(CTX, ORDER_ID, { quantity: 99, recipient: 'Lab' });
+
+      expect(result.quantity).toBe(99);
+      expect(repo.update).toHaveBeenCalledWith(
+        TENANT,
+        ORDER_ID,
+        expect.objectContaining({ quantity: 99, recipient: 'Lab', updatedBy: USER }),
+        TX,
+      );
+    });
+
+    it.each(['COMPRADO_AGUARDANDO', 'ENTREGUE', 'CANCELADO'] as const)(
+      'accepts buyer fields (buyerNotes/passphrase/deliveryForecast) in %s',
+      async (status) => {
+        repo.lockById.mockResolvedValue(orderRow({ status }));
+        repo.update.mockResolvedValue(orderRow({ status, buyerNotes: 'ok', passphrase: 'laranja' }));
+
+        const result = await service.update(CTX, ORDER_ID, {
+          buyerNotes: 'ok',
+          passphrase: 'laranja',
+          deliveryForecast: '2026-09-01T00:00:00.000Z',
+        });
+
+        expect(result.buyerNotes).toBe('ok');
+        expect(repo.update).toHaveBeenCalledWith(
+          TENANT,
+          ORDER_ID,
+          expect.objectContaining({
+            buyerNotes: 'ok',
+            passphrase: 'laranja',
+            deliveryForecast: new Date('2026-09-01T00:00:00.000Z'),
+          }),
+          TX,
+        );
+      },
+    );
+
+    it('writes OBSERVACAO_ATUALIZADA when notes change (fields listed, passphrase never echoed)', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'PENDENTE' }));
+      repo.update.mockResolvedValue(orderRow());
+
+      await service.update(CTX, ORDER_ID, { requesterNotes: 'urgente', buyerNotes: 'visto' });
+
+      expect(repo.insertEvent).toHaveBeenCalledTimes(1);
+      expect(repo.insertEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'OBSERVACAO_ATUALIZADA',
+          details: { fields: ['requesterNotes', 'buyerNotes'] },
+        }),
+        TX,
+      );
+    });
+
+    it('does NOT write an event for a patch without notes', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'PENDENTE' }));
+      repo.update.mockResolvedValue(orderRow());
+
+      await service.update(CTX, ORDER_ID, { quantity: 10 });
+
+      expect(repo.insertEvent).not.toHaveBeenCalled();
+    });
+
+    it('rejects deadlineType=CUSTOMIZADO when no deadlineDate resolves (400)', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'PENDENTE', deadlineDate: null }));
+
+      await expect(
+        service.update(CTX, ORDER_ID, { deadlineType: 'CUSTOMIZADO' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('accepts CUSTOMIZADO when the patch carries the date', async () => {
+      repo.lockById.mockResolvedValue(orderRow({ status: 'PENDENTE', deadlineDate: null }));
+      repo.update.mockResolvedValue(orderRow({ deadlineType: 'CUSTOMIZADO' }));
+
+      await service.update(CTX, ORDER_ID, {
+        deadlineType: 'CUSTOMIZADO',
+        deadlineDate: '2026-09-15T00:00:00.000Z',
+      });
+
+      expect(repo.update).toHaveBeenCalled();
+    });
+
+    it('404s when the order does not exist', async () => {
+      repo.lockById.mockResolvedValue(null);
+      await expect(service.update(CTX, ORDER_ID, { quantity: 1 })).rejects.toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  // ===========================================================================
+  // Reads
+  // ===========================================================================
+
+  describe('reads', () => {
+    it('list returns the paginated envelope with allowedTransitions and purchaseType per row', async () => {
+      repo.list.mockResolvedValue({
+        rows: [{ order: orderRow({ status: 'ENTREGUE' }), purchaseType: 'IMPORTACAO' }],
+        total: 41,
+      });
+
+      const result = await service.list(CTX, { page: 2, pageSize: 20 });
+
+      expect(repo.list).toHaveBeenCalledWith(TENANT, expect.objectContaining({ page: 2, pageSize: 20 }));
+      expect(result.total).toBe(41);
+      expect(result.totalPages).toBe(3);
+      expect(result.items[0].purchaseType).toBe('IMPORTACAO');
+      expect(result.items[0].allowedTransitions).toEqual(['RECEBIDO_OK', 'RECEBIDO_PROBLEMA']);
+    });
+
+    it('forwards the buyer-queue filters to the repository', async () => {
+      repo.list.mockResolvedValue({ rows: [], total: 0 });
+
+      await service.list(CTX, {
+        page: 1,
+        pageSize: 20,
+        status: 'COMPRADO_AGUARDANDO',
+        projectId: PROJECT_ID,
+        purchaseType: 'NACIONAL',
+        groupByProject: true,
+      });
+
+      expect(repo.list).toHaveBeenCalledWith(TENANT, {
+        page: 1,
+        pageSize: 20,
+        status: 'COMPRADO_AGUARDANDO',
+        projectId: PROJECT_ID,
+        purchaseType: 'NACIONAL',
+        groupByProject: true,
+      });
+    });
+
+    it('getById returns the detail with files and allowedTransitions', async () => {
+      repo.getById.mockResolvedValue(orderRow());
+      repo.listFiles.mockResolvedValue([
+        { id: 'link-1', fileId: FILE_ID, createdAt: new Date() } as InvPurchaseOrderFileRow,
+      ]);
+
+      const result = await service.getById(CTX, ORDER_ID);
+
+      expect(result.files).toHaveLength(1);
+      expect(result.allowedTransitions).toEqual(['COMPRADO_AGUARDANDO', 'CANCELADO']);
+    });
+
+    it('getById 404s on a missing order', async () => {
+      repo.getById.mockResolvedValue(null);
+      await expect(service.getById(CTX, ORDER_ID)).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('listEvents 404s on a missing order and paginates otherwise', async () => {
+      repo.getById.mockResolvedValue(null);
+      await expect(service.listEvents(CTX, ORDER_ID, 1, 20)).rejects.toBeInstanceOf(NotFoundError);
+
+      repo.getById.mockResolvedValue(orderRow());
+      repo.listEvents.mockResolvedValue({
+        rows: [
+          {
+            id: 'ev-1',
+            tenantId: TENANT,
+            orderId: ORDER_ID,
+            actorId: USER,
+            eventType: 'CRIADO',
+            details: { status: 'PENDENTE' },
+            createdAt: new Date('2026-08-26T10:00:00Z'),
+          } as InvPurchaseOrderEventRow,
+        ],
+        total: 1,
+      });
+
+      const result = await service.listEvents(CTX, ORDER_ID, 1, 20);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({ eventType: 'CRIADO', actorId: USER, details: { status: 'PENDENTE' } }),
+      );
+      expect(result.totalPages).toBe(1);
+    });
+  });
+
+  // ===========================================================================
+  // Files & delete
+  // ===========================================================================
+
+  describe('files', () => {
+    it('addFiles validates asset existence and returns the full link list', async () => {
+      repo.getById.mockResolvedValue(orderRow());
+      repo.findExistingFileAssetIds.mockResolvedValue([FILE_ID]);
+      repo.listFiles.mockResolvedValue([
+        { id: 'link-1', fileId: FILE_ID, createdAt: new Date() } as InvPurchaseOrderFileRow,
+      ]);
+
+      const result = await service.addFiles(CTX, ORDER_ID, [FILE_ID]);
+
+      expect(repo.insertFiles).toHaveBeenCalledWith(TENANT, ORDER_ID, [FILE_ID], USER);
+      expect(result.files).toEqual([expect.objectContaining({ fileId: FILE_ID })]);
+    });
+
+    it('addFiles rejects unknown assets (400)', async () => {
+      repo.getById.mockResolvedValue(orderRow());
+      repo.findExistingFileAssetIds.mockResolvedValue([]);
+      await expect(service.addFiles(CTX, ORDER_ID, [FILE_ID])).rejects.toBeInstanceOf(ValidationError);
+      expect(repo.insertFiles).not.toHaveBeenCalled();
+    });
+
+    it('removeFiles unlinks and reports the count', async () => {
+      repo.getById.mockResolvedValue(orderRow());
+      repo.deleteFiles.mockResolvedValue(1);
+
+      const result = await service.removeFiles(CTX, ORDER_ID, [FILE_ID]);
+
+      expect(repo.deleteFiles).toHaveBeenCalledWith(TENANT, ORDER_ID, [FILE_ID]);
+      expect(result).toEqual({ orderId: ORDER_ID, removed: 1 });
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes an existing order', async () => {
+      repo.delete.mockResolvedValue(true);
+      await service.delete(CTX, ORDER_ID);
+      expect(repo.delete).toHaveBeenCalledWith(TENANT, ORDER_ID);
+    });
+
+    it('404s on a missing order', async () => {
+      repo.delete.mockResolvedValue(false);
+      await expect(service.delete(CTX, ORDER_ID)).rejects.toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  // ===========================================================================
+  // Drizzle error unwrapping (known gotcha: SQLSTATE on err.cause)
+  // ===========================================================================
+
+  describe('repo error mapping', () => {
+    it('maps a wrapped 23503 (FK) from create to a friendly 400', async () => {
+      repo.insert.mockRejectedValue(
+        drizzleError('23503', 'violates foreign key constraint "inv_purchase_orders_project_id_..."'),
+      );
+
+      await expect(
+        service.create(CTX, {
+          projectId: PROJECT_ID,
+          itemId: ITEM_ID,
+          quantity: 1,
+          deadlineType: 'URGENTE',
+        } as Parameters<InventoryPurchaseOrderService['create']>[1]),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+});


### PR DESCRIPTION
RFC-0061 §M3 — Compras (purchase requests + buyer queue). Implements the module against the real schema (migration 0067) and replaces the 501 defers in `purchases.controller.ts` with concrete routes.

## What's in

**New files**
- `src/repositories/inventory/InventoryPurchaseOrderRepository.ts` — `inv_purchase_orders` + `_events` + `_files`; tx boundary + `FOR UPDATE` order lock; buyer-queue listing joins `inv_items` for `purchaseType`; `hasReceiptEntry` guard query; `file_assets` existence check (annotation_attachments pattern).
- `src/services/inventory/InventoryPurchaseOrderService.ts` — all §M3 business rules.
- `tests/unit/inventory/m3-purchase-order-service.test.ts` (68 tests), `tests/unit/inventory/m3-contract.test.ts` (21 tests).

**Modified**: only `src/controllers/inventory/purchases.controller.ts` (defers → real handlers). No touches to app.ts, schema, DTOs, errors, entities, shared.ts or other modules.

## Rules implemented

- **create** — `requesterId = req.context.userId`; item is a required catalog FK; `itemNameSnapshot`/`itemLink` snapshotted at request time; project and `fileIds` validated for existence (friendly 400 instead of raw 23503); `CRIADO` event + file links in the same transaction.
- **PATCH** — requester fields (`quantity`, `recipient`, `deliveryPoint`, `deadlineType`, `deadlineDate`, `requesterNotes`) only while `PENDENTE`, else `INV_EDIT_LOCKED_STATE` 409; buyer fields (`buyerNotes`, `passphrase`, `deliveryForecast`) in any state; `CUSTOMIZADO` must resolve to a concrete `deadlineDate` after the patch; notes edits log `OBSERVACAO_ATUALIZADA` (field names only — passphrase is never echoed, DEC-10).
- **status** — `PURCHASE_ORDER_TRANSITIONS` enforced server-side under the row lock (DEC-4): illegal → `INV_ILLEGAL_TRANSITION` 409 with `{ current, allowedTransitions }`; repeat → `INV_ALREADY_IN_STATE` 409 (A1); `STATUS_ALTERADO {from,to,note?}` event in the same transaction.
- **RECEBIDO_OK** → exactly one automatic `ENTRADA` via `InventoryStockService.createMovement` (`purchaseOrderId` set, idempotency key `po-receipt:<orderId>`, location `FABRICA`, reason "Entrada automática — recebimento de compra").
- **reads** include `allowedTransitions` (S3); list supports `status`, `projectId`, `purchaseType` (via the item join), `groupByProject` + pagination with `total`/`totalPages`.
- **events** — `GET /purchase-orders/:id/events` paginated, chronological.
- **files** — `POST`/`DELETE /purchase-orders/:id/files` link/unlink existing `file_assets` by id (two-phase upload, DEC-8); unlink leaves the asset untouched.
- **delete** — server-side confirmation token (S3, 428 without it).
- Drizzle gotcha honored: SQLSTATE read from `err.cause` in `mapRepoError` (23505/23503/23514/40001).

## Trade-off: receipt ENTRADA runs after the status commit

`InventoryStockService.createMovement` owns its own transaction (its API takes no external tx), so the entry cannot join the status transaction. Order of operations: status + `STATUS_ALTERADO` event commit first, then the movement is created. Exactly-once is still guaranteed durably by the partial UNIQUE `inv_stock_movements_po_entry_uq` `(tenant_id, purchase_order_id) WHERE type='ENTRADA'` (A1, migration 0067): on any failure/race the service re-checks `hasReceiptEntry` — entry present → idempotent success; absent → the error propagates. Residual window: if the movement insert fails transiently after the status commit, the order is `RECEBIDO_OK` with no entry and the terminal state cannot be re-posted (409). See Follow-ups.

## M10 hooks (fine-grained RBAC not in this PR)

Per the phased plan, any principal with `inventory:write` can currently do everything. The gates are centralized as no-op methods so M10 only fills them in: `assertCallerMayEditRequesterFields`, `assertCallerMayEditBuyerFields`, `assertCallerMayTransition` (requester-only `ENTREGUE → RECEBIDO_*`), `assertCallerMayDelete` (admin-only), plus `allowedTransitions` trimming per role.

## Tests

- `m3-purchase-order-service.test.ts` — the ENTIRE state machine enumerated from `PURCHASE_ORDER_TRANSITIONS` (6 legal, 19 illegal, 5 repeats — a fixture test asserts full coverage of the map), receipt-entry idempotency (dup → success when ledger row exists; rethrow when not), `INV_EDIT_LOCKED_STATE` for every locked state, buyer-field edits in any state, event writes, deadline consistency, file validation, Drizzle `err.cause` unwrapping.
- `m3-contract.test.ts` — real router + real auth chain (contextMiddleware → hybridAuthByMethod), only auth leaves and the M3 service mocked: DTO 400s, 409 bodies with `details`, 428 confirmation guard, 201/200 envelopes.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint <changed files> --max-warnings 0` — clean
- `npx jest tests/unit/inventory --coverage=false` — 13 suites, 205 tests, all passing (coverage disabled because global thresholds are calibrated for the full suite, not a directory subset)

## Notes for the merge / Follow-ups

- **Frozen contract test**: `tests/unit/controllers/inventory.contract.test.ts` still carries one M3 case (`GET /purchase-orders → 501`, ~line 120) now superseded by `m3-contract.test.ts` — drop it at merge, same as 08dc614 did for M1/M2/M9.
- **Follow-up (self-heal)**: recovery path for the residual window above (e.g. a reconciliation job or allowing an idempotent re-post of `RECEBIDO_OK` that only backfills the missing entry). Until then, ops can backfill via `POST /stock/movements` with `purchaseOrderId` — the partial UNIQUE still protects.
- **Follow-up (receipt location)**: the RFC does not pin the receipt-entry location; `FABRICA` chosen (source purchases served the factory). Exported as `RECEIPT_ENTRY_LOCATION` for an easy revisit.
- **Follow-up (M10)**: RBAC hooks above; `Idempotency-Key` was intentionally not required on `POST /:id/status` (the state machine + partial UNIQUE make replays safe: 409 + no double entry), matching the frozen deferred contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvWKPT4KpwdZYVNVAis2qK
