### PR TITLE
feat(inventory): M4 production (P2)

### DIFF
--- a/src/controllers/inventory/production.controller.ts
+++ b/src/controllers/inventory/production.controller.ts
@@ -1,20 +1,155 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { defer, requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
+import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+import {
+  inventoryProductionService,
+  CreateAssemblyReleaseSchema,
+  CreateReleaseIssueSchema,
+  ResolveIssueSchema,
+  CorrectAssemblyReleaseSchema,
+  SimulatorPreviewSchema,
+} from '../../services/inventory/InventoryProductionService';
+import { sendSuccess, sendCreated } from '../../middleware/response';
 
-// M4 — Produção (P2; demand resolution P3 — A4)
+// M4 — Produção (P2). Real routes (RFC-0061 §M4):
+// - Fila de Produção grouped by product with the ALMOXARIFADO balance.
+// - Liberação de Montagem: photo + responsibles, FIFO demand consumption and
+//   BOM explosion into component SAIDAs — one service transaction.
+// - Divergências (issues) + correction with the homologated floor.
+// - Capacity and the preview-only simulator (DEC-13).
+// Demand resolution stays deferred to P3 with M6 (A4).
 const router = Router();
 
-router.get('/production/demands', defer('M4', 'P2'));
-router.post('/production/resolve-demand', defer('M4', 'P3'));
-router.get('/production/capacity', defer('M4', 'P2'));
-router.post('/production/simulator/preview', defer('M4', 'P2'));
+// GET /production/demands — pending demands grouped by product (paginated).
+router.get('/production/demands', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryProductionService.listDemands(tenantId, page, pageSize);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
-router.get('/assembly-releases', defer('M4', 'P2'));
-router.post('/assembly-releases', defer('M4', 'P2', (req) => { requireIdempotencyKey(req); }));
-router.post('/assembly-releases/:id/correct', defer('M4', 'P2', (req) => { requireUuid('id', req.params.id); }));
-router.delete('/assembly-releases/:id', defer('M4', 'P2', (req) => { requireUuid('id', req.params.id); requireConfirmation(req); }));
-router.get('/assembly-releases/:id/issues', defer('M4', 'P2', (req) => { requireUuid('id', req.params.id); }));
-router.post('/assembly-releases/:id/issues', defer('M4', 'P2', (req) => { requireUuid('id', req.params.id); }));
-router.post('/issues/:id/resolve', defer('M4', 'P2', (req) => { requireUuid('id', req.params.id); }));
+// POST /production/resolve-demand — P3 (depends on expedition orders, A4).
+router.post('/production/resolve-demand', defer('M4', 'P3'));
+
+// GET /production/capacity — min over BOM components; limiting flagged.
+router.get('/production/capacity', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryProductionService.getCapacity(tenantId, page, pageSize);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /production/simulator/preview — DEC-13: preview-only, NO writes.
+router.post('/production/simulator/preview', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const dto = SimulatorPreviewSchema.parse(req.body ?? {});
+    const data = await inventoryProductionService.previewSimulation(tenantId, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /assembly-releases — paginated, newest first, with items.
+router.get('/assembly-releases', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryProductionService.listReleases(tenantId, page, pageSize);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /assembly-releases — release + FIFO demand consumption + BOM SAIDAs in
+// one transaction. Creates movements → Idempotency-Key required (S1).
+router.post('/assembly-releases', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateAssemblyReleaseSchema.parse(req.body ?? {});
+    const data = await inventoryProductionService.createRelease({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /assembly-releases/:id/correct — floor at homologated units; delta
+// movements (SAIDA/ENTRADA) with loss factor; resolves open issues.
+router.post('/assembly-releases/:id/correct', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = CorrectAssemblyReleaseSchema.parse(req.body ?? {});
+    const data = await inventoryProductionService.correctRelease({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /assembly-releases/:id — destructive (S3): confirmationToken
+// required. Cascades items/issues/homologations; movements NOT reversed.
+router.delete('/assembly-releases/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    requireConfirmation(req);
+    const data = await inventoryProductionService.deleteRelease({ tenantId, userId }, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /assembly-releases/:id/issues — paginated issue list for one release.
+router.get('/assembly-releases/:id/issues', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryProductionService.listIssues(tenantId, req.params.id, page, pageSize);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /assembly-releases/:id/issues — report a divergence (status ABERTA).
+router.post('/assembly-releases/:id/issues', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = CreateReleaseIssueSchema.parse(req.body ?? {});
+    const data = await inventoryProductionService.reportIssue({ tenantId, userId }, req.params.id, dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /issues/:id/resolve — resolve one issue (resolved_by/at + note).
+router.post('/issues/:id/resolve', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = ResolveIssueSchema.parse(req.body ?? {});
+    const data = await inventoryProductionService.resolveIssue({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryProductionRepository.ts
+++ b/src/repositories/inventory/InventoryProductionRepository.ts
@@ -1,0 +1,559 @@
+// =============================================================================
+// RFC-0061 M4 — Produção data access (inv_production_demands,
+// inv_assembly_releases + items + issues) plus the read-only views M4 needs
+// over the catalog/BOM (inv_boms, inv_items), the homologation floor
+// (inv_homologations + inv_homologation_units — read-only, M5 owns writes)
+// and derived component balances (inv_stock_movements — DEC-2).
+//
+// Conventions (matched from InventoryStockRepository): shared `db` client,
+// tenant-scoped reads, every mutating method accepts an optional executor so
+// the service composes them inside ONE transaction; `withTransaction` exposes
+// the boundary. Component stock movements themselves are written through the
+// M2 repository (composed with the same executor) — this file never inserts
+// into inv_stock_movements.
+//
+// Query builders are public so SQL-shape tests can assert the generated SQL
+// (PgDialect.sqlToQuery) without a database.
+// =============================================================================
+
+import { and, asc, desc, eq, inArray, sql } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+import type { StockDbClient, StockTx } from './InventoryStockRepository';
+
+const {
+  invItems,
+  invBoms,
+  invProductionDemands,
+  invAssemblyReleases,
+  invAssemblyReleaseItems,
+  invAssemblyReleaseIssues,
+  invHomologations,
+  invHomologationUnits,
+  invStockMovements,
+} = schema;
+
+// Re-export the transaction typing so the service deals with ONE client type
+// when composing this repository with the M2 stock repository.
+export type ProductionTx = StockTx;
+export type ProductionDbClient = StockDbClient;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvProductionDemandRow = typeof invProductionDemands.$inferSelect;
+export type InvAssemblyReleaseRow = typeof invAssemblyReleases.$inferSelect;
+export type InvAssemblyReleaseItemRow = typeof invAssemblyReleaseItems.$inferSelect;
+export type InvAssemblyReleaseIssueRow = typeof invAssemblyReleaseIssues.$inferSelect;
+
+export interface NewReleaseInput {
+  tenantId: string;
+  photoFileId: string;
+  responsibles: string[];
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewReleaseItemInput {
+  tenantId: string;
+  releaseId: string;
+  itemId: string;
+  quantity: number;
+}
+
+export interface NewIssueInput {
+  tenantId: string;
+  releaseId: string;
+  releaseItemId?: string | null;
+  itemId?: string | null;
+  reportedQuantity?: number | null;
+  message?: string | null;
+  reportedBy?: string | null;
+}
+
+/** One row of GET /production/demands (grouped by product — DEC-5 FK). */
+export interface DemandGroupRow {
+  itemId: string;
+  itemName: string;
+  totalQuantity: number;
+  demandCount: number;
+  oldestCreatedAt: Date | null;
+  /** Derived ALMOXARIFADO ("Estoque Myio") balance — numeric as string. */
+  almoxarifadoBalance: string;
+}
+
+/** Release item joined with its catalog name. */
+export interface ReleaseItemWithName {
+  id: string;
+  itemId: string;
+  itemName: string;
+  quantity: number;
+}
+
+/** BOM row for explosion/capacity: component + its loss percent (inv_items). */
+export interface BomExplosionRow {
+  productItemId: string;
+  componentItemId: string;
+  componentName: string;
+  /** numeric(12,3) as string */
+  quantity: string;
+  /** component's inv_items.loss_percent as string */
+  lossPercent: string;
+}
+
+export interface ComponentBalanceRow {
+  itemId: string;
+  balance: string;
+}
+
+export interface HomologatedCountRow {
+  itemId: string;
+  homologatedCount: number;
+}
+
+export class InventoryProductionRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  async withTransaction<T>(fn: (tx: ProductionTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fila de Produção (production demands)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Pending demands grouped by product with the derived ALMOXARIFADO balance
+   * side-by-side (§M4 "Fila de Produção"). Grouping is by the item FK (DEC-5)
+   * — item names are already case-insensitively unique via normalized_name, so
+   * this matches the source's case-insensitive name grouping.
+   */
+  demandsGroupedQuery(tenantId: string, pageSize: number, offset: number) {
+    return sql`
+      SELECT d.item_id::text     AS item_id,
+             i.name              AS item_name,
+             SUM(d.quantity)::int AS total_quantity,
+             COUNT(*)::int       AS demand_count,
+             MIN(d.created_at)   AS oldest_created_at,
+             COALESCE((
+               SELECT SUM(CASE WHEN m.type IN ('ENTRADA','AJUSTE','TRANSFERENCIA_IN')
+                               THEN m.quantity ELSE -m.quantity END)
+               FROM inv_stock_movements m
+               WHERE m.tenant_id = ${tenantId}
+                 AND m.item_id = d.item_id
+                 AND m.location = 'ALMOXARIFADO'
+             ), 0)::text AS almoxarifado_balance
+      FROM inv_production_demands d
+      JOIN inv_items i ON i.id = d.item_id
+      WHERE d.tenant_id = ${tenantId} AND d.status = 'PENDENTE'
+      GROUP BY d.item_id, i.name
+      ORDER BY lower(i.name), d.item_id
+      LIMIT ${pageSize} OFFSET ${offset}
+    `;
+  }
+
+  async listPendingDemandsGrouped(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    client: ProductionDbClient = db,
+  ): Promise<{ rows: DemandGroupRow[]; total: number }> {
+    const result = await client.execute(this.demandsGroupedQuery(tenantId, pageSize, (page - 1) * pageSize));
+    const raw = result as unknown as Array<Record<string, unknown>>;
+    const rows = raw.map((r) => ({
+      itemId: String(r.item_id),
+      itemName: String(r.item_name),
+      totalQuantity: Number(r.total_quantity),
+      demandCount: Number(r.demand_count),
+      oldestCreatedAt: r.oldest_created_at ? new Date(r.oldest_created_at as string) : null,
+      almoxarifadoBalance: String(r.almoxarifado_balance),
+    }));
+
+    const countResult = await client.execute(sql`
+      SELECT COUNT(DISTINCT d.item_id)::int AS total
+      FROM inv_production_demands d
+      JOIN inv_items i ON i.id = d.item_id
+      WHERE d.tenant_id = ${tenantId} AND d.status = 'PENDENTE'
+    `);
+    const countRows = countResult as unknown as Array<{ total: number }>;
+    return { rows, total: Number(countRows[0]?.total ?? 0) };
+  }
+
+  /**
+   * FIFO queue for one product: PENDENTE demands, oldest first, locked for the
+   * release transaction so two concurrent releases cannot double-consume.
+   */
+  lockPendingDemandsQuery(tenantId: string, itemId: string, client: ProductionDbClient = db) {
+    return client
+      .select()
+      .from(invProductionDemands)
+      .where(
+        and(
+          eq(invProductionDemands.tenantId, tenantId),
+          eq(invProductionDemands.itemId, itemId),
+          eq(invProductionDemands.status, 'PENDENTE'),
+        ),
+      )
+      .orderBy(asc(invProductionDemands.createdAt), asc(invProductionDemands.id))
+      .for('update');
+  }
+
+  async lockPendingDemandsForItem(
+    tenantId: string,
+    itemId: string,
+    client: ProductionDbClient = db,
+  ): Promise<InvProductionDemandRow[]> {
+    return this.lockPendingDemandsQuery(tenantId, itemId, client);
+  }
+
+  async concludeDemand(tenantId: string, id: string, client: ProductionDbClient = db): Promise<void> {
+    await client
+      .update(invProductionDemands)
+      .set({ status: 'CONCLUIDO' })
+      .where(and(eq(invProductionDemands.tenantId, tenantId), eq(invProductionDemands.id, id)));
+  }
+
+  /** Partial FIFO consumption: reduce the pending quantity, keep PENDENTE. */
+  async reduceDemandQuantity(
+    tenantId: string,
+    id: string,
+    newQuantity: number,
+    client: ProductionDbClient = db,
+  ): Promise<void> {
+    await client
+      .update(invProductionDemands)
+      .set({ quantity: newQuantity })
+      .where(and(eq(invProductionDemands.tenantId, tenantId), eq(invProductionDemands.id, id)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assembly releases
+  // ---------------------------------------------------------------------------
+
+  async insertRelease(input: NewReleaseInput, client: ProductionDbClient = db): Promise<InvAssemblyReleaseRow> {
+    const [row] = await client
+      .insert(invAssemblyReleases)
+      .values({
+        tenantId: input.tenantId,
+        photoFileId: input.photoFileId,
+        responsibles: input.responsibles,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async insertReleaseItems(
+    inputs: NewReleaseItemInput[],
+    client: ProductionDbClient = db,
+  ): Promise<InvAssemblyReleaseItemRow[]> {
+    if (inputs.length === 0) return [];
+    return client.insert(invAssemblyReleaseItems).values(inputs).returning();
+  }
+
+  async listReleases(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    client: ProductionDbClient = db,
+  ): Promise<{ rows: InvAssemblyReleaseRow[]; total: number }> {
+    const rows = await client
+      .select()
+      .from(invAssemblyReleases)
+      .where(eq(invAssemblyReleases.tenantId, tenantId))
+      .orderBy(desc(invAssemblyReleases.createdAt), desc(invAssemblyReleases.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invAssemblyReleases)
+      .where(eq(invAssemblyReleases.tenantId, tenantId));
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  /** Items (joined with catalog names) for a set of releases. */
+  async listReleaseItems(
+    tenantId: string,
+    releaseIds: string[],
+    client: ProductionDbClient = db,
+  ): Promise<Array<ReleaseItemWithName & { releaseId: string }>> {
+    if (releaseIds.length === 0) return [];
+    return client
+      .select({
+        id: invAssemblyReleaseItems.id,
+        releaseId: invAssemblyReleaseItems.releaseId,
+        itemId: invAssemblyReleaseItems.itemId,
+        itemName: invItems.name,
+        quantity: invAssemblyReleaseItems.quantity,
+      })
+      .from(invAssemblyReleaseItems)
+      .innerJoin(invItems, eq(invItems.id, invAssemblyReleaseItems.itemId))
+      .where(
+        and(
+          eq(invAssemblyReleaseItems.tenantId, tenantId),
+          inArray(invAssemblyReleaseItems.releaseId, releaseIds),
+        ),
+      )
+      .orderBy(asc(invItems.name));
+  }
+
+  async getReleaseById(
+    tenantId: string,
+    id: string,
+    client: ProductionDbClient = db,
+  ): Promise<{ release: InvAssemblyReleaseRow; items: ReleaseItemWithName[] } | null> {
+    const [release] = await client
+      .select()
+      .from(invAssemblyReleases)
+      .where(and(eq(invAssemblyReleases.tenantId, tenantId), eq(invAssemblyReleases.id, id)))
+      .limit(1);
+    if (!release) return null;
+    const items = await this.listReleaseItems(tenantId, [release.id], client);
+    return { release, items };
+  }
+
+  async updateReleaseItemQuantity(
+    tenantId: string,
+    releaseItemId: string,
+    quantity: number,
+    client: ProductionDbClient = db,
+  ): Promise<void> {
+    await client
+      .update(invAssemblyReleaseItems)
+      .set({ quantity })
+      .where(
+        and(eq(invAssemblyReleaseItems.tenantId, tenantId), eq(invAssemblyReleaseItems.id, releaseItemId)),
+      );
+  }
+
+  /**
+   * Hard delete. Schema cascades take items, issues and the release's
+   * homologations (+ their units) with it — movements are intentionally NOT
+   * reversed (source parity; see service doc).
+   */
+  async deleteRelease(tenantId: string, id: string, client: ProductionDbClient = db): Promise<boolean> {
+    const rows = await client
+      .delete(invAssemblyReleases)
+      .where(and(eq(invAssemblyReleases.tenantId, tenantId), eq(invAssemblyReleases.id, id)))
+      .returning({ id: invAssemblyReleases.id });
+    return rows.length > 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Homologation floor (read-only — M5 owns these tables)
+  // ---------------------------------------------------------------------------
+
+  /** Units already homologated for a release, per item — the correction floor. */
+  async homologatedCountsByItem(
+    tenantId: string,
+    releaseId: string,
+    client: ProductionDbClient = db,
+  ): Promise<HomologatedCountRow[]> {
+    const rows = await client
+      .select({
+        itemId: invHomologations.itemId,
+        homologatedCount: sql<number>`count(${invHomologationUnits.id})::int`,
+      })
+      .from(invHomologations)
+      .leftJoin(invHomologationUnits, eq(invHomologationUnits.homologationId, invHomologations.id))
+      .where(and(eq(invHomologations.tenantId, tenantId), eq(invHomologations.releaseId, releaseId)))
+      .groupBy(invHomologations.itemId);
+    return rows.map((r) => ({ itemId: r.itemId, homologatedCount: Number(r.homologatedCount) }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Issues
+  // ---------------------------------------------------------------------------
+
+  async insertIssue(input: NewIssueInput, client: ProductionDbClient = db): Promise<InvAssemblyReleaseIssueRow> {
+    const [row] = await client
+      .insert(invAssemblyReleaseIssues)
+      .values({
+        tenantId: input.tenantId,
+        releaseId: input.releaseId,
+        releaseItemId: input.releaseItemId ?? null,
+        itemId: input.itemId ?? null,
+        reportedQuantity: input.reportedQuantity ?? null,
+        message: input.message ?? null,
+        status: 'ABERTA',
+        reportedBy: input.reportedBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async listIssues(
+    tenantId: string,
+    releaseId: string,
+    page: number,
+    pageSize: number,
+    client: ProductionDbClient = db,
+  ): Promise<{ rows: InvAssemblyReleaseIssueRow[]; total: number }> {
+    const where = and(
+      eq(invAssemblyReleaseIssues.tenantId, tenantId),
+      eq(invAssemblyReleaseIssues.releaseId, releaseId),
+    );
+    const rows = await client
+      .select()
+      .from(invAssemblyReleaseIssues)
+      .where(where)
+      .orderBy(desc(invAssemblyReleaseIssues.createdAt), desc(invAssemblyReleaseIssues.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invAssemblyReleaseIssues)
+      .where(where);
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  async getIssueById(
+    tenantId: string,
+    id: string,
+    client: ProductionDbClient = db,
+  ): Promise<InvAssemblyReleaseIssueRow | null> {
+    const [row] = await client
+      .select()
+      .from(invAssemblyReleaseIssues)
+      .where(and(eq(invAssemblyReleaseIssues.tenantId, tenantId), eq(invAssemblyReleaseIssues.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async resolveIssue(
+    tenantId: string,
+    id: string,
+    resolvedBy: string | null,
+    resolutionNote: string | null,
+    client: ProductionDbClient = db,
+  ): Promise<InvAssemblyReleaseIssueRow | null> {
+    const [row] = await client
+      .update(invAssemblyReleaseIssues)
+      .set({ status: 'RESOLVIDA', resolvedBy, resolvedAt: new Date(), resolutionNote })
+      .where(
+        and(
+          eq(invAssemblyReleaseIssues.tenantId, tenantId),
+          eq(invAssemblyReleaseIssues.id, id),
+          eq(invAssemblyReleaseIssues.status, 'ABERTA'),
+        ),
+      )
+      .returning();
+    return row ?? null;
+  }
+
+  /** Resolve every open issue of a release (correction flow). */
+  async resolveOpenIssues(
+    tenantId: string,
+    releaseId: string,
+    resolvedBy: string | null,
+    resolutionNote: string | null,
+    client: ProductionDbClient = db,
+  ): Promise<number> {
+    const rows = await client
+      .update(invAssemblyReleaseIssues)
+      .set({ status: 'RESOLVIDA', resolvedBy, resolvedAt: new Date(), resolutionNote })
+      .where(
+        and(
+          eq(invAssemblyReleaseIssues.tenantId, tenantId),
+          eq(invAssemblyReleaseIssues.releaseId, releaseId),
+          eq(invAssemblyReleaseIssues.status, 'ABERTA'),
+        ),
+      )
+      .returning({ id: invAssemblyReleaseIssues.id });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // BOM & capacity reads
+  // ---------------------------------------------------------------------------
+
+  /** BOM rows for a set of products, with the component's loss percent. */
+  async getBomsForProducts(
+    tenantId: string,
+    productItemIds: string[],
+    client: ProductionDbClient = db,
+  ): Promise<BomExplosionRow[]> {
+    if (productItemIds.length === 0) return [];
+    return client
+      .select({
+        productItemId: invBoms.productItemId,
+        componentItemId: invBoms.componentItemId,
+        componentName: invItems.name,
+        quantity: invBoms.quantity,
+        lossPercent: invItems.lossPercent,
+      })
+      .from(invBoms)
+      .innerJoin(invItems, eq(invItems.id, invBoms.componentItemId))
+      .where(and(eq(invBoms.tenantId, tenantId), inArray(invBoms.productItemId, productItemIds)))
+      .orderBy(asc(invItems.name));
+  }
+
+  /** Active manufactured PRODUCTs (the capacity page population). */
+  async listManufacturedProducts(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    client: ProductionDbClient = db,
+  ): Promise<{ rows: Array<{ id: string; name: string }>; total: number }> {
+    const where = and(
+      eq(invItems.tenantId, tenantId),
+      eq(invItems.domain, 'PRODUCT'),
+      eq(invItems.isManufactured, true),
+      eq(invItems.active, true),
+    );
+    const rows = await client
+      .select({ id: invItems.id, name: invItems.name })
+      .from(invItems)
+      .where(where)
+      .orderBy(asc(invItems.name))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invItems)
+      .where(where);
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  /** Catalog rows by id (validation of release/simulator inputs). */
+  async findItemsByIds(
+    tenantId: string,
+    ids: string[],
+    client: ProductionDbClient = db,
+  ): Promise<Array<typeof invItems.$inferSelect>> {
+    if (ids.length === 0) return [];
+    return client
+      .select()
+      .from(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), inArray(invItems.id, ids)));
+  }
+
+  /** Derived balances for a set of components at one location (no lock). */
+  async componentBalances(
+    tenantId: string,
+    componentItemIds: string[],
+    location: string,
+    client: ProductionDbClient = db,
+  ): Promise<ComponentBalanceRow[]> {
+    if (componentItemIds.length === 0) return [];
+    return client
+      .select({
+        itemId: invStockMovements.itemId,
+        balance: sql<string>`coalesce(sum(case when ${invStockMovements.type} in ('ENTRADA','AJUSTE','TRANSFERENCIA_IN') then ${invStockMovements.quantity} else -${invStockMovements.quantity} end), 0)::text`,
+      })
+      .from(invStockMovements)
+      .where(
+        and(
+          eq(invStockMovements.tenantId, tenantId),
+          inArray(invStockMovements.itemId, componentItemIds),
+          eq(invStockMovements.location, location),
+        ),
+      )
+      .groupBy(invStockMovements.itemId);
+  }
+}
+
+export const inventoryProductionRepository = new InventoryProductionRepository();

--- a/src/services/inventory/InventoryProductionService.ts
+++ b/src/services/inventory/InventoryProductionService.ts
@@ -1,0 +1,1004 @@
+// =============================================================================
+// RFC-0061 M4 — Produção service (business rules).
+//
+// Owns:
+//   - Fila de Produção: pending demands grouped by product + ALMOXARIFADO
+//     balance side-by-side (§M4).
+//   - Liberação de Montagem: photo + responsibles + manufactured PRODUCT
+//     items; consumes the demand queue FIFO (PENDENTE, created_at asc —
+//     conclude or partial-reduce) and explodes the BOM into component SAIDA
+//     movements (reason "Consumo de montagem") with the component's loss
+//     factor, 3-decimal rounding — ALL inside one DB transaction.
+//   - Divergências: issue report / resolve.
+//   - Correção: edits released quantities with a FLOOR at already-homologated
+//     units per item; positive delta → SAIDA, negative → ENTRADA (reason
+//     "Correção de liberação de montagem", loss factor applied); resolves the
+//     release's open issues.
+//   - Capacidade: min over BOM components of floor(balance / (qty × loss)).
+//   - Simulador: preview-only (DEC-13) — NO writes ever.
+//
+// Composing with M2 (trade-off, documented): InventoryStockService.
+// createMovement opens its OWN transaction (repository.withTransaction), so it
+// cannot join the release transaction. The M2 *repository* was explicitly
+// designed for composition ("every mutating method accepts an optional
+// executor"), so this service drives inventoryStockRepository.lockItem /
+// getBalance / insertMovement with the release transaction's executor and
+// re-applies the M2 negative-stock guard itself (same lock → derived balance →
+// INV_INSUFFICIENT_STOCK sequence). Release + demand consumption + component
+// SAIDAs therefore commit or roll back atomically — the release only exists if
+// every component consumption succeeded.
+//
+// Component consumption location: FABRICA (assembly happens at the factory;
+// homologation later moves finished goods into ALMOXARIFADO — §M5). The
+// production queue shows the ALMOXARIFADO ("Estoque Myio") balance per §M4.
+//
+// M4 DTOs live here (exported Zod schemas): the RFC finalizes P2 DTOs at
+// implementation time and src/dto is frozen for this PR (module-boundary
+// rule) — follow-up: fold them into src/dto/request/InventoryDTO.ts in a
+// consolidating PR.
+// =============================================================================
+
+import { z } from 'zod';
+import {
+  InventoryProductionRepository,
+  inventoryProductionRepository,
+  ProductionDbClient,
+  InvAssemblyReleaseRow,
+  InvAssemblyReleaseIssueRow,
+  BomExplosionRow,
+  ReleaseItemWithName,
+} from '../../repositories/inventory/InventoryProductionRepository';
+import {
+  InventoryStockRepository,
+  inventoryStockRepository,
+} from '../../repositories/inventory/InventoryStockRepository';
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../shared/errors/AppError';
+import { alreadyInState, insufficientStock } from '../../shared/errors/InventoryError';
+import type { InvPaginatedResponse } from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Request DTOs (M4 — finalized at implementation time per the RFC)
+// -----------------------------------------------------------------------------
+
+const uuid = z.string().uuid();
+
+export const CreateAssemblyReleaseSchema = z
+  .object({
+    photoFileId: uuid,
+    responsibles: z.array(uuid).min(1).max(50),
+    notes: z.string().max(4096).optional(),
+    items: z
+      .array(z.object({ itemId: uuid, quantity: z.number().int().min(1).max(100000) }).strict())
+      .min(1)
+      .max(200),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (new Set(v.items.map((i) => i.itemId)).size !== v.items.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'duplicate itemId in items', path: ['items'] });
+    }
+  });
+export type CreateAssemblyReleaseDTO = z.infer<typeof CreateAssemblyReleaseSchema>;
+
+export const CreateReleaseIssueSchema = z
+  .object({
+    releaseItemId: uuid.optional(),
+    itemId: uuid.optional(),
+    reportedQuantity: z.number().int().min(0).max(100000).optional(),
+    message: z.string().max(4096).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (v.reportedQuantity === undefined && !v.message) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'an issue needs a reportedQuantity or a message',
+        path: ['message'],
+      });
+    }
+  });
+export type CreateReleaseIssueDTO = z.infer<typeof CreateReleaseIssueSchema>;
+
+export const ResolveIssueSchema = z
+  .object({ resolutionNote: z.string().max(4096).optional() })
+  .strict();
+export type ResolveIssueDTO = z.infer<typeof ResolveIssueSchema>;
+
+export const CorrectAssemblyReleaseSchema = z
+  .object({
+    items: z
+      .array(z.object({ releaseItemId: uuid, quantity: z.number().int().min(1).max(100000) }).strict())
+      .min(1)
+      .max(200),
+    resolutionNote: z.string().max(4096).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (new Set(v.items.map((i) => i.releaseItemId)).size !== v.items.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'duplicate releaseItemId in items', path: ['items'] });
+    }
+  });
+export type CorrectAssemblyReleaseDTO = z.infer<typeof CorrectAssemblyReleaseSchema>;
+
+export const SimulatorPreviewSchema = z
+  .object({
+    items: z
+      .array(z.object({ itemId: uuid, quantity: z.number().int().min(1).max(100000) }).strict())
+      .min(1)
+      .max(200),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (new Set(v.items.map((i) => i.itemId)).size !== v.items.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'duplicate itemId in items', path: ['items'] });
+    }
+  });
+export type SimulatorPreviewDTO = z.infer<typeof SimulatorPreviewSchema>;
+
+// -----------------------------------------------------------------------------
+// Response read models
+// -----------------------------------------------------------------------------
+
+export interface InvProductionDemandGroupResponse {
+  itemId: string;
+  itemName: string;
+  totalQuantity: number;
+  demandCount: number;
+  oldestCreatedAt: string | null;
+  almoxarifadoBalance: number;
+}
+
+export interface InvAssemblyReleaseResponse {
+  id: string;
+  photoFileId: string;
+  responsibles: string[];
+  notes: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  items: Array<{ id: string; itemId: string; itemName: string; quantity: number }>;
+}
+
+export interface InvConsumedComponent {
+  componentItemId: string;
+  componentName: string;
+  quantity: number;
+  location: string;
+}
+
+export interface InvCreateReleaseResponse {
+  release: InvAssemblyReleaseResponse;
+  consumedComponents: InvConsumedComponent[];
+  demandSummary: { concluded: number; reducedPartial: number };
+}
+
+export interface InvReleaseIssueResponse {
+  id: string;
+  releaseId: string;
+  releaseItemId: string | null;
+  itemId: string | null;
+  reportedQuantity: number | null;
+  message: string | null;
+  status: string;
+  resolutionNote: string | null;
+  reportedBy: string | null;
+  resolvedBy: string | null;
+  resolvedAt: string | null;
+  createdAt: string;
+}
+
+export interface InvComponentAdjustment {
+  componentItemId: string;
+  componentName: string;
+  movementType: 'SAIDA' | 'ENTRADA';
+  quantity: number;
+  location: string;
+}
+
+export interface InvCorrectReleaseResponse {
+  release: InvAssemblyReleaseResponse;
+  adjustments: InvComponentAdjustment[];
+  resolvedIssues: number;
+}
+
+export interface InvCapacityComponent {
+  componentItemId: string;
+  componentName: string;
+  bomQuantity: number;
+  lossPercent: number;
+  requiredPerUnit: number;
+  balance: number;
+  possible: number;
+  limiting: boolean;
+}
+
+export interface InvCapacityRow {
+  itemId: string;
+  itemName: string;
+  hasBom: boolean;
+  /** null when the product has no BOM ("sem regras"). */
+  possible: number | null;
+  components: InvCapacityComponent[];
+}
+
+export interface InvSimulatorComponent {
+  componentItemId: string;
+  componentName: string;
+  required: number;
+  balance: number;
+  missing: number;
+  sufficient: boolean;
+}
+
+export interface InvSimulatorPreviewResponse {
+  location: string;
+  products: Array<{ itemId: string; itemName: string; quantity: number; hasBom: boolean }>;
+  components: InvSimulatorComponent[];
+  feasible: boolean;
+}
+
+// -----------------------------------------------------------------------------
+// Seams (mocked in unit tests)
+// -----------------------------------------------------------------------------
+
+export type IInventoryProductionRepository = Pick<
+  InventoryProductionRepository,
+  | 'withTransaction'
+  | 'listPendingDemandsGrouped'
+  | 'lockPendingDemandsForItem'
+  | 'concludeDemand'
+  | 'reduceDemandQuantity'
+  | 'insertRelease'
+  | 'insertReleaseItems'
+  | 'listReleases'
+  | 'listReleaseItems'
+  | 'getReleaseById'
+  | 'updateReleaseItemQuantity'
+  | 'deleteRelease'
+  | 'homologatedCountsByItem'
+  | 'insertIssue'
+  | 'listIssues'
+  | 'getIssueById'
+  | 'resolveIssue'
+  | 'resolveOpenIssues'
+  | 'getBomsForProducts'
+  | 'listManufacturedProducts'
+  | 'findItemsByIds'
+  | 'componentBalances'
+>;
+
+/** The M2 seam this service composes inside the release transaction. */
+export type IProductionStockRepository = Pick<
+  InventoryStockRepository,
+  'lockItem' | 'getBalance' | 'insertMovement'
+>;
+
+export interface ProductionContext {
+  tenantId: string;
+  userId?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Constants & numeric helpers
+// -----------------------------------------------------------------------------
+
+/** Components are consumed from the factory floor (see header). */
+export const COMPONENT_LOCATION = 'FABRICA';
+export const REASON_ASSEMBLY_CONSUMPTION = 'Consumo de montagem';
+export const REASON_ASSEMBLY_CORRECTION = 'Correção de liberação de montagem';
+
+// Idempotency cache tuning (best-effort, per-process — same M2 pattern).
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_MAX_ENTRIES = 5000;
+
+/** Kill FP noise at micro precision, then round half-up to 3 decimals. */
+export function round3(n: number): number {
+  return Math.round(Math.round(n * 1e6) / 1000) / 1000;
+}
+
+/** Ceil to 3 decimals (simulator — never under-reserve components). */
+export function ceil3(n: number): number {
+  return Math.ceil(Math.round(n * 1e6) / 1000) / 1000;
+}
+
+function lossFactor(lossPercent: string | number): number {
+  return 1 + Number(lossPercent) / 100;
+}
+
+/** floor(balance / perUnit) on micro-integers (no FP division drift). */
+function floorDiv(balance: number, perUnit: number): number {
+  const perUnitMicro = Math.round(perUnit * 1e6);
+  if (perUnitMicro <= 0) return 0;
+  return Math.floor(Math.round(balance * 1e6) / perUnitMicro);
+}
+
+export class InventoryProductionService {
+  private repository: IInventoryProductionRepository;
+
+  private stockRepository: IProductionStockRepository;
+
+  private idempotencyCache = new Map<string, { at: number; promise: Promise<unknown> }>();
+
+  constructor(repository?: IInventoryProductionRepository, stockRepository?: IProductionStockRepository) {
+    this.repository = repository ?? inventoryProductionRepository;
+    this.stockRepository = stockRepository ?? inventoryStockRepository;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fila de Produção
+  // ---------------------------------------------------------------------------
+
+  async listDemands(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvProductionDemandGroupResponse>> {
+    const { rows, total } = await this.repository.listPendingDemandsGrouped(tenantId, page, pageSize);
+    return {
+      items: rows.map((r) => ({
+        itemId: r.itemId,
+        itemName: r.itemName,
+        totalQuantity: r.totalQuantity,
+        demandCount: r.demandCount,
+        oldestCreatedAt: r.oldestCreatedAt ? r.oldestCreatedAt.toISOString() : null,
+        almoxarifadoBalance: Number(r.almoxarifadoBalance),
+      })),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Liberação de Montagem
+  // ---------------------------------------------------------------------------
+
+  async listReleases(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvAssemblyReleaseResponse>> {
+    const { rows, total } = await this.repository.listReleases(tenantId, page, pageSize);
+    const items = await this.repository.listReleaseItems(tenantId, rows.map((r) => r.id));
+    const byRelease = new Map<string, ReleaseItemWithName[]>();
+    for (const item of items) {
+      const list = byRelease.get(item.releaseId) ?? [];
+      list.push(item);
+      byRelease.set(item.releaseId, list);
+    }
+    return {
+      items: rows.map((r) => this.toReleaseResponse(r, byRelease.get(r.id) ?? [])),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async createRelease(
+    ctx: ProductionContext,
+    dto: CreateAssemblyReleaseDTO,
+    idempotencyKey: string,
+  ): Promise<InvCreateReleaseResponse> {
+    return this.idempotent(ctx.tenantId, `release:${idempotencyKey}`, () =>
+      this.doCreateRelease(ctx, dto),
+    );
+  }
+
+  private async doCreateRelease(
+    ctx: ProductionContext,
+    dto: CreateAssemblyReleaseDTO,
+  ): Promise<InvCreateReleaseResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        // 1) Validate + lock the products (deterministic id order — deadlock
+        //    hygiene: products first, then components, each sorted).
+        const sortedItems = [...dto.items].sort((a, b) => a.itemId.localeCompare(b.itemId));
+        const nameById = new Map<string, string>();
+        for (const entry of sortedItems) {
+          const item = await this.stockRepository.lockItem(ctx.tenantId, entry.itemId, tx);
+          if (!item) throw new NotFoundError(`Item ${entry.itemId} not found`);
+          if (item.domain !== 'PRODUCT' || !item.isManufactured) {
+            throw new ValidationError(
+              `Liberação de montagem aceita apenas produtos manufaturados (item ${item.name})`,
+            );
+          }
+          nameById.set(item.id, item.name);
+        }
+
+        // 2) Release + items.
+        const release = await this.repository.insertRelease(
+          {
+            tenantId: ctx.tenantId,
+            photoFileId: dto.photoFileId,
+            responsibles: dto.responsibles,
+            notes: dto.notes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        const releaseItems = await this.repository.insertReleaseItems(
+          dto.items.map((i) => ({
+            tenantId: ctx.tenantId,
+            releaseId: release.id,
+            itemId: i.itemId,
+            quantity: i.quantity,
+          })),
+          tx,
+        );
+
+        // 3) FIFO demand consumption (PENDENTE per item, created_at asc).
+        const demandSummary = { concluded: 0, reducedPartial: 0 };
+        for (const entry of sortedItems) {
+          let remaining = entry.quantity;
+          if (remaining <= 0) continue;
+          const queue = await this.repository.lockPendingDemandsForItem(ctx.tenantId, entry.itemId, tx);
+          for (const demand of queue) {
+            if (remaining <= 0) break;
+            if (demand.quantity <= remaining) {
+              await this.repository.concludeDemand(ctx.tenantId, demand.id, tx);
+              remaining -= demand.quantity;
+              demandSummary.concluded += 1;
+            } else {
+              await this.repository.reduceDemandQuantity(
+                ctx.tenantId,
+                demand.id,
+                demand.quantity - remaining,
+                tx,
+              );
+              remaining = 0;
+              demandSummary.reducedPartial += 1;
+            }
+          }
+        }
+
+        // 4) BOM explosion → component SAIDAs with loss factor (§M4):
+        //    Σ bom.quantity × produced × (1 + loss_percent/100), rounded to 3
+        //    decimals per component AFTER summing across products.
+        const boms = await this.repository.getBomsForProducts(
+          ctx.tenantId,
+          dto.items.map((i) => i.itemId),
+          tx,
+        );
+        const producedByItem = new Map(dto.items.map((i) => [i.itemId, i.quantity]));
+        const consumption = this.explodeBom(boms, producedByItem);
+
+        const consumedComponents: InvConsumedComponent[] = [];
+        for (const comp of consumption) {
+          if (comp.quantity <= 0) continue;
+          await this.consumeComponent(ctx, comp.componentItemId, comp.quantity, {
+            reason: REASON_ASSEMBLY_CONSUMPTION,
+            photoFileId: dto.photoFileId,
+            tx,
+          });
+          consumedComponents.push({ ...comp, location: COMPONENT_LOCATION });
+        }
+
+        return {
+          release: this.toReleaseResponse(
+            release,
+            releaseItems.map((ri) => ({
+              id: ri.id,
+              itemId: ri.itemId,
+              itemName: nameById.get(ri.itemId) ?? '',
+              quantity: ri.quantity,
+            })),
+          ),
+          consumedComponents,
+          demandSummary,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Divergências (issues)
+  // ---------------------------------------------------------------------------
+
+  async reportIssue(
+    ctx: ProductionContext,
+    releaseId: string,
+    dto: CreateReleaseIssueDTO,
+  ): Promise<InvReleaseIssueResponse> {
+    const found = await this.repository.getReleaseById(ctx.tenantId, releaseId);
+    if (!found) throw new NotFoundError(`Assembly release ${releaseId} not found`);
+    if (dto.releaseItemId && !found.items.some((i) => i.id === dto.releaseItemId)) {
+      throw new ValidationError(`releaseItemId ${dto.releaseItemId} does not belong to release ${releaseId}`);
+    }
+    try {
+      const row = await this.repository.insertIssue({
+        tenantId: ctx.tenantId,
+        releaseId,
+        releaseItemId: dto.releaseItemId ?? null,
+        itemId: dto.itemId ?? null,
+        reportedQuantity: dto.reportedQuantity ?? null,
+        message: dto.message ?? null,
+        reportedBy: ctx.userId ?? null,
+      });
+      return this.toIssueResponse(row);
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  async listIssues(
+    tenantId: string,
+    releaseId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvReleaseIssueResponse>> {
+    const found = await this.repository.getReleaseById(tenantId, releaseId);
+    if (!found) throw new NotFoundError(`Assembly release ${releaseId} not found`);
+    const { rows, total } = await this.repository.listIssues(tenantId, releaseId, page, pageSize);
+    return {
+      items: rows.map((r) => this.toIssueResponse(r)),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async resolveIssue(
+    ctx: ProductionContext,
+    issueId: string,
+    dto: ResolveIssueDTO,
+  ): Promise<InvReleaseIssueResponse> {
+    const issue = await this.repository.getIssueById(ctx.tenantId, issueId);
+    if (!issue) throw new NotFoundError(`Issue ${issueId} not found`);
+    if (issue.status === 'RESOLVIDA') throw alreadyInState('RESOLVIDA');
+    try {
+      const row = await this.repository.resolveIssue(
+        ctx.tenantId,
+        issueId,
+        ctx.userId ?? null,
+        dto.resolutionNote ?? null,
+      );
+      // The guarded UPDATE (status='ABERTA') lost a race → already resolved.
+      if (!row) throw alreadyInState('RESOLVIDA');
+      return this.toIssueResponse(row);
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Correção de liberação
+  // ---------------------------------------------------------------------------
+
+  async correctRelease(
+    ctx: ProductionContext,
+    releaseId: string,
+    dto: CorrectAssemblyReleaseDTO,
+  ): Promise<InvCorrectReleaseResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const found = await this.repository.getReleaseById(ctx.tenantId, releaseId, tx);
+        if (!found) throw new NotFoundError(`Assembly release ${releaseId} not found`);
+        const itemsById = new Map(found.items.map((i) => [i.id, i]));
+
+        // FLOOR: units already homologated per item (M5 tables, read-only).
+        const homologated = new Map(
+          (await this.repository.homologatedCountsByItem(ctx.tenantId, releaseId, tx)).map((h) => [
+            h.itemId,
+            h.homologatedCount,
+          ]),
+        );
+
+        // Signed per-component delta, aggregated across the corrected items.
+        const deltaByProduct = new Map<string, number>();
+        for (const entry of dto.items) {
+          const releaseItem = itemsById.get(entry.releaseItemId);
+          if (!releaseItem) {
+            throw new ValidationError(
+              `releaseItemId ${entry.releaseItemId} does not belong to release ${releaseId}`,
+            );
+          }
+          const floor = homologated.get(releaseItem.itemId) ?? 0;
+          if (entry.quantity < floor) {
+            throw new ConflictError(
+              `Quantidade (${entry.quantity}) abaixo do já homologado (${floor}) para o item ${releaseItem.itemName}`,
+            );
+          }
+          const delta = entry.quantity - releaseItem.quantity;
+          if (delta !== 0) {
+            deltaByProduct.set(
+              releaseItem.itemId,
+              (deltaByProduct.get(releaseItem.itemId) ?? 0) + delta,
+            );
+            await this.repository.updateReleaseItemQuantity(
+              ctx.tenantId,
+              releaseItem.id,
+              entry.quantity,
+              tx,
+            );
+          }
+        }
+
+        // BOM explosion of the signed deltas → net component adjustments.
+        const boms = await this.repository.getBomsForProducts(
+          ctx.tenantId,
+          [...deltaByProduct.keys()],
+          tx,
+        );
+        const netByComponent = new Map<string, { name: string; micro: number }>();
+        for (const bom of boms) {
+          const delta = deltaByProduct.get(bom.productItemId) ?? 0;
+          if (delta === 0) continue;
+          const amount = Number(bom.quantity) * delta * lossFactor(bom.lossPercent);
+          const acc = netByComponent.get(bom.componentItemId) ?? { name: bom.componentName, micro: 0 };
+          acc.micro += Math.round(amount * 1e6);
+          netByComponent.set(bom.componentItemId, acc);
+        }
+
+        const adjustments: InvComponentAdjustment[] = [];
+        const sortedComponents = [...netByComponent.entries()].sort(([a], [b]) => a.localeCompare(b));
+        for (const [componentItemId, acc] of sortedComponents) {
+          const net = Math.round(acc.micro / 1000) / 1000; // 3-decimal grain
+          if (net === 0) continue;
+          if (net > 0) {
+            await this.consumeComponent(ctx, componentItemId, net, {
+              reason: REASON_ASSEMBLY_CORRECTION,
+              photoFileId: found.release.photoFileId,
+              tx,
+            });
+            adjustments.push({
+              componentItemId,
+              componentName: acc.name,
+              movementType: 'SAIDA',
+              quantity: net,
+              location: COMPONENT_LOCATION,
+            });
+          } else {
+            await this.stockRepository.insertMovement(
+              {
+                tenantId: ctx.tenantId,
+                itemId: componentItemId,
+                location: COMPONENT_LOCATION,
+                quantity: String(-net),
+                type: 'ENTRADA',
+                reason: REASON_ASSEMBLY_CORRECTION,
+                createdBy: ctx.userId ?? null,
+              },
+              tx,
+            );
+            adjustments.push({
+              componentItemId,
+              componentName: acc.name,
+              movementType: 'ENTRADA',
+              quantity: -net,
+              location: COMPONENT_LOCATION,
+            });
+          }
+        }
+
+        const resolvedIssues = await this.repository.resolveOpenIssues(
+          ctx.tenantId,
+          releaseId,
+          ctx.userId ?? null,
+          dto.resolutionNote ?? 'Resolvida via correção de liberação',
+          tx,
+        );
+
+        const updated = await this.repository.getReleaseById(ctx.tenantId, releaseId, tx);
+        return {
+          release: this.toReleaseResponse(updated?.release ?? found.release, updated?.items ?? found.items),
+          adjustments,
+          resolvedIssues,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Delete
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Hard delete of a release: schema cascades remove its items, issues and its
+   * homologations (+units). Stock movements are intentionally NOT reversed —
+   * parity with the source system, where deleting a release keeps the ledger
+   * history (an explicit AJUSTE, audited as such, is the correction path).
+   */
+  async deleteRelease(ctx: ProductionContext, releaseId: string): Promise<{ deleted: boolean }> {
+    try {
+      const deleted = await this.repository.deleteRelease(ctx.tenantId, releaseId);
+      if (!deleted) throw new NotFoundError(`Assembly release ${releaseId} not found`);
+      return { deleted: true };
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Capacidade
+  // ---------------------------------------------------------------------------
+
+  async getCapacity(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvPaginatedResponse<InvCapacityRow>> {
+    const { rows: products, total } = await this.repository.listManufacturedProducts(
+      tenantId,
+      page,
+      pageSize,
+    );
+    const boms = await this.repository.getBomsForProducts(tenantId, products.map((p) => p.id));
+    const componentIds = [...new Set(boms.map((b) => b.componentItemId))];
+    const balances = new Map(
+      (await this.repository.componentBalances(tenantId, componentIds, COMPONENT_LOCATION)).map((b) => [
+        b.itemId,
+        Number(b.balance),
+      ]),
+    );
+
+    const bomsByProduct = new Map<string, BomExplosionRow[]>();
+    for (const bom of boms) {
+      const list = bomsByProduct.get(bom.productItemId) ?? [];
+      list.push(bom);
+      bomsByProduct.set(bom.productItemId, list);
+    }
+
+    const items: InvCapacityRow[] = products.map((product) => {
+      const productBoms = bomsByProduct.get(product.id) ?? [];
+      if (productBoms.length === 0) {
+        // "sem regras" — the product has no BOM to compute capacity from.
+        return { itemId: product.id, itemName: product.name, hasBom: false, possible: null, components: [] };
+      }
+      const components = productBoms.map((bom) => {
+        const balance = balances.get(bom.componentItemId) ?? 0;
+        const requiredPerUnit = round3(Number(bom.quantity) * lossFactor(bom.lossPercent));
+        const possible = Math.max(0, floorDiv(balance, Number(bom.quantity) * lossFactor(bom.lossPercent)));
+        return {
+          componentItemId: bom.componentItemId,
+          componentName: bom.componentName,
+          bomQuantity: Number(bom.quantity),
+          lossPercent: Number(bom.lossPercent),
+          requiredPerUnit,
+          balance,
+          possible,
+          limiting: false,
+        };
+      });
+      const possible = Math.min(...components.map((c) => c.possible));
+      for (const c of components) c.limiting = c.possible === possible;
+      return { itemId: product.id, itemName: product.name, hasBom: true, possible, components };
+    });
+
+    return { items, page, pageSize, total, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Simulador (DEC-13: preview-only — NO writes)
+  // ---------------------------------------------------------------------------
+
+  async previewSimulation(tenantId: string, dto: SimulatorPreviewDTO): Promise<InvSimulatorPreviewResponse> {
+    const itemIds = dto.items.map((i) => i.itemId);
+    const catalog = await this.repository.findItemsByIds(tenantId, itemIds);
+    const catalogById = new Map(catalog.map((c) => [c.id, c]));
+    for (const entry of dto.items) {
+      const item = catalogById.get(entry.itemId);
+      if (!item) throw new NotFoundError(`Item ${entry.itemId} not found`);
+      if (item.domain !== 'PRODUCT' || !item.isManufactured) {
+        throw new ValidationError(`Simulador aceita apenas produtos manufaturados (item ${item.name})`);
+      }
+    }
+
+    const boms = await this.repository.getBomsForProducts(tenantId, itemIds);
+    const bomProducts = new Set(boms.map((b) => b.productItemId));
+    const desiredByItem = new Map(dto.items.map((i) => [i.itemId, i.quantity]));
+
+    // Required per component = ceil3(Σ bom.qty × desired × loss factor).
+    const requiredByComponent = new Map<string, { name: string; micro: number }>();
+    for (const bom of boms) {
+      const desired = desiredByItem.get(bom.productItemId) ?? 0;
+      if (desired <= 0) continue;
+      const amount = Number(bom.quantity) * desired * lossFactor(bom.lossPercent);
+      const acc = requiredByComponent.get(bom.componentItemId) ?? { name: bom.componentName, micro: 0 };
+      acc.micro += Math.round(amount * 1e6);
+      requiredByComponent.set(bom.componentItemId, acc);
+    }
+
+    const componentIds = [...requiredByComponent.keys()];
+    const balances = new Map(
+      (await this.repository.componentBalances(tenantId, componentIds, COMPONENT_LOCATION)).map((b) => [
+        b.itemId,
+        Number(b.balance),
+      ]),
+    );
+
+    const components: InvSimulatorComponent[] = [...requiredByComponent.entries()]
+      .sort(([, a], [, b]) => a.name.localeCompare(b.name))
+      .map(([componentItemId, acc]) => {
+        const required = Math.ceil(acc.micro / 1000) / 1000; // ceil to 3 decimals
+        const balance = balances.get(componentItemId) ?? 0;
+        const missing = Math.max(0, round3(required - balance));
+        return {
+          componentItemId,
+          componentName: acc.name,
+          required,
+          balance,
+          missing,
+          sufficient: missing === 0,
+        };
+      });
+
+    return {
+      location: COMPONENT_LOCATION,
+      products: dto.items.map((i) => ({
+        itemId: i.itemId,
+        itemName: catalogById.get(i.itemId)?.name ?? '',
+        quantity: i.quantity,
+        hasBom: bomProducts.has(i.itemId),
+      })),
+      components,
+      feasible: components.length > 0 && components.every((c) => c.sufficient),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  /** Σ bom.qty × produced × loss factor per component, rounded to 3 decimals. */
+  private explodeBom(
+    boms: BomExplosionRow[],
+    producedByItem: Map<string, number>,
+  ): Array<{ componentItemId: string; componentName: string; quantity: number }> {
+    const acc = new Map<string, { name: string; micro: number }>();
+    for (const bom of boms) {
+      const produced = producedByItem.get(bom.productItemId) ?? 0;
+      if (produced <= 0) continue;
+      const amount = Number(bom.quantity) * produced * lossFactor(bom.lossPercent);
+      const entry = acc.get(bom.componentItemId) ?? { name: bom.componentName, micro: 0 };
+      entry.micro += Math.round(amount * 1e6);
+      acc.set(bom.componentItemId, entry);
+    }
+    return [...acc.entries()]
+      .sort(([a], [b]) => a.localeCompare(b)) // deterministic lock order
+      .map(([componentItemId, entry]) => ({
+        componentItemId,
+        componentName: entry.name,
+        quantity: Math.round(entry.micro / 1000) / 1000,
+      }));
+  }
+
+  /**
+   * Component SAIDA under the M2 guard sequence, composed with the release
+   * transaction: FOR UPDATE item lock → derived balance → guard → insert.
+   */
+  private async consumeComponent(
+    ctx: ProductionContext,
+    componentItemId: string,
+    quantity: number,
+    opts: { reason: string; photoFileId?: string | null; tx: ProductionDbClient },
+  ): Promise<void> {
+    const item = await this.stockRepository.lockItem(ctx.tenantId, componentItemId, opts.tx);
+    if (!item) throw new NotFoundError(`Component ${componentItemId} not found`);
+    const totals = await this.stockRepository.getBalance(
+      ctx.tenantId,
+      componentItemId,
+      COMPONENT_LOCATION,
+      opts.tx,
+    );
+    const balance = Number(totals.balance);
+    if (Math.round(balance * 1000) < Math.round(quantity * 1000)) {
+      throw insufficientStock(componentItemId, COMPONENT_LOCATION, balance, quantity);
+    }
+    await this.stockRepository.insertMovement(
+      {
+        tenantId: ctx.tenantId,
+        itemId: componentItemId,
+        location: COMPONENT_LOCATION,
+        quantity: String(quantity),
+        type: 'SAIDA',
+        reason: opts.reason,
+        photoFileId: opts.photoFileId ?? null,
+        createdBy: ctx.userId ?? null,
+      },
+      opts.tx,
+    );
+  }
+
+  private toReleaseResponse(
+    row: InvAssemblyReleaseRow,
+    items: ReleaseItemWithName[],
+  ): InvAssemblyReleaseResponse {
+    return {
+      id: row.id,
+      photoFileId: row.photoFileId,
+      responsibles: row.responsibles ?? [],
+      notes: row.notes ?? null,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+      createdBy: row.createdBy ?? null,
+      items: items.map((i) => ({ id: i.id, itemId: i.itemId, itemName: i.itemName, quantity: i.quantity })),
+    };
+  }
+
+  private toIssueResponse(row: InvAssemblyReleaseIssueRow): InvReleaseIssueResponse {
+    return {
+      id: row.id,
+      releaseId: row.releaseId,
+      releaseItemId: row.releaseItemId ?? null,
+      itemId: row.itemId ?? null,
+      reportedQuantity: row.reportedQuantity ?? null,
+      message: row.message ?? null,
+      status: row.status,
+      resolutionNote: row.resolutionNote ?? null,
+      reportedBy: row.reportedBy ?? null,
+      resolvedBy: row.resolvedBy ?? null,
+      resolvedAt: row.resolvedAt ? new Date(row.resolvedAt).toISOString() : null,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotency (best-effort, per-process — same M2 pattern; durable storage
+  // is the standing inv_idempotency_keys follow-up from the M2 PR).
+  // ---------------------------------------------------------------------------
+
+  private async idempotent<T>(tenantId: string, key: string, run: () => Promise<T>): Promise<T> {
+    const cacheKey = `${tenantId}:${key}`;
+    const now = Date.now();
+    const hit = this.idempotencyCache.get(cacheKey);
+    if (hit && now - hit.at < IDEMPOTENCY_TTL_MS) {
+      return hit.promise as Promise<T>;
+    }
+    const promise = run();
+    this.idempotencyCache.set(cacheKey, { at: now, promise });
+    // A failed attempt must NOT poison the key — retries reuse it on purpose.
+    promise.catch(() => this.idempotencyCache.delete(cacheKey));
+    this.evictStaleIdempotencyEntries(now);
+    return promise;
+  }
+
+  private evictStaleIdempotencyEntries(now: number): void {
+    if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    for (const [key, entry] of this.idempotencyCache) {
+      if (now - entry.at >= IDEMPOTENCY_TTL_MS) this.idempotencyCache.delete(key);
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    }
+    for (const key of this.idempotencyCache.keys()) {
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+      this.idempotencyCache.delete(key);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error mapping (Drizzle gotcha: the real SQLSTATE lives on `err.cause`)
+  // ---------------------------------------------------------------------------
+
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      throw new ConflictError('Registro duplicado (violação de unicidade)');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (item, foto, release ou demanda)');
+    }
+    if (code === '23514' || /check constraint/i.test(message)) {
+      throw new ValidationError('Valor viola uma restrição do banco (quantidade/status)');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+export const inventoryProductionService = new InventoryProductionService();

--- a/tests/unit/inventory/m4-bom-explosion.test.ts
+++ b/tests/unit/inventory/m4-bom-explosion.test.ts
@@ -1,0 +1,167 @@
+/**
+ * RFC-0061 M4 — BOM explosion on assembly release (§M4): component SAIDA of
+ * Σ bom.quantity × produced × (1 + loss_percent/100), rounded to 3 decimals
+ * AFTER summing across the release's products, reason "Consumo de montagem",
+ * from FABRICA, under the M2 negative-stock guard — inside the release tx.
+ */
+
+import {
+  InventoryProductionService,
+  CreateAssemblyReleaseDTO,
+  REASON_ASSEMBLY_CONSUMPTION,
+  COMPONENT_LOCATION,
+  round3,
+  ceil3,
+} from '../../../src/services/inventory/InventoryProductionService';
+import { InventoryError } from '../../../src/shared/errors/InventoryError';
+import {
+  CTX,
+  PRODUCT_A,
+  PRODUCT_B,
+  COMPONENT_1,
+  COMPONENT_2,
+  PHOTO_ID,
+  USER,
+  makeBomRow,
+  makeProdRepo,
+  makeStockRepo,
+} from './m4-helpers';
+
+function releaseDto(items: Array<{ itemId: string; quantity: number }>): CreateAssemblyReleaseDTO {
+  return { photoFileId: PHOTO_ID, responsibles: [USER], items } as CreateAssemblyReleaseDTO;
+}
+
+describe('M4 — BOM explosion with loss factor and 3-decimal rounding', () => {
+  it('writes one SAIDA per component: qty × produced × (1 + loss/100)', async () => {
+    const repo = makeProdRepo({
+      getBomsForProducts: jest.fn(async () => [
+        makeBomRow(PRODUCT_A, COMPONENT_1, '2', '10'), // 2 × 10 × 1.10 = 22
+        makeBomRow(PRODUCT_A, COMPONENT_2, '0.333', '0'), // 0.333 × 10 = 3.33
+      ]),
+    });
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 10 }]), 'b1');
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(2);
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: COMPONENT_1,
+        quantity: '22',
+        type: 'SAIDA',
+        location: COMPONENT_LOCATION,
+        reason: REASON_ASSEMBLY_CONSUMPTION,
+        photoFileId: PHOTO_ID,
+        createdBy: USER,
+      }),
+      expect.anything(),
+    );
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: COMPONENT_2, quantity: '3.33', type: 'SAIDA' }),
+      expect.anything(),
+    );
+    expect(result.consumedComponents).toEqual([
+      expect.objectContaining({ componentItemId: COMPONENT_1, quantity: 22, location: 'FABRICA' }),
+      expect.objectContaining({ componentItemId: COMPONENT_2, quantity: 3.33 }),
+    ]);
+  });
+
+  it('rounds the summed consumption to 3 decimals (0.001 × 3 × 1.15 → 0.003)', async () => {
+    const repo = makeProdRepo({
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '0.001', '15')]),
+    });
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 3 }]), 'b2');
+
+    // 0.001 × 3 × 1.15 = 0.00345 → 0.003 at the ledger's 3-decimal grain.
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: COMPONENT_1, quantity: '0.003' }),
+      expect.anything(),
+    );
+  });
+
+  it('aggregates a component shared by two products into ONE movement (sum, then round)', async () => {
+    const repo = makeProdRepo({
+      getBomsForProducts: jest.fn(async () => [
+        makeBomRow(PRODUCT_A, COMPONENT_1, '2', '0'),
+        makeBomRow(PRODUCT_B, COMPONENT_1, '0.5', '0'),
+      ]),
+    });
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    await service.createRelease(
+      CTX,
+      releaseDto([
+        { itemId: PRODUCT_A, quantity: 1 },
+        { itemId: PRODUCT_B, quantity: 1 },
+      ]),
+      'b3',
+    );
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ itemId: COMPONENT_1, quantity: '2.5' }),
+      expect.anything(),
+    );
+  });
+
+  it('fails the WHOLE release when a component lacks stock (INV_INSUFFICIENT_STOCK inside the tx)', async () => {
+    const repo = makeProdRepo({
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '2', '0')]),
+    });
+    const stockRepo = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '3', totalIn: '3', totalOut: '0', lastMovementAt: null })),
+    });
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    // needs 2 × 5 = 10 > balance 3 → guard fires, tx aborts, no movement.
+    await expect(
+      service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 5 }]), 'b4'),
+    ).rejects.toMatchObject({ code: 'INV_INSUFFICIENT_STOCK' } as Partial<InventoryError>);
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('a product without BOM releases fine with zero component consumption', async () => {
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(makeProdRepo(), stockRepo);
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 4 }]), 'b5');
+
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(result.consumedComponents).toEqual([]);
+  });
+
+  it('replays the original result for a repeated Idempotency-Key (no double consumption)', async () => {
+    const repo = makeProdRepo({
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '1', '0')]),
+    });
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+    const dto = releaseDto([{ itemId: PRODUCT_A, quantity: 1 }]);
+
+    const first = await service.createRelease(CTX, dto, 'same-key');
+    const second = await service.createRelease(CTX, dto, 'same-key');
+
+    expect(second).toBe(first);
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(repo.insertRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('M4 — numeric helpers', () => {
+  it('round3 rounds half-up at the 3rd decimal and kills FP noise', () => {
+    expect(round3(0.0035)).toBe(0.004);
+    expect(round3(0.00345)).toBe(0.003);
+    expect(round3(0.1 * 3)).toBe(0.3); // 0.30000000000000004 → 0.3
+  });
+
+  it('ceil3 always rounds up at the 3rd decimal (but not on exact values)', () => {
+    expect(ceil3(1.0001)).toBe(1.001);
+    expect(ceil3(2.5)).toBe(2.5);
+    expect(ceil3(0.1 + 0.2)).toBe(0.3); // FP noise must not bump the ceil
+  });
+});

--- a/tests/unit/inventory/m4-capacity-preview.test.ts
+++ b/tests/unit/inventory/m4-capacity-preview.test.ts
@@ -1,0 +1,235 @@
+/**
+ * RFC-0061 M4 — capacity (min over components of floor(balance / (bom.qty ×
+ * loss factor)), limiting components flagged, "sem regras" for products
+ * without BOM) and the simulator preview (DEC-13: preview-only — NEVER
+ * writes; required = ceil to 3 decimals with the loss factor).
+ */
+
+import { InventoryProductionService } from '../../../src/services/inventory/InventoryProductionService';
+import { NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import { makeItem } from './m2-helpers';
+import {
+  TENANT,
+  PRODUCT_A,
+  PRODUCT_B,
+  COMPONENT_1,
+  COMPONENT_2,
+  makeBomRow,
+  makeProdRepo,
+  makeStockRepo,
+} from './m4-helpers';
+
+describe('M4 — production capacity', () => {
+  it('possible = min over components; the limiting component(s) are flagged', async () => {
+    const repo = makeProdRepo({
+      listManufacturedProducts: jest.fn(async () => ({
+        rows: [{ id: PRODUCT_A, name: 'Produto A' }],
+        total: 1,
+      })),
+      getBomsForProducts: jest.fn(async () => [
+        makeBomRow(PRODUCT_A, COMPONENT_1, '2', '0'), // bal 10 / 2 = 5
+        makeBomRow(PRODUCT_A, COMPONENT_2, '1', '100'), // bal 8 / (1×2) = 4 ← limiting
+      ]),
+      componentBalances: jest.fn(async () => [
+        { itemId: COMPONENT_1, balance: '10' },
+        { itemId: COMPONENT_2, balance: '8' },
+      ]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.getCapacity(TENANT, 1, 20);
+
+    expect(result.total).toBe(1);
+    const row = result.items[0];
+    expect(row.hasBom).toBe(true);
+    expect(row.possible).toBe(4);
+    const c1 = row.components.find((c) => c.componentItemId === COMPONENT_1);
+    const c2 = row.components.find((c) => c.componentItemId === COMPONENT_2);
+    expect(c1).toMatchObject({ possible: 5, limiting: false, requiredPerUnit: 2 });
+    expect(c2).toMatchObject({ possible: 4, limiting: true, requiredPerUnit: 2 });
+  });
+
+  it('floors fractional capacity (balance 9, perUnit 2 → 4)', async () => {
+    const repo = makeProdRepo({
+      listManufacturedProducts: jest.fn(async () => ({
+        rows: [{ id: PRODUCT_A, name: 'Produto A' }],
+        total: 1,
+      })),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '2', '0')]),
+      componentBalances: jest.fn(async () => [{ itemId: COMPONENT_1, balance: '9' }]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.getCapacity(TENANT, 1, 20);
+    expect(result.items[0].possible).toBe(4);
+  });
+
+  it('a product without BOM comes back as "sem regras" (hasBom false, possible null)', async () => {
+    const repo = makeProdRepo({
+      listManufacturedProducts: jest.fn(async () => ({
+        rows: [
+          { id: PRODUCT_A, name: 'Produto A' },
+          { id: PRODUCT_B, name: 'Produto B' },
+        ],
+        total: 2,
+      })),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '1', '0')]),
+      componentBalances: jest.fn(async () => [{ itemId: COMPONENT_1, balance: '3' }]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.getCapacity(TENANT, 1, 20);
+
+    const b = result.items.find((r) => r.itemId === PRODUCT_B);
+    expect(b).toMatchObject({ hasBom: false, possible: null, components: [] });
+    const a = result.items.find((r) => r.itemId === PRODUCT_A);
+    expect(a).toMatchObject({ hasBom: true, possible: 3 });
+  });
+
+  it('a component with no movements counts as balance 0 → possible 0', async () => {
+    const repo = makeProdRepo({
+      listManufacturedProducts: jest.fn(async () => ({
+        rows: [{ id: PRODUCT_A, name: 'Produto A' }],
+        total: 1,
+      })),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '1', '0')]),
+      componentBalances: jest.fn(async () => []),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.getCapacity(TENANT, 1, 20);
+    expect(result.items[0].possible).toBe(0);
+    expect(result.items[0].components[0].limiting).toBe(true);
+  });
+});
+
+describe('M4 — simulator preview (DEC-13: preview-only)', () => {
+  const catalog = [
+    makeItem({ id: PRODUCT_A, name: 'Produto A', domain: 'PRODUCT', isManufactured: true }),
+    makeItem({ id: PRODUCT_B, name: 'Produto B', domain: 'PRODUCT', isManufactured: true }),
+  ];
+
+  it('computes required with the loss factor, ceil to 3 decimals, vs balance', async () => {
+    const repo = makeProdRepo({
+      findItemsByIds: jest.fn(async () => catalog),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '0.333', '10')]),
+      componentBalances: jest.fn(async () => [{ itemId: COMPONENT_1, balance: '1' }]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.previewSimulation(TENANT, {
+      items: [{ itemId: PRODUCT_A, quantity: 3 }],
+    });
+
+    // 0.333 × 3 × 1.10 = 1.0989 → ceil3 = 1.099; balance 1 → missing 0.099.
+    expect(result.components).toEqual([
+      expect.objectContaining({
+        componentItemId: COMPONENT_1,
+        required: 1.099,
+        balance: 1,
+        missing: 0.099,
+        sufficient: false,
+      }),
+    ]);
+    expect(result.feasible).toBe(false);
+    expect(result.location).toBe('FABRICA');
+  });
+
+  it('is feasible when every component is covered; products without BOM are flagged', async () => {
+    const repo = makeProdRepo({
+      findItemsByIds: jest.fn(async () => catalog),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '2', '0')]),
+      componentBalances: jest.fn(async () => [{ itemId: COMPONENT_1, balance: '100' }]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.previewSimulation(TENANT, {
+      items: [
+        { itemId: PRODUCT_A, quantity: 5 },
+        { itemId: PRODUCT_B, quantity: 1 },
+      ],
+    });
+
+    expect(result.components).toEqual([
+      expect.objectContaining({ componentItemId: COMPONENT_1, required: 10, missing: 0, sufficient: true }),
+    ]);
+    expect(result.feasible).toBe(true);
+    expect(result.products).toEqual([
+      expect.objectContaining({ itemId: PRODUCT_A, hasBom: true }),
+      expect.objectContaining({ itemId: PRODUCT_B, hasBom: false }),
+    ]);
+  });
+
+  it('NEVER writes: no movements, releases or demand updates on preview', async () => {
+    const repo = makeProdRepo({
+      findItemsByIds: jest.fn(async () => catalog),
+      getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '1', '0')]),
+      componentBalances: jest.fn(async () => [{ itemId: COMPONENT_1, balance: '0' }]),
+    });
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    await service.previewSimulation(TENANT, { items: [{ itemId: PRODUCT_A, quantity: 100 }] });
+
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(stockRepo.lockItem).not.toHaveBeenCalled();
+    expect(repo.insertRelease).not.toHaveBeenCalled();
+    expect(repo.insertReleaseItems).not.toHaveBeenCalled();
+    expect(repo.concludeDemand).not.toHaveBeenCalled();
+    expect(repo.reduceDemandQuantity).not.toHaveBeenCalled();
+    expect(repo.withTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown or non-manufactured items', async () => {
+    const service = new InventoryProductionService(
+      makeProdRepo({ findItemsByIds: jest.fn(async () => []) }),
+      makeStockRepo(),
+    );
+    await expect(
+      service.previewSimulation(TENANT, { items: [{ itemId: PRODUCT_A, quantity: 1 }] }),
+    ).rejects.toThrow(NotFoundError);
+
+    const service2 = new InventoryProductionService(
+      makeProdRepo({
+        findItemsByIds: jest.fn(async () => [makeItem({ id: PRODUCT_A, domain: 'COMPONENT' })]),
+      }),
+      makeStockRepo(),
+    );
+    await expect(
+      service2.previewSimulation(TENANT, { items: [{ itemId: PRODUCT_A, quantity: 1 }] }),
+    ).rejects.toThrow(ValidationError);
+  });
+});
+
+describe('M4 — fila de produção read model', () => {
+  it('maps grouped demand rows with the ALMOXARIFADO balance as a number', async () => {
+    const repo = makeProdRepo({
+      listPendingDemandsGrouped: jest.fn(async () => ({
+        rows: [
+          {
+            itemId: PRODUCT_A,
+            itemName: 'Produto A',
+            totalQuantity: 7,
+            demandCount: 3,
+            oldestCreatedAt: new Date('2026-01-05T00:00:00Z'),
+            almoxarifadoBalance: '2.5',
+          },
+        ],
+        total: 1,
+      })),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.listDemands(TENANT, 1, 20);
+
+    expect(result.items[0]).toEqual({
+      itemId: PRODUCT_A,
+      itemName: 'Produto A',
+      totalQuantity: 7,
+      demandCount: 3,
+      oldestCreatedAt: '2026-01-05T00:00:00.000Z',
+      almoxarifadoBalance: 2.5,
+    });
+    expect(result.totalPages).toBe(1);
+  });
+});

--- a/tests/unit/inventory/m4-contract.test.ts
+++ b/tests/unit/inventory/m4-contract.test.ts
@@ -1,0 +1,391 @@
+/**
+ * RFC-0061 M4 — wired-contract test for the REAL production routes.
+ *
+ * M4 now serves real handlers for demands / capacity / simulator preview /
+ * assembly releases / issues; POST /production/resolve-demand intentionally
+ * stays the 501 marker (P3 with M6 — A4). Auth chain and guard behavior
+ * (missing Idempotency-Key → 400, missing confirmationToken → 428) unchanged.
+ *
+ * Same harness as m2-contract.test.ts: real router + real auth middleware,
+ * auth leaves mocked — plus the M4 service mocked (no DB).
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+// Mock ONLY the service singleton — the Zod schemas the controller imports
+// from the same module must stay real.
+jest.mock('../../../src/services/inventory/InventoryProductionService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryProductionService');
+  return {
+    ...actual,
+    inventoryProductionService: {
+      listDemands: jest.fn(),
+      listReleases: jest.fn(),
+      createRelease: jest.fn(),
+      reportIssue: jest.fn(),
+      listIssues: jest.fn(),
+      resolveIssue: jest.fn(),
+      correctRelease: jest.fn(),
+      deleteRelease: jest.fn(),
+      getCapacity: jest.fn(),
+      previewSimulation: jest.fn(),
+    },
+  };
+});
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryProductionService } from '../../../src/services/inventory/InventoryProductionService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+const RELEASE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const ISSUE_ID = '66666666-6666-4666-8666-666666666666';
+const PHOTO_ID = '44444444-4444-4444-4444-444444444444';
+const USER_ID = '22222222-2222-2222-2222-222222222222';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T };
+
+const svc = inventoryProductionService as jest.Mocked<typeof inventoryProductionService>;
+
+const goodRelease = {
+  photoFileId: PHOTO_ID,
+  responsibles: [USER_ID],
+  items: [{ itemId: ITEM_ID, quantity: 3 }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M4 production routes — real contract', () => {
+  it('GET /production/demands → 200 paginated groups', async () => {
+    svc.listDemands.mockResolvedValue({
+      items: [{ itemId: ITEM_ID, itemName: 'P', totalQuantity: 5, demandCount: 2, oldestCreatedAt: null, almoxarifadoBalance: 1 }],
+      page: 1,
+      pageSize: 20,
+      total: 1,
+      totalPages: 1,
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/demands'), { headers: { 'x-api-key': 'gcdr_cust_x' } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: Array<{ totalQuantity: number }> }>;
+      expect(body.data.items[0].totalQuantity).toBe(5);
+      expect(svc.listDemands).toHaveBeenCalledWith(TENANT, 1, 20);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /production/resolve-demand → STILL 501 (P3 with M6 — A4)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/resolve-demand'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(501);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_NOT_IMPLEMENTED');
+      expect(body.error.details).toMatchObject({ module: 'M4', phase: 'P3' });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /assembly-releases with key + valid body → 201', async () => {
+    svc.createRelease.mockResolvedValue({
+      release: { id: RELEASE_ID, items: [] },
+      consumedComponents: [],
+      demandSummary: { concluded: 0, reducedPartial: 0 },
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/assembly-releases'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'rel-1' },
+        body: JSON.stringify(goodRelease),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<{ release: { id: string } }>;
+      expect(body.data.release.id).toBe(RELEASE_ID);
+      expect(svc.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        expect.objectContaining({ photoFileId: PHOTO_ID }),
+        'rel-1',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /assembly-releases without Idempotency-Key → 400 INV_IDEMPOTENCY_KEY_MISSING', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/assembly-releases'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify(goodRelease),
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(svc.createRelease).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /assembly-releases without photo/responsibles → 400, service untouched', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/assembly-releases'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'rel-2' },
+        body: JSON.stringify({ items: [{ itemId: ITEM_ID, quantity: 1 }] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.createRelease).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /assembly-releases → 200 paginated', async () => {
+    svc.listReleases.mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/assembly-releases'), { headers: { 'x-api-key': 'gcdr_cust_x' } });
+      expect(res.status).toBe(200);
+      expect(svc.listReleases).toHaveBeenCalledWith(TENANT, 1, 20);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /assembly-releases/:id/correct → 200 with adjustments', async () => {
+    svc.correctRelease.mockResolvedValue({ release: { id: RELEASE_ID }, adjustments: [], resolvedIssues: 1 } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/assembly-releases/${RELEASE_ID}/correct`), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({ items: [{ releaseItemId: ISSUE_ID, quantity: 5 }] }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ resolvedIssues: number }>;
+      expect(body.data.resolvedIssues).toBe(1);
+      expect(svc.correctRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        RELEASE_ID,
+        expect.objectContaining({ items: [{ releaseItemId: ISSUE_ID, quantity: 5 }] }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /assembly-releases/:id without confirmationToken → 428', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/assembly-releases/${RELEASE_ID}`), {
+        method: 'DELETE',
+        headers: { 'x-api-key': 'gcdr_cust_x' },
+      });
+      expect(res.status).toBe(428);
+      expect(((await res.json()) as ErrBody).error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(svc.deleteRelease).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /assembly-releases/:id with X-Confirmation-Token → 200', async () => {
+    svc.deleteRelease.mockResolvedValue({ deleted: true } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/assembly-releases/${RELEASE_ID}`), {
+        method: 'DELETE',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'x-confirmation-token': 'excluir' },
+      });
+      expect(res.status).toBe(200);
+      expect(svc.deleteRelease).toHaveBeenCalledWith(expect.objectContaining({ tenantId: TENANT }), RELEASE_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /assembly-releases/:id/issues → 201 (reported_by from context)', async () => {
+    svc.reportIssue.mockResolvedValue({ id: ISSUE_ID, status: 'ABERTA' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/assembly-releases/${RELEASE_ID}/issues`), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({ message: 'faltou 1 unidade' }),
+      });
+      expect(res.status).toBe(201);
+      expect(svc.reportIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        RELEASE_ID,
+        expect.objectContaining({ message: 'faltou 1 unidade' }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /assembly-releases/:id/issues → 200 paginated', async () => {
+    svc.listIssues.mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/assembly-releases/${RELEASE_ID}/issues`), {
+        headers: { 'x-api-key': 'gcdr_cust_x' },
+      });
+      expect(res.status).toBe(200);
+      expect(svc.listIssues).toHaveBeenCalledWith(TENANT, RELEASE_ID, 1, 20);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /issues/:id/resolve → 200', async () => {
+    svc.resolveIssue.mockResolvedValue({ id: ISSUE_ID, status: 'RESOLVIDA' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/issues/${ISSUE_ID}/resolve`), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({ resolutionNote: 'corrigido' }),
+      });
+      expect(res.status).toBe(200);
+      expect(svc.resolveIssue).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        ISSUE_ID,
+        expect.objectContaining({ resolutionNote: 'corrigido' }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /production/capacity → 200', async () => {
+    svc.getCapacity.mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/capacity'), { headers: { 'x-api-key': 'gcdr_cust_x' } });
+      expect(res.status).toBe(200);
+      expect(svc.getCapacity).toHaveBeenCalledWith(TENANT, 1, 20);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /production/simulator/preview → 200 (DEC-13 preview-only)', async () => {
+    svc.previewSimulation.mockResolvedValue({
+      location: 'FABRICA',
+      products: [],
+      components: [],
+      feasible: true,
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/simulator/preview'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({ items: [{ itemId: ITEM_ID, quantity: 2 }] }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ feasible: boolean }>;
+      expect(body.data.feasible).toBe(true);
+      expect(svc.previewSimulation).toHaveBeenCalledWith(TENANT, expect.objectContaining({ items: [{ itemId: ITEM_ID, quantity: 2 }] }));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /production/simulator/preview with a bad body → 400, service untouched', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/simulator/preview'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
+        body: JSON.stringify({ items: [] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.previewSimulation).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('service InventoryError surfaces its code through the errorHandler', async () => {
+    const { insufficientStock } = jest.requireActual<
+      typeof import('../../../src/shared/errors/InventoryError')
+    >('../../../src/shared/errors/InventoryError');
+    svc.createRelease.mockRejectedValue(insufficientStock(ITEM_ID, 'FABRICA', 1, 22));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/assembly-releases'), {
+        method: 'POST',
+        headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json', 'idempotency-key': 'rel-9' },
+        body: JSON.stringify(goodRelease),
+      });
+      expect(res.status).toBe(409);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_INSUFFICIENT_STOCK');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m4-correction.test.ts
+++ b/tests/unit/inventory/m4-correction.test.ts
@@ -1,0 +1,220 @@
+/**
+ * RFC-0061 M4 — release correction (§M4 "Divergências"): edits released
+ * quantities with a FLOOR at already-homologated units per item; positive
+ * delta → component SAIDA, negative → ENTRADA (reason "Correção de liberação
+ * de montagem", loss factor applied); resolves the release's open issues.
+ */
+
+import {
+  InventoryProductionService,
+  REASON_ASSEMBLY_CORRECTION,
+  COMPONENT_LOCATION,
+} from '../../../src/services/inventory/InventoryProductionService';
+import { ConflictError, NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  PRODUCT_A,
+  COMPONENT_1,
+  USER,
+  RELEASE_ID,
+  makeBomRow,
+  makeRelease,
+  makeProdRepo,
+  makeStockRepo,
+} from './m4-helpers';
+
+const RELEASE_ITEM_ID = '77777777-0000-4000-8000-000000000001';
+
+function repoWithRelease(overrides: Record<string, jest.Mock> = {}) {
+  return makeProdRepo({
+    getReleaseById: jest.fn(async () => ({
+      release: makeRelease(),
+      items: [{ id: RELEASE_ITEM_ID, itemId: PRODUCT_A, itemName: 'Produto A', quantity: 10 }],
+    })),
+    getBomsForProducts: jest.fn(async () => [makeBomRow(PRODUCT_A, COMPONENT_1, '2', '10')]),
+    homologatedCountsByItem: jest.fn(async () => [{ itemId: PRODUCT_A, homologatedCount: 4 }]),
+    resolveOpenIssues: jest.fn(async () => 2),
+    ...overrides,
+  });
+}
+
+describe('M4 — release correction', () => {
+  it('positive delta consumes extra components via SAIDA with the loss factor', async () => {
+    const repo = repoWithRelease();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.correctRelease(CTX, RELEASE_ID, {
+      items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 12 }],
+    });
+
+    // delta +2 → 2 × 2 × 1.10 = 4.4 SAIDA.
+    expect(repo.updateReleaseItemQuantity).toHaveBeenCalledWith(
+      CTX.tenantId,
+      RELEASE_ITEM_ID,
+      12,
+      expect.anything(),
+    );
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: COMPONENT_1,
+        quantity: '4.4',
+        type: 'SAIDA',
+        location: COMPONENT_LOCATION,
+        reason: REASON_ASSEMBLY_CORRECTION,
+      }),
+      expect.anything(),
+    );
+    expect(result.adjustments).toEqual([
+      expect.objectContaining({ componentItemId: COMPONENT_1, movementType: 'SAIDA', quantity: 4.4 }),
+    ]);
+    expect(result.resolvedIssues).toBe(2);
+  });
+
+  it('negative delta returns components via ENTRADA with the loss factor', async () => {
+    const repo = repoWithRelease();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.correctRelease(CTX, RELEASE_ID, {
+      items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 6 }],
+    });
+
+    // delta −4 → 4 × 2 × 1.10 = 8.8 back in as ENTRADA.
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: COMPONENT_1,
+        quantity: '8.8',
+        type: 'ENTRADA',
+        reason: REASON_ASSEMBLY_CORRECTION,
+      }),
+      expect.anything(),
+    );
+    expect(result.adjustments).toEqual([
+      expect.objectContaining({ componentItemId: COMPONENT_1, movementType: 'ENTRADA', quantity: 8.8 }),
+    ]);
+  });
+
+  it('rejects a quantity below the homologated floor (409, nothing written)', async () => {
+    const repo = repoWithRelease();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    // floor = 4 homologated units; 3 < 4 → conflict.
+    await expect(
+      service.correctRelease(CTX, RELEASE_ID, {
+        items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 3 }],
+      }),
+    ).rejects.toThrow(ConflictError);
+    expect(repo.updateReleaseItemQuantity).not.toHaveBeenCalled();
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(repo.resolveOpenIssues).not.toHaveBeenCalled();
+  });
+
+  it('accepts a quantity exactly at the homologated floor', async () => {
+    const repo = repoWithRelease();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.correctRelease(CTX, RELEASE_ID, {
+      items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 4 }],
+    });
+
+    // delta −6 → ENTRADA 6 × 2 × 1.10 = 13.2.
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: '13.2', type: 'ENTRADA' }),
+      expect.anything(),
+    );
+    expect(result.resolvedIssues).toBe(2);
+  });
+
+  it('an unchanged quantity writes no movement but still resolves open issues', async () => {
+    const repo = repoWithRelease();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.correctRelease(CTX, RELEASE_ID, {
+      items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 10 }],
+    });
+
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(repo.updateReleaseItemQuantity).not.toHaveBeenCalled();
+    expect(result.adjustments).toEqual([]);
+    expect(result.resolvedIssues).toBe(2);
+  });
+
+  it('rejects a releaseItemId that does not belong to the release', async () => {
+    const service = new InventoryProductionService(repoWithRelease(), makeStockRepo());
+    await expect(
+      service.correctRelease(CTX, RELEASE_ID, {
+        items: [{ releaseItemId: '99999999-9999-4999-8999-999999999999', quantity: 5 }],
+      }),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('404s for an unknown release', async () => {
+    const service = new InventoryProductionService(
+      makeProdRepo({ getReleaseById: jest.fn(async () => null) }),
+      makeStockRepo(),
+    );
+    await expect(
+      service.correctRelease(CTX, RELEASE_ID, {
+        items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 5 }],
+      }),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('passes the resolution note and the caller to resolveOpenIssues', async () => {
+    const repo = repoWithRelease();
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    await service.correctRelease(CTX, RELEASE_ID, {
+      items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 11 }],
+      resolutionNote: 'ajuste combinado com o estoque',
+    });
+
+    expect(repo.resolveOpenIssues).toHaveBeenCalledWith(
+      CTX.tenantId,
+      RELEASE_ID,
+      USER,
+      'ajuste combinado com o estoque',
+      expect.anything(),
+    );
+  });
+
+  it('correction SAIDA still respects the negative-stock guard', async () => {
+    const stockRepo = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '1', totalIn: '1', totalOut: '0', lastMovementAt: null })),
+    });
+    const service = new InventoryProductionService(repoWithRelease(), stockRepo);
+
+    await expect(
+      service.correctRelease(CTX, RELEASE_ID, {
+        items: [{ releaseItemId: RELEASE_ITEM_ID, quantity: 12 }],
+      }),
+    ).rejects.toMatchObject({ code: 'INV_INSUFFICIENT_STOCK' });
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+});
+
+describe('M4 — release delete', () => {
+  it('deletes and reports { deleted: true } (movements NOT reversed — source parity)', async () => {
+    const repo = makeProdRepo();
+    const stockRepo = makeStockRepo();
+    const service = new InventoryProductionService(repo, stockRepo);
+
+    const result = await service.deleteRelease(CTX, RELEASE_ID);
+
+    expect(result).toEqual({ deleted: true });
+    expect(repo.deleteRelease).toHaveBeenCalledWith(CTX.tenantId, RELEASE_ID);
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('404s when the release does not exist', async () => {
+    const service = new InventoryProductionService(
+      makeProdRepo({ deleteRelease: jest.fn(async () => false) }),
+      makeStockRepo(),
+    );
+    await expect(service.deleteRelease(CTX, RELEASE_ID)).rejects.toThrow(NotFoundError);
+  });
+});

--- a/tests/unit/inventory/m4-fifo.test.ts
+++ b/tests/unit/inventory/m4-fifo.test.ts
@@ -1,0 +1,124 @@
+/**
+ * RFC-0061 M4 — FIFO consumption of the production-demand queue by an
+ * assembly release (§M4): PENDENTE demands per item, created_at asc; a
+ * release concludes demands it fully covers and partial-reduces the first it
+ * cannot — all inside the release transaction.
+ */
+
+import {
+  InventoryProductionService,
+  CreateAssemblyReleaseDTO,
+} from '../../../src/services/inventory/InventoryProductionService';
+import { ValidationError, NotFoundError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  PRODUCT_A,
+  PRODUCT_B,
+  PHOTO_ID,
+  USER,
+  makeDemand,
+  makeProdRepo,
+  makeStockRepo,
+} from './m4-helpers';
+import { makeItem } from './m2-helpers';
+
+function releaseDto(items: Array<{ itemId: string; quantity: number }>): CreateAssemblyReleaseDTO {
+  return { photoFileId: PHOTO_ID, responsibles: [USER], items } as CreateAssemblyReleaseDTO;
+}
+
+describe('M4 — FIFO demand consumption on release', () => {
+  it('concludes older demands fully covered and partial-reduces the next one', async () => {
+    const d1 = makeDemand({ quantity: 3, createdAt: new Date('2026-01-01T00:00:00Z') });
+    const d2 = makeDemand({ quantity: 4, createdAt: new Date('2026-01-02T00:00:00Z') });
+    const repo = makeProdRepo({
+      lockPendingDemandsForItem: jest.fn(async () => [d1, d2]),
+    });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 5 }]), 'k1');
+
+    // 5 produced: d1 (3) concluded; d2 reduced 4 → 2, stays PENDENTE.
+    expect(repo.concludeDemand).toHaveBeenCalledTimes(1);
+    expect(repo.concludeDemand).toHaveBeenCalledWith(CTX.tenantId, d1.id, expect.anything());
+    expect(repo.reduceDemandQuantity).toHaveBeenCalledTimes(1);
+    expect(repo.reduceDemandQuantity).toHaveBeenCalledWith(CTX.tenantId, d2.id, 2, expect.anything());
+    expect(result.demandSummary).toEqual({ concluded: 1, reducedPartial: 1 });
+  });
+
+  it('concludes every demand when production exactly matches the queue', async () => {
+    const d1 = makeDemand({ quantity: 3 });
+    const d2 = makeDemand({ quantity: 4 });
+    const repo = makeProdRepo({ lockPendingDemandsForItem: jest.fn(async () => [d1, d2]) });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 7 }]), 'k2');
+
+    expect(repo.concludeDemand).toHaveBeenCalledTimes(2);
+    expect(repo.reduceDemandQuantity).not.toHaveBeenCalled();
+    expect(result.demandSummary).toEqual({ concluded: 2, reducedPartial: 0 });
+  });
+
+  it('surplus production beyond the queue concludes everything and ignores the rest', async () => {
+    const d1 = makeDemand({ quantity: 3 });
+    const repo = makeProdRepo({ lockPendingDemandsForItem: jest.fn(async () => [d1]) });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 10 }]), 'k3');
+
+    expect(repo.concludeDemand).toHaveBeenCalledTimes(1);
+    expect(repo.reduceDemandQuantity).not.toHaveBeenCalled();
+    expect(result.demandSummary).toEqual({ concluded: 1, reducedPartial: 0 });
+  });
+
+  it('an empty queue leaves the demand tables untouched', async () => {
+    const repo = makeProdRepo();
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 2 }]), 'k4');
+
+    expect(repo.concludeDemand).not.toHaveBeenCalled();
+    expect(repo.reduceDemandQuantity).not.toHaveBeenCalled();
+    expect(result.demandSummary).toEqual({ concluded: 0, reducedPartial: 0 });
+  });
+
+  it('consumes each product queue independently (two items in one release)', async () => {
+    const dA = makeDemand({ itemId: PRODUCT_A, quantity: 2 });
+    const dB = makeDemand({ itemId: PRODUCT_B, quantity: 5 });
+    const lock = jest.fn(async (_t: string, itemId: string) => (itemId === PRODUCT_A ? [dA] : [dB]));
+    const repo = makeProdRepo({ lockPendingDemandsForItem: lock });
+    const service = new InventoryProductionService(repo, makeStockRepo());
+
+    const result = await service.createRelease(
+      CTX,
+      releaseDto([
+        { itemId: PRODUCT_A, quantity: 2 },
+        { itemId: PRODUCT_B, quantity: 3 },
+      ]),
+      'k5',
+    );
+
+    expect(repo.concludeDemand).toHaveBeenCalledWith(CTX.tenantId, dA.id, expect.anything());
+    expect(repo.reduceDemandQuantity).toHaveBeenCalledWith(CTX.tenantId, dB.id, 2, expect.anything());
+    expect(result.demandSummary).toEqual({ concluded: 1, reducedPartial: 1 });
+  });
+
+  it('rejects a release item that is not a manufactured PRODUCT', async () => {
+    const stockRepo = makeStockRepo({
+      lockItem: jest.fn(async (_t: string, id: string) => makeItem({ id, domain: 'COMPONENT' })),
+    });
+    const service = new InventoryProductionService(makeProdRepo(), stockRepo);
+
+    await expect(
+      service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 1 }]), 'k6'),
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it('rejects a release for an unknown item (404)', async () => {
+    const stockRepo = makeStockRepo({ lockItem: jest.fn(async () => null) });
+    const service = new InventoryProductionService(makeProdRepo(), stockRepo);
+
+    await expect(
+      service.createRelease(CTX, releaseDto([{ itemId: PRODUCT_A, quantity: 1 }]), 'k7'),
+    ).rejects.toThrow(NotFoundError);
+  });
+});

--- a/tests/unit/inventory/m4-helpers.ts
+++ b/tests/unit/inventory/m4-helpers.ts
@@ -1,0 +1,174 @@
+// Shared fixtures/mocks for the RFC-0061 M4 unit suites (service with mocked
+// production + stock repositories — no DB). Reuses the M2 item/movement
+// factories.
+
+import type {
+  IInventoryProductionRepository,
+  IProductionStockRepository,
+} from '../../../src/services/inventory/InventoryProductionService';
+import type {
+  InvProductionDemandRow,
+  InvAssemblyReleaseRow,
+  InvAssemblyReleaseItemRow,
+  InvAssemblyReleaseIssueRow,
+  BomExplosionRow,
+  NewReleaseInput,
+  NewReleaseItemInput,
+  NewIssueInput,
+} from '../../../src/repositories/inventory/InventoryProductionRepository';
+import type { NewMovementInput } from '../../../src/repositories/inventory/InventoryStockRepository';
+import { makeItem, movementRowFrom, TENANT, USER } from './m2-helpers';
+
+export { TENANT, USER };
+export const CTX = { tenantId: TENANT, userId: USER };
+
+export const PRODUCT_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+export const PRODUCT_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+export const COMPONENT_1 = 'cccccccc-cccc-4ccc-8ccc-cccccccccc01';
+export const COMPONENT_2 = 'cccccccc-cccc-4ccc-8ccc-cccccccccc02';
+export const RELEASE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+export const PHOTO_ID = '44444444-4444-4444-4444-444444444444';
+
+let seq = 0;
+function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-0000-0000-0000-${String(seq).padStart(12, '0')}`;
+}
+
+export function makeDemand(overrides: Partial<InvProductionDemandRow> = {}): InvProductionDemandRow {
+  return {
+    id: nextId('11111111'),
+    tenantId: TENANT,
+    expeditionOrderItemId: nextId('99999999'),
+    expeditionOrderId: null,
+    itemId: PRODUCT_A,
+    quantity: 1,
+    status: 'PENDENTE',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  } as InvProductionDemandRow;
+}
+
+export function makeRelease(overrides: Partial<InvAssemblyReleaseRow> = {}): InvAssemblyReleaseRow {
+  return {
+    id: RELEASE_ID,
+    tenantId: TENANT,
+    photoFileId: PHOTO_ID,
+    responsibles: [USER],
+    notes: null,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvAssemblyReleaseRow;
+}
+
+export function makeIssue(overrides: Partial<InvAssemblyReleaseIssueRow> = {}): InvAssemblyReleaseIssueRow {
+  return {
+    id: nextId('66666666'),
+    tenantId: TENANT,
+    releaseId: RELEASE_ID,
+    releaseItemId: null,
+    itemId: null,
+    reportedQuantity: null,
+    message: 'divergência',
+    status: 'ABERTA',
+    resolutionNote: null,
+    reportedBy: USER,
+    resolvedBy: null,
+    resolvedAt: null,
+    createdAt: new Date('2026-02-02T00:00:00Z'),
+    ...overrides,
+  } as InvAssemblyReleaseIssueRow;
+}
+
+export function makeBomRow(
+  productItemId: string,
+  componentItemId: string,
+  quantity: string,
+  lossPercent: string,
+  componentName = `component ${componentItemId.slice(-2)}`,
+): BomExplosionRow {
+  return { productItemId, componentItemId, componentName, quantity, lossPercent };
+}
+
+export type MockProdRepo = jest.Mocked<IInventoryProductionRepository>;
+export type MockStockRepo = jest.Mocked<IProductionStockRepository>;
+
+/** Production repo mock: withTransaction just runs the callback. */
+export function makeProdRepo(overrides: Record<string, jest.Mock> = {}): MockProdRepo {
+  const repo = {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    listPendingDemandsGrouped: jest.fn(async () => ({ rows: [], total: 0 })),
+    lockPendingDemandsForItem: jest.fn(async () => [] as InvProductionDemandRow[]),
+    concludeDemand: jest.fn(async () => undefined),
+    reduceDemandQuantity: jest.fn(async () => undefined),
+    insertRelease: jest.fn(async (input: NewReleaseInput) =>
+      makeRelease({
+        photoFileId: input.photoFileId,
+        responsibles: input.responsibles,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+      }),
+    ),
+    insertReleaseItems: jest.fn(async (inputs: NewReleaseItemInput[]) =>
+      inputs.map(
+        (i) =>
+          ({
+            id: nextId('77777777'),
+            tenantId: i.tenantId,
+            releaseId: i.releaseId,
+            itemId: i.itemId,
+            quantity: i.quantity,
+          }) as InvAssemblyReleaseItemRow,
+      ),
+    ),
+    listReleases: jest.fn(async () => ({ rows: [], total: 0 })),
+    listReleaseItems: jest.fn(async () => []),
+    getReleaseById: jest.fn(async () => null),
+    updateReleaseItemQuantity: jest.fn(async () => undefined),
+    deleteRelease: jest.fn(async () => true),
+    homologatedCountsByItem: jest.fn(async () => []),
+    insertIssue: jest.fn(async (input: NewIssueInput) =>
+      makeIssue({
+        releaseId: input.releaseId,
+        releaseItemId: input.releaseItemId ?? null,
+        itemId: input.itemId ?? null,
+        reportedQuantity: input.reportedQuantity ?? null,
+        message: input.message ?? null,
+        reportedBy: input.reportedBy ?? null,
+      }),
+    ),
+    listIssues: jest.fn(async () => ({ rows: [], total: 0 })),
+    getIssueById: jest.fn(async () => null),
+    resolveIssue: jest.fn(async () => makeIssue({ status: 'RESOLVIDA', resolvedBy: USER, resolvedAt: new Date() })),
+    resolveOpenIssues: jest.fn(async () => 0),
+    getBomsForProducts: jest.fn(async () => [] as BomExplosionRow[]),
+    listManufacturedProducts: jest.fn(async () => ({ rows: [], total: 0 })),
+    findItemsByIds: jest.fn(async () => []),
+    componentBalances: jest.fn(async () => []),
+  } as unknown as MockProdRepo;
+  return Object.assign(repo, overrides);
+}
+
+/**
+ * Stock repo mock (the M2 seam composed inside the release tx). By default
+ * every id resolves to a MANUFACTURED PRODUCT when it matches PRODUCT_*, and
+ * to a plain COMPONENT otherwise; balances are effectively unlimited.
+ */
+export function makeStockRepo(overrides: Record<string, jest.Mock> = {}): MockStockRepo {
+  const repo = {
+    lockItem: jest.fn(async (_tenant: string, itemId: string) =>
+      itemId === PRODUCT_A || itemId === PRODUCT_B
+        ? makeItem({ id: itemId, name: `Produto ${itemId.slice(-2)}`, domain: 'PRODUCT', isManufactured: true })
+        : makeItem({ id: itemId, name: `Componente ${itemId.slice(-2)}`, domain: 'COMPONENT' }),
+    ),
+    getBalance: jest.fn(async () => ({
+      balance: '1000000',
+      totalIn: '1000000',
+      totalOut: '0',
+      lastMovementAt: null,
+    })),
+    insertMovement: jest.fn(async (input: NewMovementInput) => movementRowFrom(input)),
+  } as unknown as MockStockRepo;
+  return Object.assign(repo, overrides);
+}


### PR DESCRIPTION
## RFC-0061 M4 — Produção (P2)

Implements §M4 on top of the M1/M2/M9 base. **Demand resolution stays the 501 marker** (`POST /production/resolve-demand`) — it ships in P3 with M6 (A4).

### Endpoints (all real now, except resolve-demand)

| Route | Behavior |
|---|---|
| `GET /production/demands` | PENDENTE demands grouped by product (item FK — DEC-5; names are case-insensitively unique via `normalized_name`), summed quantities, derived **ALMOXARIFADO** ("Estoque Myio") balance side-by-side; paginated |
| `POST /assembly-releases` | `Idempotency-Key` required; `photoFileId` + `responsibles[]` + manufactured `PRODUCT` items with `quantity > 0`; ONE transaction (see below) |
| `GET /assembly-releases` | paginated, newest first, items joined with catalog names |
| `POST /assembly-releases/:id/issues` / `GET .../issues` | report divergence (`ABERTA`, `reported_by` = caller) / paginated list |
| `POST /issues/:id/resolve` | `resolution_note` + `resolved_by/at`; resolving twice → 409 `INV_ALREADY_IN_STATE` |
| `POST /assembly-releases/:id/correct` | **floor = already-homologated units per item** (reads `inv_homologations`/`inv_homologation_units` only); net signed component delta with loss factor → `SAIDA` / `ENTRADA` (reason "Correção de liberação de montagem"); resolves open issues |
| `DELETE /assembly-releases/:id` | `confirmationToken` (428 without); schema **cascades** remove items, issues and the release's homologations (+units); **movements are NOT reversed** — source parity, an explicit audited `AJUSTE` is the correction path |
| `GET /production/capacity` | per product with BOM: `possible = min(floor(balance / (bom.qty × (1+loss/100))))`, limiting components flagged; product without BOM → `hasBom:false, possible:null` ("sem regras") |
| `POST /production/simulator/preview` | **DEC-13 preview-only**: required = `ceil` to 3 decimals with loss factor vs balance — zero writes (asserted by test) |
| `POST /production/resolve-demand` | unchanged 501 `INV_NOT_IMPLEMENTED { module: M4, phase: P3 }` |

### Release transaction (§M4)

1. Lock + validate products (`FOR UPDATE`, manufactured PRODUCT only; deterministic id order).
2. Insert release + items.
3. **FIFO** demand consumption per item: `PENDENTE`, `created_at asc`, locked `FOR UPDATE`; fully covered → `CONCLUIDO`, first uncovered → partial quantity reduce (stays `PENDENTE`).
4. **BOM explosion**: Σ `bom.quantity × produced × (1 + component.loss_percent/100)` per component, summed across products **then** rounded to 3 decimals (ledger grain), one `SAIDA` per component from **FABRICA**, reason "Consumo de montagem", release photo attached (satisfies the W4 exit matrix for components), under the M2 negative-stock guard (`INV_INSUFFICIENT_STOCK` aborts everything).

### Design notes / trade-offs

- **M2 composition**: `InventoryStockService.createMovement` opens its own transaction, so it cannot join the release tx. The M2 **repository** seam was built for composition ("every mutating method accepts an optional executor"), so the M4 service drives `inventoryStockRepository.lockItem/getBalance/insertMovement` with the release transaction's executor and re-applies the guard sequence itself. Release + demand queue + consumption commit or roll back atomically — the release only exists if every consumption succeeded.
- **Component location = FABRICA**: assembly consumes factory-floor stock; homologation (M5) later writes finished goods `ENTRADA` into ALMOXARIFADO. Capacity/simulator read FABRICA component balances for the same reason; the demand queue shows the ALMOXARIFADO product balance per §M4.
- **M4 DTOs live in the service module** (`src/dto` is frozen by the module-boundary rule for this PR; the RFC allows later phases to finalize DTOs at implementation time). Follow-up: fold them into `src/dto/request/InventoryDTO.ts` in a consolidating PR.
- **Idempotency**: same best-effort per-process cache as M2 (`inv_idempotency_keys` durable storage remains the standing follow-up from the M2 PR).
- Numeric hygiene: micro-integer (1e-6) accumulation before the 3-decimal round/ceil — no FP drift in explosion, correction deltas, capacity floors.
- `tests/unit/controllers/inventory.contract.test.ts` untouched — it has **no M4 cases**, so nothing was superseded; the wired M4 contract lives in `m4-contract.test.ts`.

### Tests (all mocked-repo, no DB)

- `m4-fifo.test.ts` — conclusion, exact match, surplus, partial reduce, multi-product queues, item validation.
- `m4-bom-explosion.test.ts` — loss factor, 3-decimal rounding, cross-product aggregation into one movement, insufficient-stock abort, idempotent replay, `round3`/`ceil3` edge cases.
- `m4-correction.test.ts` — homologated floor (409 below, OK at floor), +delta `SAIDA` / −delta `ENTRADA` with loss, issue resolution, guard on correction, delete semantics.
- `m4-capacity-preview.test.ts` — min/floor, limiting flags, "sem regras", zero-balance components, preview math and **no-write assertion**, demand read model.
- `m4-contract.test.ts` — real router + real auth chain (mocked leaves) + mocked service: 201/200 paths, Idempotency-Key 400, confirmation 428, resolve-demand still 501, error-code passthrough.

### Status

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` on all new/edited files — clean (repo-wide lint has 4 pre-existing errors in legacy files untouched here: `monitor-admin.controller.ts`, `middleware/context.ts`, `middleware/requestMonitor.ts`)
- `jest tests/unit/inventory` — **16 suites / 167 tests green** (5 new M4 suites)

### Follow-ups

- Move M4 Zod schemas into `src/dto/request/InventoryDTO.ts` (consolidating PR).
- Durable `inv_idempotency_keys` (inherited M2 follow-up) — release creation would benefit most.
- RBAC seed for `role:inventory-factory` scoping of these routes (RFC §RBAC, separate deliverable).
- P3: demand resolution (`resolve-demand`) with M6 expedition orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvWKPT4KpwdZYVNVAis2qK
