### PR TITLE
feat(inventory): M5 homologation & QR (P2)

### DIFF
--- a/src/controllers/inventory/homologation.controller.ts
+++ b/src/controllers/inventory/homologation.controller.ts
@@ -1,17 +1,118 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { defer, requireUuid, requireIdempotencyKey } from './shared';
 import { QrValidateSchema } from '../../dto/request/InventoryDTO';
+import {
+  inventoryHomologationService,
+  CreateHomologationSchema,
+  AddUnitToBoxSchema,
+  HomologationListQuerySchema,
+} from '../../services/inventory/InventoryHomologationService';
+import { inventoryQrService } from '../../services/inventory/InventoryQrService';
+import { sendSuccess, sendCreated } from '../../middleware/response';
 
-// M5 — Homologação & QR (P2)
+// M5 — Homologação & QR (P2). Real routes (RFC-0061 §M5):
+// homologations create QR identities in inv_qr_registry (A2 — global cross
+// box×unit uniqueness) and finish with an ENTRADA into ALMOXARIFADO; box ops
+// re-shuffle units between boxes; /qr/validate (S2) gives per-code verdicts
+// for handheld scanners; /qr/trace/:code (S5) returns the current-state
+// header + normalized timeline. POST /qr/generate stays deferred: it
+// delegates QR generation to the external platform, whose client ships with
+// M8 (P4) — v1 keeps external-only generation (source parity).
 const router = Router();
 
-router.get('/homologations', defer('M5', 'P2'));
-router.post('/homologations', defer('M5', 'P2', (req) => { requireIdempotencyKey(req); }));
-router.get('/homologations/boxes', defer('M5', 'P2'));
-router.post('/homologations/boxes/:id/add-unit', defer('M5', 'P2', (req) => { requireUuid('id', req.params.id); }));
-router.post('/homologations/units/:id/remove-from-box', defer('M5', 'P2', (req) => { requireUuid('id', req.params.id); }));
-router.post('/qr/generate', defer('M5', 'P2'));
-router.get('/qr/trace/:code', defer('M5', 'P2'));
-router.post('/qr/validate', defer('M5', 'P2', (req) => { QrValidateSchema.parse(req.body ?? {}); }));
+// GET /homologations — paginated listing (optional itemId/releaseId filters).
+router.get('/homologations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = HomologationListQuerySchema.parse(req.query);
+    const data = await inventoryHomologationService.listHomologations(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /homologations — homologate units (unitário or caixa de N). Creates
+// stock (ENTRADA into ALMOXARIFADO), so the Idempotency-Key is required (S1).
+router.post('/homologations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateHomologationSchema.parse(req.body ?? {});
+    const data = await inventoryHomologationService.createHomologation({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /homologations/boxes — paginated box listing with fill state.
+router.get('/homologations/boxes', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = HomologationListQuerySchema.parse(req.query);
+    const data = await inventoryHomologationService.listBoxes(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /homologations/boxes/:id/add-unit — move a homologated unit into an
+// incomplete box of the same material (no ledger movement — same location).
+router.post('/homologations/boxes/:id/add-unit', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = AddUnitToBoxSchema.parse(req.body ?? {});
+    const data = await inventoryHomologationService.addUnitToBox({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /homologations/units/:id/remove-from-box — the unit becomes its own
+// box_size=1 homologation; an emptied box is deleted.
+router.post('/homologations/units/:id/remove-from-box', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const data = await inventoryHomologationService.removeFromBox({ tenantId, userId }, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /qr/generate — delegates to the external platform (M8 client, P4).
+// v1 keeps generation external-only (source parity — RFC Unresolved q. 3).
+router.post('/qr/generate', defer('M5 /qr/generate (external platform client — M8)', 'P4'));
+
+// GET /qr/trace/:code — S5 traceability. `:code` accepts the bare code or the
+// URL-encoded full https://produto.myio.com.br/<code> URL.
+router.get('/qr/trace/:code', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const raw = decodeURIComponent(req.params.code ?? '');
+    const data = await inventoryQrService.trace(tenantId, raw);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /qr/validate — S2 per-beep batch validation; 200 with one verdict per
+// code, never failing the batch as a whole.
+router.post('/qr/validate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const dto = QrValidateSchema.parse(req.body ?? {});
+    const data = await inventoryQrService.validate(tenantId, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryHomologationRepository.ts
+++ b/src/repositories/inventory/InventoryHomologationRepository.ts
@@ -1,0 +1,509 @@
+// =============================================================================
+// RFC-0061 M5 — Homologation & QR repository (data access only).
+//
+// Owns `inv_homologations`, `inv_homologation_units` and `inv_qr_registry`
+// (A2 — the single QR identity source: every QR value, unit or box, is
+// inserted here once per tenant; the UNIQUE index gives cross box×unit
+// duplicate detection by constraint). Also provides the read paths the QR
+// services need over `inv_assembly_release_items` (remaining-to-homologate),
+// `inv_movement_qrs` + `inv_stock_movements` (ledger events per QR),
+// `inv_delivery_qrs` + `inv_item_deliveries` + `inv_expedition_orders`
+// (expedition baixas — S5 trace) and `inv_expedition_order_items` (validate
+// context resolution). All reads are tenant-scoped; every mutating method
+// accepts an optional executor so the service composes them inside ONE
+// transaction (same conventions as InventoryStockRepository).
+// =============================================================================
+
+import { and, asc, desc, eq, gt, inArray, like, or, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+
+const {
+  invItems,
+  invQrRegistry,
+  invHomologations,
+  invHomologationUnits,
+  invAssemblyReleaseItems,
+  invMovementQrs,
+  invStockMovements,
+  invDeliveryQrs,
+  invItemDeliveries,
+  invExpeditionOrders,
+  invExpeditionOrderItems,
+} = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as InventoryStockRepository)
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type HomologTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type HomologDbClient = typeof db | HomologTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvItemRow = typeof invItems.$inferSelect;
+export type InvQrRegistryRow = typeof invQrRegistry.$inferSelect;
+export type InvHomologationRow = typeof invHomologations.$inferSelect;
+export type InvHomologationUnitRow = typeof invHomologationUnits.$inferSelect;
+
+export interface NewHomologationInput {
+  tenantId: string;
+  itemId: string;
+  releaseId?: string | null;
+  boxSize: number;
+  boxQr?: string | null;
+  responsibleId?: string | null;
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewUnitInput {
+  qrValue: string;
+  position?: number | null;
+}
+
+export interface NewRegistryInput {
+  qrValue: string;
+  kind: 'UNIT' | 'BOX';
+  itemId?: string | null;
+  createdBy?: string | null;
+}
+
+export interface HomologationListFilters {
+  itemId?: string;
+  releaseId?: string;
+  boxesOnly?: boolean;
+}
+
+/** One inv_movement_qrs link joined with its ledger movement (trace/validate). */
+export interface QrMovementEventRow {
+  qrValue: string | null;
+  boxQr: string | null;
+  movementId: string;
+  type: string;
+  location: string;
+  quantity: string;
+  reason: string | null;
+  responsible: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+}
+
+/** One inv_delivery_qrs link joined with its delivery (+ expedition order). */
+export interface QrDeliveryEventRow {
+  qrValue: string | null;
+  boxQr: string | null;
+  deliveryId: string;
+  orderItemId: string;
+  orderId: string | null;
+  orderTitle: string | null;
+  orderStatus: string | null;
+  createdBy: string | null;
+  createdAt: Date | null;
+}
+
+/** Homologation unit joined with its homologation (validate/trace lookups). */
+export interface UnitWithHomologationRow {
+  unit: InvHomologationUnitRow;
+  homologation: InvHomologationRow;
+}
+
+export class InventoryHomologationRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  async withTransaction<T>(fn: (tx: HomologTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Catalog / releases (read-only helpers)
+  // ---------------------------------------------------------------------------
+
+  async getItem(tenantId: string, itemId: string, client: HomologDbClient = db): Promise<InvItemRow | null> {
+    const [row] = await client
+      .select()
+      .from(invItems)
+      .where(and(eq(invItems.tenantId, tenantId), eq(invItems.id, itemId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /**
+   * Total quantity released for (release, item) in inv_assembly_release_items.
+   * `null` when the release has no row for the item (caller decides the error).
+   */
+  async releasedQuantity(
+    tenantId: string,
+    releaseId: string,
+    itemId: string,
+    client: HomologDbClient = db,
+  ): Promise<number | null> {
+    const [row] = await client
+      .select({ total: sql<string | null>`sum(${invAssemblyReleaseItems.quantity})::text` })
+      .from(invAssemblyReleaseItems)
+      .where(
+        and(
+          eq(invAssemblyReleaseItems.tenantId, tenantId),
+          eq(invAssemblyReleaseItems.releaseId, releaseId),
+          eq(invAssemblyReleaseItems.itemId, itemId),
+        ),
+      );
+    return row?.total === null || row?.total === undefined ? null : Number(row.total);
+  }
+
+  /** Units already homologated against (release, item) — remaining accounting. */
+  async homologatedCount(
+    tenantId: string,
+    releaseId: string,
+    itemId: string,
+    client: HomologDbClient = db,
+  ): Promise<number> {
+    const [row] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invHomologationUnits)
+      .innerJoin(invHomologations, eq(invHomologations.id, invHomologationUnits.homologationId))
+      .where(
+        and(
+          eq(invHomologations.tenantId, tenantId),
+          eq(invHomologations.releaseId, releaseId),
+          eq(invHomologations.itemId, itemId),
+        ),
+      );
+    return row?.total ?? 0;
+  }
+
+  /** Resolve an expedition-order item (validate context: orderItemId → itemId). */
+  async getExpeditionOrderItem(
+    tenantId: string,
+    orderItemId: string,
+    client: HomologDbClient = db,
+  ): Promise<{ id: string; itemId: string; orderId: string } | null> {
+    const [row] = await client
+      .select({
+        id: invExpeditionOrderItems.id,
+        itemId: invExpeditionOrderItems.itemId,
+        orderId: invExpeditionOrderItems.orderId,
+      })
+      .from(invExpeditionOrderItems)
+      .where(and(eq(invExpeditionOrderItems.tenantId, tenantId), eq(invExpeditionOrderItems.id, orderItemId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // QR registry (A2)
+  // ---------------------------------------------------------------------------
+
+  async findRegistryByValues(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<InvQrRegistryRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select()
+      .from(invQrRegistry)
+      .where(and(eq(invQrRegistry.tenantId, tenantId), inArray(invQrRegistry.qrValue, values)));
+  }
+
+  async insertRegistryRows(
+    tenantId: string,
+    rows: NewRegistryInput[],
+    client: HomologDbClient = db,
+  ): Promise<InvQrRegistryRow[]> {
+    if (rows.length === 0) return [];
+    return client
+      .insert(invQrRegistry)
+      .values(
+        rows.map((r) => ({
+          tenantId,
+          qrValue: r.qrValue,
+          kind: r.kind,
+          itemId: r.itemId ?? null,
+          createdBy: r.createdBy ?? null,
+        })),
+      )
+      .returning();
+  }
+
+  /** Remove registry rows (e.g. an emptied box's QR ceases to exist). */
+  async deleteRegistryByValues(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<number> {
+    if (values.length === 0) return 0;
+    const rows = await client
+      .delete(invQrRegistry)
+      .where(and(eq(invQrRegistry.tenantId, tenantId), inArray(invQrRegistry.qrValue, values)))
+      .returning({ id: invQrRegistry.id });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Homologations & units
+  // ---------------------------------------------------------------------------
+
+  async insertHomologation(input: NewHomologationInput, client: HomologDbClient = db): Promise<InvHomologationRow> {
+    const [row] = await client
+      .insert(invHomologations)
+      .values({
+        tenantId: input.tenantId,
+        itemId: input.itemId,
+        releaseId: input.releaseId ?? null,
+        boxSize: input.boxSize,
+        boxQr: input.boxQr ?? null,
+        responsibleId: input.responsibleId ?? null,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async insertUnits(
+    tenantId: string,
+    homologationId: string,
+    units: NewUnitInput[],
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationUnitRow[]> {
+    if (units.length === 0) return [];
+    return client
+      .insert(invHomologationUnits)
+      .values(
+        units.map((u, i) => ({
+          tenantId,
+          homologationId,
+          qrValue: u.qrValue,
+          position: u.position ?? i + 1,
+        })),
+      )
+      .returning();
+  }
+
+  async getHomologationById(
+    tenantId: string,
+    id: string,
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationRow | null> {
+    const [row] = await client
+      .select()
+      .from(invHomologations)
+      .where(and(eq(invHomologations.tenantId, tenantId), eq(invHomologations.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async getUnitById(
+    tenantId: string,
+    id: string,
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationUnitRow | null> {
+    const [row] = await client
+      .select()
+      .from(invHomologationUnits)
+      .where(and(eq(invHomologationUnits.tenantId, tenantId), eq(invHomologationUnits.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async countUnits(homologationId: string, client: HomologDbClient = db): Promise<number> {
+    const [row] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invHomologationUnits)
+      .where(eq(invHomologationUnits.homologationId, homologationId));
+    return row?.total ?? 0;
+  }
+
+  async unitsByHomologationIds(
+    tenantId: string,
+    ids: string[],
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationUnitRow[]> {
+    if (ids.length === 0) return [];
+    return client
+      .select()
+      .from(invHomologationUnits)
+      .where(and(eq(invHomologationUnits.tenantId, tenantId), inArray(invHomologationUnits.homologationId, ids)))
+      .orderBy(asc(invHomologationUnits.position), asc(invHomologationUnits.createdAt));
+  }
+
+  /** Move a unit into another homologation (box ops). */
+  async moveUnit(
+    tenantId: string,
+    unitId: string,
+    newHomologationId: string,
+    position: number | null,
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationUnitRow | null> {
+    const [row] = await client
+      .update(invHomologationUnits)
+      .set({ homologationId: newHomologationId, position })
+      .where(and(eq(invHomologationUnits.tenantId, tenantId), eq(invHomologationUnits.id, unitId)))
+      .returning();
+    return row ?? null;
+  }
+
+  async deleteHomologation(tenantId: string, id: string, client: HomologDbClient = db): Promise<number> {
+    const rows = await client
+      .delete(invHomologations)
+      .where(and(eq(invHomologations.tenantId, tenantId), eq(invHomologations.id, id)))
+      .returning({ id: invHomologations.id });
+    return rows.length;
+  }
+
+  /** Paginated homologation listing (newest first). */
+  async list(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    filters: HomologationListFilters = {},
+    client: HomologDbClient = db,
+  ): Promise<{ rows: InvHomologationRow[]; total: number }> {
+    const conditions: (SQL | undefined)[] = [eq(invHomologations.tenantId, tenantId)];
+    if (filters.itemId) conditions.push(eq(invHomologations.itemId, filters.itemId));
+    if (filters.releaseId) conditions.push(eq(invHomologations.releaseId, filters.releaseId));
+    if (filters.boxesOnly) conditions.push(gt(invHomologations.boxSize, 1));
+    const where = and(...conditions);
+
+    const rows = await client
+      .select()
+      .from(invHomologations)
+      .where(where)
+      .orderBy(desc(invHomologations.createdAt), desc(invHomologations.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invHomologations)
+      .where(where);
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  /**
+   * Highest existing sequence for the auto-generated box-QR convention
+   * `<prefix><seq>` (sequential per box-size prefix — §M5). Parsed in JS so a
+   * foreign value under the prefix never breaks the query.
+   */
+  async maxBoxSeq(tenantId: string, prefix: string, client: HomologDbClient = db): Promise<number> {
+    const rows = await client
+      .select({ boxQr: invHomologations.boxQr })
+      .from(invHomologations)
+      .where(and(eq(invHomologations.tenantId, tenantId), like(invHomologations.boxQr, `${prefix}%`)));
+    let max = 0;
+    for (const row of rows) {
+      const tail = row.boxQr?.slice(prefix.length) ?? '';
+      if (/^\d+$/.test(tail)) max = Math.max(max, Number(tail));
+    }
+    return max;
+  }
+
+  // ---------------------------------------------------------------------------
+  // QR lookups (validate S2 / trace S5)
+  // ---------------------------------------------------------------------------
+
+  /** Homologation units matching any of the candidate QR spellings. */
+  async findUnitsByQrValues(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<UnitWithHomologationRow[]> {
+    if (values.length === 0) return [];
+    const rows = await client
+      .select({ unit: invHomologationUnits, homologation: invHomologations })
+      .from(invHomologationUnits)
+      .innerJoin(invHomologations, eq(invHomologations.id, invHomologationUnits.homologationId))
+      .where(and(eq(invHomologationUnits.tenantId, tenantId), inArray(invHomologationUnits.qrValue, values)));
+    return rows;
+  }
+
+  /** Box homologations matching any of the candidate box-QR spellings. */
+  async findBoxesByQrValues(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<InvHomologationRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select()
+      .from(invHomologations)
+      .where(and(eq(invHomologations.tenantId, tenantId), inArray(invHomologations.boxQr, values)));
+  }
+
+  /**
+   * Ledger events linked to any of the QR values — matched on the unit value
+   * (`qr_value`) OR the box value (`box_qr`), oldest first (S5 timeline).
+   */
+  async movementEventsByQrs(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<QrMovementEventRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select({
+        qrValue: invMovementQrs.qrValue,
+        boxQr: invMovementQrs.boxQr,
+        movementId: invStockMovements.id,
+        type: invStockMovements.type,
+        location: invStockMovements.location,
+        quantity: invStockMovements.quantity,
+        reason: invStockMovements.reason,
+        responsible: invStockMovements.responsible,
+        createdBy: invStockMovements.createdBy,
+        createdAt: invStockMovements.createdAt,
+      })
+      .from(invMovementQrs)
+      .innerJoin(invStockMovements, eq(invStockMovements.id, invMovementQrs.movementId))
+      .where(
+        and(
+          eq(invMovementQrs.tenantId, tenantId),
+          or(inArray(invMovementQrs.qrValue, values), inArray(invMovementQrs.boxQr, values)),
+        ),
+      )
+      .orderBy(asc(invStockMovements.createdAt), asc(invStockMovements.id));
+  }
+
+  /**
+   * Expedition baixas linked to any of the QR values (unit or box spelling),
+   * joined with the delivery and its order. Absent rows are normal (M6 is a
+   * later phase) — callers must treat an empty result as "no baixa yet".
+   */
+  async deliveryEventsByQrs(
+    tenantId: string,
+    values: string[],
+    client: HomologDbClient = db,
+  ): Promise<QrDeliveryEventRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select({
+        qrValue: invDeliveryQrs.qrValue,
+        boxQr: invDeliveryQrs.boxQr,
+        deliveryId: invDeliveryQrs.deliveryId,
+        orderItemId: invDeliveryQrs.orderItemId,
+        orderId: invItemDeliveries.orderId,
+        orderTitle: invExpeditionOrders.title,
+        orderStatus: invExpeditionOrders.status,
+        createdBy: invItemDeliveries.createdBy,
+        createdAt: invItemDeliveries.createdAt,
+      })
+      .from(invDeliveryQrs)
+      .innerJoin(invItemDeliveries, eq(invItemDeliveries.id, invDeliveryQrs.deliveryId))
+      .leftJoin(invExpeditionOrders, eq(invExpeditionOrders.id, invItemDeliveries.orderId))
+      .where(
+        and(
+          eq(invDeliveryQrs.tenantId, tenantId),
+          or(inArray(invDeliveryQrs.qrValue, values), inArray(invDeliveryQrs.boxQr, values)),
+        ),
+      )
+      .orderBy(asc(invItemDeliveries.createdAt), asc(invItemDeliveries.id));
+  }
+}
+
+export const inventoryHomologationRepository = new InventoryHomologationRepository();

--- a/src/services/inventory/InventoryHomologationService.ts
+++ b/src/services/inventory/InventoryHomologationService.ts
@@ -1,0 +1,587 @@
+// =============================================================================
+// RFC-0061 M5 — Homologation service (business rules).
+//
+// §M5 rules ported from the source:
+//   - box_size ∈ {1,10,50,100,224}; a box (box_size > 1) always carries a box
+//     QR — auto-generated sequentially per size prefix when not sent
+//     (`https://produto.myio.com.br/caixa-<N>/<seq>`);
+//   - GLOBAL duplicate detection across box + unit QRs via inv_qr_registry
+//     (A2): a friendly transactional pre-check plus the 23505 backstop
+//     (SQLSTATE lives on `err.cause` — Drizzle wraps the driver error);
+//   - remaining-to-homologate accounting per (release, item): homologating
+//     above the remainder → 422;
+//   - finishing a homologation writes the ENTRADA movement into ALMOXARIFADO
+//     via InventoryStockService (reason "Homologação — unitário|caixa de N").
+//     NOTE: the entry runs in the stock service's own transaction AFTER the
+//     homologation transaction commits (M2 owns the ledger boundary) — see
+//     the PR follow-up about a shared-transaction seam.
+//   - box ops: add-unit (same-material incomplete box; INV_BOX_FULL /
+//     INV_QR_WRONG_ITEM), remove-from-box (unit becomes a box_size=1
+//     homologation; an emptied box is deleted along with its box-QR identity).
+//
+// M5 request DTOs live here (RFC §API conventions: "later phases may finalize
+// DTOs at implementation time") so this module ships without touching the
+// frozen P0/P1 DTO files.
+// =============================================================================
+
+import { z } from 'zod';
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+  HomologDbClient,
+  InvHomologationRow,
+  InvHomologationUnitRow,
+  NewUnitInput,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import { InventoryStockService, inventoryStockService } from './InventoryStockService';
+import { AppError, ConflictError, NotFoundError, ValidationError } from '../../shared/errors/AppError';
+import { InventoryError, qrDuplicate, qrWrongItem } from '../../shared/errors/InventoryError';
+import { INV_BOX_SIZES } from '../../domain/entities/Inventory';
+import type { InvPaginatedResponse } from '../../dto/response/InventoryResponseDTO';
+import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+
+// -----------------------------------------------------------------------------
+// M5 request DTOs
+// -----------------------------------------------------------------------------
+
+const uuid = z.string().uuid();
+
+export const CreateHomologationSchema = z
+  .object({
+    itemId: uuid,
+    releaseId: uuid.optional(),
+    boxSize: z
+      .number()
+      .int()
+      .refine((v) => (INV_BOX_SIZES as readonly number[]).includes(v), {
+        message: `boxSize must be one of ${INV_BOX_SIZES.join(', ')}`,
+      }),
+    boxQr: z.string().min(1).max(512).optional(),
+    responsibleId: uuid.optional(),
+    notes: z.string().max(4096).optional(),
+    units: z
+      .array(
+        z
+          .object({
+            qrValue: z.string().min(1).max(512),
+            position: z.number().int().min(1).optional(),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(224),
+  })
+  .strict();
+export type CreateHomologationDTO = z.infer<typeof CreateHomologationSchema>;
+
+export const AddUnitToBoxSchema = z.object({ unitId: uuid }).strict();
+export type AddUnitToBoxDTO = z.infer<typeof AddUnitToBoxSchema>;
+
+export const HomologationListQuerySchema = PaginationQuerySchema.extend({
+  itemId: uuid.optional(),
+  releaseId: uuid.optional(),
+});
+export type HomologationListQuery = z.infer<typeof HomologationListQuerySchema>;
+
+// -----------------------------------------------------------------------------
+// Response shapes (M5 — finalized at implementation time, §API conventions)
+// -----------------------------------------------------------------------------
+
+export interface InvHomologationUnitResponse {
+  id: string;
+  qrValue: string;
+  position: number | null;
+}
+
+export interface InvHomologationResponse {
+  id: string;
+  itemId: string;
+  releaseId: string | null;
+  boxSize: number;
+  boxQr: string | null;
+  responsibleId: string | null;
+  notes: string | null;
+  createdAt: string;
+  createdBy: string | null;
+  units: InvHomologationUnitResponse[];
+  /** Ledger entry written on creation (absent on plain reads). */
+  movementId?: string;
+}
+
+export interface InvBoxResponse extends InvHomologationResponse {
+  unitCount: number;
+  isFull: boolean;
+}
+
+export interface InvRemoveFromBoxResponse {
+  unit: InvHomologationUnitResponse;
+  homologation: InvHomologationResponse;
+  /** True when the source box was emptied and therefore deleted. */
+  boxDeleted: boolean;
+}
+
+/** Caller identity from `req.context`. */
+export interface HomologationContext {
+  tenantId: string;
+  userId?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Constants & seams
+// -----------------------------------------------------------------------------
+
+/** QR base URL kept from the source (§M5 — "QR formats kept"). */
+export const QR_BASE_URL = 'https://produto.myio.com.br/';
+
+/** Auto box-QR convention: `<base>caixa-<boxSize>/<seq>` (sequential per prefix). */
+export function boxQrPrefix(boxSize: number): string {
+  return `${QR_BASE_URL}caixa-${boxSize}/`;
+}
+
+export type IInventoryHomologationRepository = Pick<
+  InventoryHomologationRepository,
+  | 'withTransaction'
+  | 'getItem'
+  | 'releasedQuantity'
+  | 'homologatedCount'
+  | 'findRegistryByValues'
+  | 'insertRegistryRows'
+  | 'deleteRegistryByValues'
+  | 'insertHomologation'
+  | 'insertUnits'
+  | 'getHomologationById'
+  | 'getUnitById'
+  | 'countUnits'
+  | 'unitsByHomologationIds'
+  | 'moveUnit'
+  | 'deleteHomologation'
+  | 'list'
+  | 'maxBoxSeq'
+>;
+
+/** The one M2 seam this module calls (stock entry on homologation finish). */
+export type IStockEntryService = Pick<InventoryStockService, 'createMovement'>;
+
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_MAX_ENTRIES = 2000;
+
+/**
+ * 422 — homologating above the remaining quantity of the linked release item.
+ * Appendix D has no dedicated code; this module-local error carries a
+ * machine-readable code + params the same way (surfaced as `error.details`).
+ */
+export class HomologationOverRemainingError extends AppError {
+  public readonly details: Record<string, unknown>;
+
+  constructor(released: number, homologated: number, requested: number) {
+    super(
+      'INV_HOMOLOGATION_OVER_REMAINING',
+      'Quantidade excede o restante a homologar da liberação',
+      422,
+    );
+    this.details = { released, homologated, remaining: released - homologated, requested };
+  }
+}
+
+export class InventoryHomologationService {
+  private repository: IInventoryHomologationRepository;
+  private stockService: IStockEntryService;
+
+  private idempotencyCache = new Map<string, { at: number; promise: Promise<unknown> }>();
+
+  constructor(repository?: IInventoryHomologationRepository, stockService?: IStockEntryService) {
+    this.repository = repository ?? inventoryHomologationRepository;
+    this.stockService = stockService ?? inventoryStockService;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
+
+  async listHomologations(
+    tenantId: string,
+    query: HomologationListQuery,
+  ): Promise<InvPaginatedResponse<InvHomologationResponse>> {
+    const { page, pageSize, itemId, releaseId } = query;
+    const { rows, total } = await this.repository.list(tenantId, page, pageSize, { itemId, releaseId });
+    const units = await this.repository.unitsByHomologationIds(tenantId, rows.map((r) => r.id));
+    return {
+      items: rows.map((row) => this.toResponse(row, units.filter((u) => u.homologationId === row.id))),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  async listBoxes(
+    tenantId: string,
+    query: HomologationListQuery,
+  ): Promise<InvPaginatedResponse<InvBoxResponse>> {
+    const { page, pageSize, itemId, releaseId } = query;
+    const { rows, total } = await this.repository.list(tenantId, page, pageSize, {
+      itemId,
+      releaseId,
+      boxesOnly: true,
+    });
+    const units = await this.repository.unitsByHomologationIds(tenantId, rows.map((r) => r.id));
+    return {
+      items: rows.map((row) => {
+        const boxUnits = units.filter((u) => u.homologationId === row.id);
+        return {
+          ...this.toResponse(row, boxUnits),
+          unitCount: boxUnits.length,
+          isFull: boxUnits.length >= row.boxSize,
+        };
+      }),
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create homologation
+  // ---------------------------------------------------------------------------
+
+  async createHomologation(
+    ctx: HomologationContext,
+    dto: CreateHomologationDTO,
+    idempotencyKey: string,
+  ): Promise<InvHomologationResponse> {
+    return this.idempotent(ctx.tenantId, `homologation:${idempotencyKey}`, () =>
+      this.doCreateHomologation(ctx, dto, idempotencyKey),
+    );
+  }
+
+  private async doCreateHomologation(
+    ctx: HomologationContext,
+    dto: CreateHomologationDTO,
+    idempotencyKey: string,
+  ): Promise<InvHomologationResponse> {
+    // Shape rules before touching the DB.
+    if (dto.boxSize === 1) {
+      if (dto.boxQr) throw new ValidationError('Homologação unitária não possui QR de caixa');
+      if (dto.units.length !== 1) {
+        throw new ValidationError('Homologação unitária exige exatamente 1 unidade');
+      }
+    } else if (dto.units.length > dto.boxSize) {
+      throw new InventoryError(
+        'INV_BOX_TOO_BIG',
+        `Caixa de ${dto.boxSize} não comporta ${dto.units.length} unidades`,
+        422,
+        { boxSize: dto.boxSize, units: dto.units.length },
+      );
+    }
+
+    // In-payload duplicate check (cheap, friendly — the registry catches the rest).
+    const seen = new Set<string>();
+    for (const unit of dto.units) {
+      if (seen.has(unit.qrValue)) throw qrDuplicate(unit.qrValue);
+      seen.add(unit.qrValue);
+    }
+    if (dto.boxQr && seen.has(dto.boxQr)) throw qrDuplicate(dto.boxQr);
+
+    let created: { homologation: InvHomologationRow; units: InvHomologationUnitRow[] };
+    try {
+      created = await this.repository.withTransaction(async (tx) => {
+        const item = await this.repository.getItem(ctx.tenantId, dto.itemId, tx);
+        if (!item) throw new NotFoundError(`Item ${dto.itemId} not found`);
+        if (item.domain !== 'PRODUCT') {
+          throw new ValidationError('Homologação aplica-se apenas a itens PRODUCT');
+        }
+
+        // Remaining-to-homologate accounting per release item (§M5).
+        if (dto.releaseId) {
+          const released = await this.repository.releasedQuantity(ctx.tenantId, dto.releaseId, dto.itemId, tx);
+          if (released === null) {
+            throw new NotFoundError(`Release ${dto.releaseId} has no item ${dto.itemId}`);
+          }
+          const homologated = await this.repository.homologatedCount(ctx.tenantId, dto.releaseId, dto.itemId, tx);
+          if (homologated + dto.units.length > released) {
+            throw new HomologationOverRemainingError(released, homologated, dto.units.length);
+          }
+        }
+
+        // Box QR: mandatory for boxes — auto-generated per size prefix if absent.
+        let boxQr = dto.boxQr ?? null;
+        if (dto.boxSize > 1 && !boxQr) {
+          const prefix = boxQrPrefix(dto.boxSize);
+          const seq = (await this.repository.maxBoxSeq(ctx.tenantId, prefix, tx)) + 1;
+          boxQr = `${prefix}${seq}`;
+        }
+
+        // Global cross box×unit duplicate pre-check against the registry (A2),
+        // inside the transaction; the UNIQUE index is the concurrent backstop.
+        const allValues = [...dto.units.map((u) => u.qrValue), ...(boxQr ? [boxQr] : [])];
+        const existing = await this.repository.findRegistryByValues(ctx.tenantId, allValues, tx);
+        if (existing.length > 0) throw qrDuplicate(existing[0].qrValue);
+
+        const homologation = await this.repository.insertHomologation(
+          {
+            tenantId: ctx.tenantId,
+            itemId: dto.itemId,
+            releaseId: dto.releaseId ?? null,
+            boxSize: dto.boxSize,
+            boxQr,
+            responsibleId: dto.responsibleId ?? null,
+            notes: dto.notes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        const unitInputs: NewUnitInput[] = dto.units.map((u, i) => ({
+          qrValue: u.qrValue,
+          position: u.position ?? i + 1,
+        }));
+        const units = await this.repository.insertUnits(ctx.tenantId, homologation.id, unitInputs, tx);
+
+        await this.repository.insertRegistryRows(
+          ctx.tenantId,
+          [
+            ...units.map((u) => ({
+              qrValue: u.qrValue,
+              kind: 'UNIT' as const,
+              itemId: dto.itemId,
+              createdBy: ctx.userId ?? null,
+            })),
+            ...(boxQr
+              ? [{ qrValue: boxQr, kind: 'BOX' as const, itemId: dto.itemId, createdBy: ctx.userId ?? null }]
+              : []),
+          ],
+          tx,
+        );
+
+        return { homologation, units };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+
+    // Finishing a homologation = ENTRADA into ALMOXARIFADO (§M5), delegated to
+    // the M2 ledger owner. Runs after the homologation tx commits — follow-up
+    // in the PR about a shared-transaction seam.
+    const reason =
+      created.homologation.boxSize === 1
+        ? 'Homologação — unitário'
+        : `Homologação — caixa de ${created.homologation.boxSize}`;
+    const movement = await this.stockService.createMovement(
+      { tenantId: ctx.tenantId, userId: ctx.userId },
+      {
+        itemId: dto.itemId,
+        location: 'ALMOXARIFADO',
+        quantity: created.units.length,
+        type: 'ENTRADA',
+        reason,
+        qrs: created.units.map((u) => ({
+          qrValue: u.qrValue,
+          ...(created.homologation.boxQr ? { boxQr: created.homologation.boxQr } : {}),
+          homologationUnitId: u.id,
+        })),
+      },
+      `homologation-entry:${idempotencyKey}`,
+    );
+
+    return { ...this.toResponse(created.homologation, created.units), movementId: movement.id };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Box operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Move an existing homologated unit into an incomplete box of the SAME
+   * material. The unit's source homologation loses it; an emptied source is
+   * deleted (and a deleted box's QR identity is released from the registry).
+   */
+  async addUnitToBox(ctx: HomologationContext, boxId: string, dto: AddUnitToBoxDTO): Promise<InvBoxResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const box = await this.repository.getHomologationById(ctx.tenantId, boxId, tx);
+        if (!box) throw new NotFoundError(`Box ${boxId} not found`);
+        if (box.boxSize <= 1) {
+          throw new ValidationError('Homologação unitária não é uma caixa');
+        }
+
+        const unit = await this.repository.getUnitById(ctx.tenantId, dto.unitId, tx);
+        if (!unit) throw new NotFoundError(`Homologation unit ${dto.unitId} not found`);
+        if (unit.homologationId === box.id) {
+          throw new ValidationError('Unidade já pertence a esta caixa');
+        }
+
+        const source = await this.repository.getHomologationById(ctx.tenantId, unit.homologationId, tx);
+        if (!source) throw new NotFoundError(`Homologation ${unit.homologationId} not found`);
+        if (source.itemId !== box.itemId) throw qrWrongItem(unit.qrValue, box.itemId);
+
+        const count = await this.repository.countUnits(box.id, tx);
+        if (count >= box.boxSize) {
+          throw new InventoryError('INV_BOX_FULL', 'Caixa cheia', 422, {
+            boxId: box.id,
+            boxSize: box.boxSize,
+            unitCount: count,
+          });
+        }
+
+        await this.repository.moveUnit(ctx.tenantId, unit.id, box.id, count + 1, tx);
+        await this.deleteIfEmptied(ctx.tenantId, source, tx);
+
+        const units = await this.repository.unitsByHomologationIds(ctx.tenantId, [box.id], tx);
+        return {
+          ...this.toResponse(box, units),
+          unitCount: units.length,
+          isFull: units.length >= box.boxSize,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /**
+   * Remove a unit from its box: the unit becomes a box_size=1 homologation of
+   * its own; an emptied box is deleted (its box-QR identity is released).
+   */
+  async removeFromBox(ctx: HomologationContext, unitId: string): Promise<InvRemoveFromBoxResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const unit = await this.repository.getUnitById(ctx.tenantId, unitId, tx);
+        if (!unit) throw new NotFoundError(`Homologation unit ${unitId} not found`);
+
+        const box = await this.repository.getHomologationById(ctx.tenantId, unit.homologationId, tx);
+        if (!box) throw new NotFoundError(`Homologation ${unit.homologationId} not found`);
+        if (box.boxSize <= 1) {
+          throw new InventoryError('INV_BOX_EMPTY', 'Unidade não está em uma caixa', 422, {
+            unitId,
+            homologationId: box.id,
+          });
+        }
+
+        const solo = await this.repository.insertHomologation(
+          {
+            tenantId: ctx.tenantId,
+            itemId: box.itemId,
+            releaseId: box.releaseId,
+            boxSize: 1,
+            boxQr: null,
+            responsibleId: box.responsibleId,
+            notes: box.notes,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        const moved = await this.repository.moveUnit(ctx.tenantId, unit.id, solo.id, 1, tx);
+        const boxDeleted = await this.deleteIfEmptied(ctx.tenantId, box, tx);
+
+        return {
+          unit: this.toUnitResponse(moved ?? unit),
+          homologation: this.toResponse(solo, moved ? [moved] : [unit]),
+          boxDeleted,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /** Delete a homologation left with zero units; releases its box-QR identity. */
+  private async deleteIfEmptied(
+    tenantId: string,
+    homologation: InvHomologationRow,
+    tx: HomologDbClient,
+  ): Promise<boolean> {
+    const left = await this.repository.countUnits(homologation.id, tx);
+    if (left > 0) return false;
+    await this.repository.deleteHomologation(tenantId, homologation.id, tx);
+    if (homologation.boxQr) {
+      await this.repository.deleteRegistryByValues(tenantId, [homologation.boxQr], tx);
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotency (best-effort, per-process — same seam as M2; durable storage
+  // is the standing inv_idempotency_keys follow-up)
+  // ---------------------------------------------------------------------------
+
+  private async idempotent<T>(tenantId: string, key: string, run: () => Promise<T>): Promise<T> {
+    const cacheKey = `${tenantId}:${key}`;
+    const now = Date.now();
+    const hit = this.idempotencyCache.get(cacheKey);
+    if (hit && now - hit.at < IDEMPOTENCY_TTL_MS) {
+      return hit.promise as Promise<T>;
+    }
+    const promise = run();
+    this.idempotencyCache.set(cacheKey, { at: now, promise });
+    promise.catch(() => this.idempotencyCache.delete(cacheKey));
+    if (this.idempotencyCache.size > IDEMPOTENCY_MAX_ENTRIES) {
+      for (const [k, entry] of this.idempotencyCache) {
+        if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) break;
+        if (now - entry.at >= IDEMPOTENCY_TTL_MS) this.idempotencyCache.delete(k);
+      }
+      // Still over cap after the TTL sweep: drop oldest-inserted first.
+      for (const k of this.idempotencyCache.keys()) {
+        if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) break;
+        this.idempotencyCache.delete(k);
+      }
+    }
+    return promise;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------------
+
+  private toResponse(row: InvHomologationRow, units: InvHomologationUnitRow[]): InvHomologationResponse {
+    return {
+      id: row.id,
+      itemId: row.itemId,
+      releaseId: row.releaseId ?? null,
+      boxSize: row.boxSize,
+      boxQr: row.boxQr ?? null,
+      responsibleId: row.responsibleId ?? null,
+      notes: row.notes ?? null,
+      createdAt: row.createdAt ? new Date(row.createdAt).toISOString() : new Date().toISOString(),
+      createdBy: row.createdBy ?? null,
+      units: units.map((u) => this.toUnitResponse(u)),
+    };
+  }
+
+  private toUnitResponse(u: InvHomologationUnitRow): InvHomologationUnitResponse {
+    return { id: u.id, qrValue: u.qrValue, position: u.position ?? null };
+  }
+
+  /**
+   * Map low-level DB errors to the RFC contract. Drizzle wraps the driver
+   * error (DrizzleQueryError): the real SQLSTATE lives on `err.cause.code`,
+   * not `err.code`/`err.message` — inspect both (known gotcha).
+   */
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as {
+      message?: string;
+      code?: string;
+      cause?: { message?: string; code?: string; detail?: string; constraint_name?: string };
+    };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      // Concurrent duplicate past the pre-check: cross box×unit uniqueness is
+      // held by inv_qr_registry_uq (plus the per-table QR uniques).
+      const detail = cause.detail ?? '';
+      const match = /\)=\([^,]+,\s*(.+)\)/.exec(detail);
+      throw qrDuplicate(match ? match[1].trim() : 'desconhecido');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (item, liberação ou unidade)');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+export const inventoryHomologationService = new InventoryHomologationService();

--- a/src/services/inventory/InventoryQrService.ts
+++ b/src/services/inventory/InventoryQrService.ts
@@ -1,0 +1,416 @@
+// =============================================================================
+// RFC-0061 M5 — QR services: scan-time validation (S2) and traceability (S5).
+//
+// S2 — POST /qr/validate: batch of codes + context (expectedItemId?,
+// orderItemId?) → per-code verdict so handheld scanners can give green/red
+// feedback per beep. The batch NEVER fails as a whole: every code gets a
+// verdict (`ok` or an Appendix D reason). A box QR expands to its units.
+//
+// S5 — GET /qr/trace/:code: accepts the bare code (`\d+(_\d+)+`) or the full
+// `https://produto.myio.com.br/<code>` URL (what a camera scan yields).
+// Response = current-state header + normalized event timeline
+// `{ts, type, actor, location, refs}` aggregating homologation, ledger
+// entries/exits (inv_movement_qrs → inv_stock_movements), expedition baixas
+// (inv_delivery_qrs → inv_item_deliveries → inv_expedition_orders — absent
+// rows are normal until M6 ships) and box membership. Unknown QR → 404; a box
+// QR expands its units, flagged as box.
+// =============================================================================
+
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+  InvHomologationRow,
+  InvQrRegistryRow,
+  QrDeliveryEventRow,
+  QrMovementEventRow,
+  UnitWithHomologationRow,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import { NotFoundError } from '../../shared/errors/AppError';
+import { QR_BASE_URL } from './InventoryHomologationService';
+import type { QrValidateDTO } from '../../dto/request/InventoryDTO';
+import type { InvQrTraceEvent, InvQrTraceResponse } from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export type IInventoryQrRepository = Pick<
+  InventoryHomologationRepository,
+  | 'findRegistryByValues'
+  | 'findUnitsByQrValues'
+  | 'findBoxesByQrValues'
+  | 'unitsByHomologationIds'
+  | 'movementEventsByQrs'
+  | 'deliveryEventsByQrs'
+  | 'getExpeditionOrderItem'
+>;
+
+/** Per-unit verdict inside a box expansion. */
+export interface QrUnitVerdict {
+  qrValue: string;
+  ok: boolean;
+  reason?: string;
+}
+
+/** Per-code verdict (extends the P0 InvQrValidateVerdict shape with M5 fields). */
+export interface QrVerdict {
+  code: string;
+  ok: boolean;
+  reason?: string;
+  itemId?: string | null;
+  isBox?: boolean;
+  units?: QrUnitVerdict[];
+}
+
+export interface QrValidateResult {
+  results: QrVerdict[];
+}
+
+const EXIT_TYPES = new Set(['SAIDA', 'TRANSFERENCIA_OUT']);
+
+/** Bare unit-code format kept from the source (§M5). */
+export const QR_CODE_REGEX = /^\d+(_\d+)+$/;
+
+// -----------------------------------------------------------------------------
+// Normalization (S5 — bare code or full URL; camera scans yield the URL)
+// -----------------------------------------------------------------------------
+
+export interface NormalizedQr {
+  /** Canonical bare code (URL prefix stripped when present). */
+  code: string;
+  /** Every spelling to match against stored values (bare + full URL + raw). */
+  candidates: string[];
+}
+
+export function normalizeQrInput(raw: string): NormalizedQr {
+  const trimmed = raw.trim();
+  let code = trimmed;
+  for (const prefix of [QR_BASE_URL, QR_BASE_URL.replace('https://', 'http://')]) {
+    if (code.toLowerCase().startsWith(prefix.toLowerCase())) {
+      code = code.slice(prefix.length);
+      break;
+    }
+  }
+  const candidates = new Set<string>([trimmed, code, `${QR_BASE_URL}${code}`]);
+  return { code, candidates: [...candidates] };
+}
+
+// -----------------------------------------------------------------------------
+// Service
+// -----------------------------------------------------------------------------
+
+export class InventoryQrService {
+  private repository: IInventoryQrRepository;
+
+  constructor(repository?: IInventoryQrRepository) {
+    this.repository = repository ?? inventoryHomologationRepository;
+  }
+
+  // ---------------------------------------------------------------------------
+  // S2 — batch validation
+  // ---------------------------------------------------------------------------
+
+  async validate(tenantId: string, dto: QrValidateDTO): Promise<QrValidateResult> {
+    // Context: an explicit expected item wins; otherwise resolve it from the
+    // expedition-order item when given (absent rows just drop the check).
+    let expectedItemId = dto.expectedItemId ?? null;
+    if (!expectedItemId && dto.orderItemId) {
+      const orderItem = await this.repository.getExpeditionOrderItem(tenantId, dto.orderItemId);
+      expectedItemId = orderItem?.itemId ?? null;
+    }
+
+    const normalized = dto.codes.map((c) => normalizeQrInput(c));
+    const allCandidates = [...new Set(normalized.flatMap((n) => n.candidates))];
+
+    const [registry, units, boxes] = await Promise.all([
+      this.repository.findRegistryByValues(tenantId, allCandidates),
+      this.repository.findUnitsByQrValues(tenantId, allCandidates),
+      this.repository.findBoxesByQrValues(tenantId, allCandidates),
+    ]);
+
+    // Expand box units so usage checks cover them too.
+    const boxUnits = await this.repository.unitsByHomologationIds(
+      tenantId,
+      boxes.map((b) => b.id),
+    );
+    const usageValues = [...new Set([...allCandidates, ...boxUnits.map((u) => u.qrValue)])];
+    const [movementEvents, deliveryEvents] = await Promise.all([
+      this.repository.movementEventsByQrs(tenantId, usageValues),
+      this.repository.deliveryEventsByQrs(tenantId, usageValues),
+    ]);
+
+    const results = dto.codes.map((raw, i) => {
+      const { candidates } = normalized[i];
+      const inSet = (v: string | null | undefined): boolean => !!v && candidates.includes(v);
+
+      const box = boxes.find((b) => inSet(b.boxQr));
+      if (box) {
+        return this.boxVerdict(raw, box, boxUnits.filter((u) => u.homologationId === box.id), expectedItemId, movementEvents, deliveryEvents);
+      }
+
+      const unit = units.find((u) => inSet(u.unit.qrValue));
+      const registryRow = registry.find((r) => inSet(r.qrValue));
+      if (!unit && !registryRow) {
+        return { code: raw, ok: false, reason: 'INV_QR_NOT_IN_REGISTRY' } as QrVerdict;
+      }
+
+      const itemId = unit?.homologation.itemId ?? registryRow?.itemId ?? null;
+      const values = [...candidates, ...(unit?.homologation.boxQr ? [unit.homologation.boxQr] : [])];
+      const usage = this.usageOf(values, movementEvents, deliveryEvents);
+      if (usage === 'USED') {
+        return { code: raw, ok: false, reason: 'INV_QR_ALREADY_USED', itemId } as QrVerdict;
+      }
+      if (expectedItemId && itemId && itemId !== expectedItemId) {
+        return { code: raw, ok: false, reason: 'INV_QR_WRONG_ITEM', itemId } as QrVerdict;
+      }
+      return { code: raw, ok: true, itemId } as QrVerdict;
+    });
+
+    return { results };
+  }
+
+  private boxVerdict(
+    raw: string,
+    box: InvHomologationRow,
+    boxUnitRows: Array<{ qrValue: string }>,
+    expectedItemId: string | null,
+    movementEvents: QrMovementEventRow[],
+    deliveryEvents: QrDeliveryEventRow[],
+  ): QrVerdict {
+    const unitVerdicts: QrUnitVerdict[] = boxUnitRows.map((u) => {
+      const usage = this.usageOf([u.qrValue, ...(box.boxQr ? [box.boxQr] : [])], movementEvents, deliveryEvents);
+      if (usage === 'USED') return { qrValue: u.qrValue, ok: false, reason: 'INV_QR_ALREADY_USED' };
+      return { qrValue: u.qrValue, ok: true };
+    });
+
+    if (expectedItemId && box.itemId !== expectedItemId) {
+      return {
+        code: raw,
+        ok: false,
+        reason: 'INV_QR_WRONG_ITEM',
+        itemId: box.itemId,
+        isBox: true,
+        units: unitVerdicts,
+      };
+    }
+    const allOk = unitVerdicts.every((u) => u.ok);
+    return {
+      code: raw,
+      ok: allOk,
+      ...(allOk ? {} : { reason: 'INV_QR_ALREADY_USED' }),
+      itemId: box.itemId,
+      isBox: true,
+      units: unitVerdicts,
+    };
+  }
+
+  /** Usage state from the QR's event history: latest ledger event an exit, or any expedition baixa → USED. */
+  private usageOf(
+    values: string[],
+    movementEvents: QrMovementEventRow[],
+    deliveryEvents: QrDeliveryEventRow[],
+  ): 'ACTIVE' | 'USED' | 'NONE' {
+    const matches = (v: string | null): boolean => !!v && values.includes(v);
+    if (deliveryEvents.some((d) => matches(d.qrValue) || matches(d.boxQr))) return 'USED';
+    const own = movementEvents.filter((m) => matches(m.qrValue) || matches(m.boxQr));
+    if (own.length === 0) return 'NONE';
+    const latest = own[own.length - 1]; // repository orders oldest-first
+    return EXIT_TYPES.has(latest.type) ? 'USED' : 'ACTIVE';
+  }
+
+  // ---------------------------------------------------------------------------
+  // S5 — trace
+  // ---------------------------------------------------------------------------
+
+  async trace(tenantId: string, rawCode: string): Promise<InvQrTraceResponse> {
+    const { code, candidates } = normalizeQrInput(rawCode);
+
+    const [registry, unitRows, boxRows] = await Promise.all([
+      this.repository.findRegistryByValues(tenantId, candidates),
+      this.repository.findUnitsByQrValues(tenantId, candidates),
+      this.repository.findBoxesByQrValues(tenantId, candidates),
+    ]);
+
+    const box = boxRows[0] ?? null;
+    const unit = unitRows[0] ?? null;
+    const registryRow: InvQrRegistryRow | null = registry[0] ?? null;
+    if (!box && !unit && !registryRow) {
+      throw new NotFoundError(`QR ${code} not found`);
+    }
+
+    if (box || registryRow?.kind === 'BOX') {
+      return this.traceBox(tenantId, code, candidates, box);
+    }
+    return this.traceUnit(tenantId, code, candidates, unit, registryRow);
+  }
+
+  private async traceUnit(
+    tenantId: string,
+    code: string,
+    candidates: string[],
+    unit: UnitWithHomologationRow | null,
+    registryRow: InvQrRegistryRow | null,
+  ): Promise<InvQrTraceResponse> {
+    const timeline: InvQrTraceEvent[] = [];
+    const boxQr = unit?.homologation.boxQr ?? null;
+    const values = [...candidates, ...(boxQr ? [boxQr] : [])];
+
+    if (unit) {
+      timeline.push({
+        ts: toIso(unit.unit.createdAt ?? unit.homologation.createdAt),
+        type: 'HOMOLOGACAO',
+        actor: unit.homologation.responsibleId ?? unit.homologation.createdBy ?? null,
+        location: 'ALMOXARIFADO',
+        refs: {
+          homologationId: unit.homologation.id,
+          itemId: unit.homologation.itemId,
+          releaseId: unit.homologation.releaseId,
+          boxQr,
+          boxSize: unit.homologation.boxSize,
+          position: unit.unit.position,
+        },
+      });
+    } else if (registryRow) {
+      // Registry-only identity (e.g. generated but not yet homologated).
+      timeline.push({
+        ts: toIso(registryRow.createdAt),
+        type: 'REGISTRO',
+        actor: registryRow.createdBy ?? null,
+        location: null,
+        refs: { itemId: registryRow.itemId, kind: registryRow.kind },
+      });
+    }
+
+    const [movementEvents, deliveryEvents] = await Promise.all([
+      this.repository.movementEventsByQrs(tenantId, values),
+      this.repository.deliveryEventsByQrs(tenantId, values),
+    ]);
+    this.pushLedgerEvents(timeline, movementEvents, candidates);
+    this.pushDeliveryEvents(timeline, deliveryEvents);
+
+    timeline.sort((a, b) => a.ts.localeCompare(b.ts));
+
+    return {
+      code,
+      current: this.currentState(movementEvents, deliveryEvents),
+      isBox: false,
+      timeline,
+    };
+  }
+
+  private async traceBox(
+    tenantId: string,
+    code: string,
+    candidates: string[],
+    box: InvHomologationRow | null,
+  ): Promise<InvQrTraceResponse> {
+    const timeline: InvQrTraceEvent[] = [];
+    const units = box ? await this.repository.unitsByHomologationIds(tenantId, [box.id]) : [];
+
+    if (box) {
+      timeline.push({
+        ts: toIso(box.createdAt),
+        type: 'HOMOLOGACAO',
+        actor: box.responsibleId ?? box.createdBy ?? null,
+        location: 'ALMOXARIFADO',
+        refs: {
+          homologationId: box.id,
+          itemId: box.itemId,
+          releaseId: box.releaseId,
+          boxSize: box.boxSize,
+          unitCount: units.length,
+        },
+      });
+    }
+
+    const [movementEvents, deliveryEvents] = await Promise.all([
+      this.repository.movementEventsByQrs(tenantId, candidates),
+      this.repository.deliveryEventsByQrs(tenantId, candidates),
+    ]);
+    this.pushLedgerEvents(timeline, movementEvents, candidates);
+    this.pushDeliveryEvents(timeline, deliveryEvents);
+
+    timeline.sort((a, b) => a.ts.localeCompare(b.ts));
+
+    return {
+      code,
+      current: this.currentState(movementEvents, deliveryEvents),
+      isBox: true,
+      units: units.map((u) => u.qrValue),
+      timeline,
+    };
+  }
+
+  private pushLedgerEvents(
+    timeline: InvQrTraceEvent[],
+    events: QrMovementEventRow[],
+    ownCandidates: string[],
+  ): void {
+    for (const m of events) {
+      timeline.push({
+        ts: toIso(m.createdAt),
+        type: EXIT_TYPES.has(m.type) ? 'SAIDA_ESTOQUE' : m.type === 'AJUSTE' ? 'AJUSTE_ESTOQUE' : 'ENTRADA_ESTOQUE',
+        actor: m.responsible ?? m.createdBy ?? null,
+        location: m.location,
+        refs: {
+          movementId: m.movementId,
+          movementType: m.type,
+          reason: m.reason,
+          // Box membership: event reached this QR through its box's QR.
+          ...(m.boxQr && !ownCandidates.includes(m.qrValue ?? '') ? { viaBoxQr: m.boxQr } : {}),
+        },
+      });
+    }
+  }
+
+  private pushDeliveryEvents(timeline: InvQrTraceEvent[], events: QrDeliveryEventRow[]): void {
+    for (const d of events) {
+      timeline.push({
+        ts: toIso(d.createdAt ?? new Date(0)),
+        type: 'EXPEDICAO_BAIXA',
+        actor: d.createdBy ?? null,
+        location: null,
+        refs: {
+          deliveryId: d.deliveryId,
+          orderItemId: d.orderItemId,
+          orderId: d.orderId,
+          orderTitle: d.orderTitle,
+          orderStatus: d.orderStatus,
+        },
+      });
+    }
+  }
+
+  /** Current-state header (S5): where the QR is now, derived from its history. */
+  private currentState(
+    movementEvents: QrMovementEventRow[],
+    deliveryEvents: QrDeliveryEventRow[],
+  ): InvQrTraceResponse['current'] {
+    const lastDelivery = deliveryEvents[deliveryEvents.length - 1] ?? null;
+    const lastMovement = movementEvents[movementEvents.length - 1] ?? null;
+
+    const deliveryTs = lastDelivery?.createdAt ? new Date(lastDelivery.createdAt).getTime() : null;
+    const movementTs = lastMovement?.createdAt ? new Date(lastMovement.createdAt).getTime() : null;
+
+    if (lastDelivery && (movementTs === null || (deliveryTs !== null && deliveryTs >= movementTs))) {
+      return {
+        location: 'EXPEDICAO',
+        status: lastDelivery.orderStatus ?? 'EXPEDIDO',
+        client: lastDelivery.orderTitle ?? null,
+      };
+    }
+    if (lastMovement) {
+      if (EXIT_TYPES.has(lastMovement.type)) {
+        return { location: null, status: 'BAIXADO', client: null };
+      }
+      return { location: lastMovement.location, status: 'EM_ESTOQUE', client: null };
+    }
+    return { location: 'ALMOXARIFADO', status: 'HOMOLOGADO', client: null };
+  }
+}
+
+function toIso(value: Date | string | null | undefined): string {
+  return value ? new Date(value).toISOString() : new Date(0).toISOString();
+}
+
+export const inventoryQrService = new InventoryQrService();

--- a/tests/unit/inventory/m5-box-ops.test.ts
+++ b/tests/unit/inventory/m5-box-ops.test.ts
@@ -1,0 +1,208 @@
+/**
+ * RFC-0061 M5 — box operations (mocked repo, no DB): add-unit into an
+ * incomplete box of the same material (INV_BOX_FULL / INV_QR_WRONG_ITEM) and
+ * remove-from-box (unit becomes a box_size=1 homologation; an emptied box is
+ * deleted and its box-QR identity released from the registry).
+ */
+
+import { InventoryHomologationService } from '../../../src/services/inventory/InventoryHomologationService';
+import { AppError, NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  TENANT,
+  ITEM_ID,
+  OTHER_ITEM_ID,
+  BOX_ID,
+  UNIT_ID,
+  BASE,
+  makeHomologation,
+  makeUnit,
+  makeHomologRepoMock,
+  makeStockServiceMock,
+  HomologRepoMock,
+  nextId,
+} from './m5-helpers';
+
+let repo: HomologRepoMock;
+let service: InventoryHomologationService;
+
+const SOLO_ID = nextId();
+const BOX_QR = `${BASE}caixa-10/1`;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  repo = makeHomologRepoMock();
+  service = new InventoryHomologationService(repo, makeStockServiceMock());
+});
+
+async function expectAppError(promise: Promise<unknown>, code: string, status: number): Promise<AppError> {
+  const err = (await promise.then(
+    () => {
+      throw new Error('expected rejection');
+    },
+    (e) => e,
+  )) as AppError;
+  expect(err).toBeInstanceOf(AppError);
+  expect(err.code).toBe(code);
+  expect(err.statusCode).toBe(status);
+  return err;
+}
+
+function box(overrides = {}) {
+  return makeHomologation({ id: BOX_ID, boxSize: 10, boxQr: BOX_QR, ...overrides });
+}
+function soloHomologation(overrides = {}) {
+  return makeHomologation({ id: SOLO_ID, boxSize: 1, boxQr: null, ...overrides });
+}
+
+describe('addUnitToBox', () => {
+  it('moves the unit into the box and deletes the emptied unitary source', async () => {
+    const target = box();
+    const source = soloHomologation();
+    const unit = makeUnit({ id: UNIT_ID, homologationId: SOLO_ID });
+    repo.getHomologationById.mockImplementation(async (_t: string, id: string) =>
+      id === BOX_ID ? target : id === SOLO_ID ? source : null,
+    );
+    repo.getUnitById.mockResolvedValue(unit);
+    // First countUnits call = box fill check (3/10); second = emptied-source check (0).
+    repo.countUnits.mockResolvedValueOnce(3).mockResolvedValueOnce(0);
+    repo.unitsByHomologationIds.mockResolvedValue([
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '9_1' }),
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '9_2' }),
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '9_3' }),
+      makeUnit({ id: UNIT_ID, homologationId: BOX_ID }),
+    ]);
+
+    const res = await service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID });
+
+    expect(repo.moveUnit).toHaveBeenCalledWith(TENANT, UNIT_ID, BOX_ID, 4, expect.anything());
+    expect(repo.deleteHomologation).toHaveBeenCalledWith(TENANT, SOLO_ID, expect.anything());
+    // Unitary source has no box QR — nothing to release from the registry.
+    expect(repo.deleteRegistryByValues).not.toHaveBeenCalled();
+    expect(res.unitCount).toBe(4);
+    expect(res.isFull).toBe(false);
+  });
+
+  it('keeps a source box that still has units (and releases nothing)', async () => {
+    const target = box();
+    const otherBoxId = nextId();
+    const source = makeHomologation({ id: otherBoxId, boxSize: 10, boxQr: `${BASE}caixa-10/2` });
+    repo.getHomologationById.mockImplementation(async (_t: string, id: string) =>
+      id === BOX_ID ? target : id === otherBoxId ? source : null,
+    );
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: otherBoxId }));
+    repo.countUnits.mockResolvedValueOnce(1).mockResolvedValueOnce(5);
+    repo.unitsByHomologationIds.mockResolvedValue([makeUnit({ id: UNIT_ID, homologationId: BOX_ID })]);
+
+    await service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID });
+
+    expect(repo.deleteHomologation).not.toHaveBeenCalled();
+    expect(repo.deleteRegistryByValues).not.toHaveBeenCalled();
+  });
+
+  it('deletes an emptied source BOX and releases its box QR from the registry', async () => {
+    const target = box();
+    const otherBoxId = nextId();
+    const sourceQr = `${BASE}caixa-10/2`;
+    const source = makeHomologation({ id: otherBoxId, boxSize: 10, boxQr: sourceQr });
+    repo.getHomologationById.mockImplementation(async (_t: string, id: string) =>
+      id === BOX_ID ? target : id === otherBoxId ? source : null,
+    );
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: otherBoxId }));
+    repo.countUnits.mockResolvedValueOnce(1).mockResolvedValueOnce(0);
+    repo.unitsByHomologationIds.mockResolvedValue([makeUnit({ id: UNIT_ID, homologationId: BOX_ID })]);
+
+    await service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID });
+
+    expect(repo.deleteHomologation).toHaveBeenCalledWith(TENANT, otherBoxId, expect.anything());
+    expect(repo.deleteRegistryByValues).toHaveBeenCalledWith(TENANT, [sourceQr], expect.anything());
+  });
+
+  it('full box → 422 INV_BOX_FULL', async () => {
+    repo.getHomologationById.mockImplementation(async (_t: string, id: string) =>
+      id === BOX_ID ? box() : soloHomologation(),
+    );
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: SOLO_ID }));
+    repo.countUnits.mockResolvedValue(10);
+    await expectAppError(service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID }), 'INV_BOX_FULL', 422);
+    expect(repo.moveUnit).not.toHaveBeenCalled();
+  });
+
+  it('unit of another material → 422 INV_QR_WRONG_ITEM', async () => {
+    repo.getHomologationById.mockImplementation(async (_t: string, id: string) =>
+      id === BOX_ID ? box() : soloHomologation({ itemId: OTHER_ITEM_ID }),
+    );
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: SOLO_ID }));
+    const err = await expectAppError(service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID }), 'INV_QR_WRONG_ITEM', 422);
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual(
+      expect.objectContaining({ expectedItemId: ITEM_ID }),
+    );
+  });
+
+  it('box not found → 404; unit not found → 404', async () => {
+    repo.getHomologationById.mockResolvedValue(null);
+    await expect(service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID })).rejects.toBeInstanceOf(NotFoundError);
+
+    repo.getHomologationById.mockResolvedValue(box());
+    repo.getUnitById.mockResolvedValue(null);
+    await expect(service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID })).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('target that is not a box → 400; unit already in the box → 400', async () => {
+    repo.getHomologationById.mockResolvedValue(soloHomologation());
+    await expect(service.addUnitToBox(CTX, SOLO_ID, { unitId: UNIT_ID })).rejects.toBeInstanceOf(ValidationError);
+
+    repo.getHomologationById.mockResolvedValue(box());
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: BOX_ID }));
+    await expect(service.addUnitToBox(CTX, BOX_ID, { unitId: UNIT_ID })).rejects.toBeInstanceOf(ValidationError);
+  });
+});
+
+describe('removeFromBox', () => {
+  it('turns the unit into a box_size=1 homologation; box with units left survives', async () => {
+    const theBox = box();
+    const unit = makeUnit({ id: UNIT_ID, homologationId: BOX_ID });
+    repo.getUnitById.mockResolvedValue(unit);
+    repo.getHomologationById.mockResolvedValue(theBox);
+    repo.insertHomologation.mockResolvedValue(soloHomologation());
+    repo.moveUnit.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: SOLO_ID }));
+    repo.countUnits.mockResolvedValue(9);
+
+    const res = await service.removeFromBox(CTX, UNIT_ID);
+
+    expect(repo.insertHomologation).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: TENANT, itemId: ITEM_ID, boxSize: 1, boxQr: null }),
+      expect.anything(),
+    );
+    expect(repo.moveUnit).toHaveBeenCalledWith(TENANT, UNIT_ID, SOLO_ID, 1, expect.anything());
+    expect(res.boxDeleted).toBe(false);
+    expect(res.homologation.boxSize).toBe(1);
+    expect(repo.deleteHomologation).not.toHaveBeenCalled();
+  });
+
+  it('deletes the emptied box and releases its box QR', async () => {
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: BOX_ID }));
+    repo.getHomologationById.mockResolvedValue(box());
+    repo.insertHomologation.mockResolvedValue(soloHomologation());
+    repo.moveUnit.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: SOLO_ID }));
+    repo.countUnits.mockResolvedValue(0);
+
+    const res = await service.removeFromBox(CTX, UNIT_ID);
+
+    expect(res.boxDeleted).toBe(true);
+    expect(repo.deleteHomologation).toHaveBeenCalledWith(TENANT, BOX_ID, expect.anything());
+    expect(repo.deleteRegistryByValues).toHaveBeenCalledWith(TENANT, [BOX_QR], expect.anything());
+  });
+
+  it('unit not inside a box → 422 INV_BOX_EMPTY', async () => {
+    repo.getUnitById.mockResolvedValue(makeUnit({ id: UNIT_ID, homologationId: SOLO_ID }));
+    repo.getHomologationById.mockResolvedValue(soloHomologation());
+    await expectAppError(service.removeFromBox(CTX, UNIT_ID), 'INV_BOX_EMPTY', 422);
+    expect(repo.insertHomologation).not.toHaveBeenCalled();
+  });
+
+  it('unknown unit → 404', async () => {
+    repo.getUnitById.mockResolvedValue(null);
+    await expect(service.removeFromBox(CTX, UNIT_ID)).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/tests/unit/inventory/m5-contract.test.ts
+++ b/tests/unit/inventory/m5-contract.test.ts
@@ -1,0 +1,323 @@
+/**
+ * RFC-0061 M5 — wired-contract test for the REAL homologation & QR routes.
+ *
+ * Same harness as m1/m2-contract: real router + real auth middleware, auth
+ * leaves mocked, M5 services mocked (no DB). Documents the standing guards
+ * (missing Idempotency-Key → 400, DTO validation → 400) and the one route M5
+ * intentionally keeps deferred: POST /qr/generate delegates QR generation to
+ * the external platform, whose client ships with M8 → still 501.
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryHomologationService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryHomologationService');
+  return {
+    ...actual,
+    inventoryHomologationService: {
+      listHomologations: jest.fn(),
+      listBoxes: jest.fn(),
+      createHomologation: jest.fn(),
+      addUnitToBox: jest.fn(),
+      removeFromBox: jest.fn(),
+    },
+  };
+});
+
+jest.mock('../../../src/services/inventory/InventoryQrService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryQrService');
+  return {
+    ...actual,
+    inventoryQrService: {
+      validate: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryHomologationService } from '../../../src/services/inventory/InventoryHomologationService';
+import { inventoryQrService } from '../../../src/services/inventory/InventoryQrService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+import { NotFoundError } from '../../../src/shared/errors/AppError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+const BOX_ID = '77777777-7777-7777-7777-777777777777';
+const UNIT_ID = '88888888-8888-8888-8888-888888888888';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T };
+
+const homologSvc = inventoryHomologationService as jest.Mocked<typeof inventoryHomologationService>;
+const qrSvc = inventoryQrService as jest.Mocked<typeof inventoryQrService>;
+
+const goodHomologation = {
+  itemId: ITEM_ID,
+  boxSize: 1,
+  units: [{ qrValue: '123_456' }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M5 homologation routes — real contract (was 501)', () => {
+  it('GET /homologations → 200 with the paginated listing', async () => {
+    homologSvc.listHomologations.mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/homologations?page=1&pageSize=20'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: unknown[] }>;
+      expect(body.data.items).toEqual([]);
+      expect(homologSvc.listHomologations).toHaveBeenCalledWith(TENANT, expect.objectContaining({ page: 1, pageSize: 20 }));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /homologations without Idempotency-Key → 400 INV_IDEMPOTENCY_KEY_MISSING', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/homologations'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify(goodHomologation),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(homologSvc.createHomologation).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /homologations with a bad body → 400 VALIDATION_ERROR', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/homologations'), {
+        method: 'POST',
+        headers: {
+          'X-API-Key': 'gcdr_cust_test',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'k-1',
+        },
+        body: JSON.stringify({ itemId: ITEM_ID, boxSize: 5, units: [] }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /homologations with key + valid body → 201 (was 501)', async () => {
+    homologSvc.createHomologation.mockResolvedValue({
+      id: BOX_ID,
+      itemId: ITEM_ID,
+      boxSize: 1,
+      units: [{ id: UNIT_ID, qrValue: '123_456', position: 1 }],
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/homologations'), {
+        method: 'POST',
+        headers: {
+          'X-API-Key': 'gcdr_cust_test',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'k-2',
+        },
+        body: JSON.stringify(goodHomologation),
+      });
+      expect(res.status).toBe(201);
+      expect(homologSvc.createHomologation).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        expect.objectContaining({ itemId: ITEM_ID, boxSize: 1 }),
+        'k-2',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /homologations/boxes → 200', async () => {
+    homologSvc.listBoxes.mockResolvedValue({ items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/homologations/boxes'), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(200);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /homologations/boxes/:id/add-unit → 200; malformed box id → 400', async () => {
+    homologSvc.addUnitToBox.mockResolvedValue({ id: BOX_ID, unitCount: 2, isFull: false } as never);
+    const srv = await listen(buildApp());
+    try {
+      const ok = await fetch(U(srv.url, `/homologations/boxes/${BOX_ID}/add-unit`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ unitId: UNIT_ID }),
+      });
+      expect(ok.status).toBe(200);
+      expect(homologSvc.addUnitToBox).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        BOX_ID,
+        { unitId: UNIT_ID },
+      );
+
+      const bad = await fetch(U(srv.url, '/homologations/boxes/not-a-uuid/add-unit'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ unitId: UNIT_ID }),
+      });
+      expect(bad.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /homologations/units/:id/remove-from-box → 200', async () => {
+    homologSvc.removeFromBox.mockResolvedValue({ boxDeleted: true } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/homologations/units/${UNIT_ID}/remove-from-box`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(homologSvc.removeFromBox).toHaveBeenCalledWith({ tenantId: TENANT, userId: 'key-1' }, UNIT_ID);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M5 QR routes — real contract', () => {
+  it('POST /qr/validate → 200 with per-code verdicts', async () => {
+    qrSvc.validate.mockResolvedValue({
+      results: [{ code: '1_1', ok: false, reason: 'INV_QR_NOT_IN_REGISTRY' }],
+    });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/validate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ codes: ['1_1'] }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ results: unknown[] }>;
+      expect(body.data.results).toHaveLength(1);
+      expect(qrSvc.validate).toHaveBeenCalledWith(TENANT, { codes: ['1_1'] });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /qr/validate with a bad body → 400 VALIDATION_ERROR (batch guardrail)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/validate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ codes: [] }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /qr/trace/:code passes the URL-decoded code to the service', async () => {
+    qrSvc.trace.mockResolvedValue({ code: '123_456', current: { location: null, status: null, client: null }, isBox: false, timeline: [] });
+    const srv = await listen(buildApp());
+    try {
+      const encoded = encodeURIComponent('https://produto.myio.com.br/123_456');
+      const res = await fetch(U(srv.url, `/qr/trace/${encoded}`), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(200);
+      expect(qrSvc.trace).toHaveBeenCalledWith(TENANT, 'https://produto.myio.com.br/123_456');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /qr/trace/:code for an unknown QR → 404', async () => {
+    qrSvc.trace.mockRejectedValue(new NotFoundError('QR 9_9 not found'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/trace/9_9'), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /qr/generate stays deferred → 501 INV_NOT_IMPLEMENTED (external platform client is M8)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/generate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(501);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_NOT_IMPLEMENTED');
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m5-helpers.ts
+++ b/tests/unit/inventory/m5-helpers.ts
@@ -1,0 +1,185 @@
+// Shared fixtures/mocks for the RFC-0061 M5 unit suites (services with a
+// mocked repository — no DB).
+
+import type {
+  IInventoryHomologationRepository,
+  IStockEntryService,
+} from '../../../src/services/inventory/InventoryHomologationService';
+import type { IInventoryQrRepository } from '../../../src/services/inventory/InventoryQrService';
+import type {
+  InvHomologationRow,
+  InvHomologationUnitRow,
+  InvQrRegistryRow,
+  InvItemRow,
+  QrMovementEventRow,
+  QrDeliveryEventRow,
+} from '../../../src/repositories/inventory/InventoryHomologationRepository';
+
+export const TENANT = '11111111-1111-1111-1111-111111111111';
+export const USER = '22222222-2222-2222-2222-222222222222';
+export const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+export const OTHER_ITEM_ID = '99999999-9999-9999-9999-999999999999';
+export const RELEASE_ID = '55555555-5555-5555-5555-555555555555';
+export const HOMOLOG_ID = '66666666-6666-6666-6666-666666666666';
+export const BOX_ID = '77777777-7777-7777-7777-777777777777';
+export const UNIT_ID = '88888888-8888-8888-8888-888888888888';
+
+export const CTX = { tenantId: TENANT, userId: USER };
+
+export const BASE = 'https://produto.myio.com.br/';
+
+export function makeItem(overrides: Partial<InvItemRow> = {}): InvItemRow {
+  return {
+    id: ITEM_ID,
+    tenantId: TENANT,
+    name: 'Produto de teste',
+    normalizedName: 'produto de teste',
+    domain: 'PRODUCT',
+    link: null,
+    description: null,
+    isManufactured: true,
+    lossPercent: '0',
+    lotQuantity: null,
+    purchaseType: null,
+    photoFileId: null,
+    active: true,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    createdBy: null,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    updatedBy: null,
+    ...overrides,
+  } as InvItemRow;
+}
+
+let seq = 0;
+export function nextId(): string {
+  seq += 1;
+  return `00000000-0000-0000-0000-${String(seq).padStart(12, '0')}`;
+}
+
+export function makeHomologation(overrides: Partial<InvHomologationRow> = {}): InvHomologationRow {
+  return {
+    id: HOMOLOG_ID,
+    tenantId: TENANT,
+    releaseId: null,
+    itemId: ITEM_ID,
+    boxSize: 1,
+    boxQr: null,
+    responsibleId: null,
+    notes: null,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvHomologationRow;
+}
+
+export function makeUnit(overrides: Partial<InvHomologationUnitRow> = {}): InvHomologationUnitRow {
+  return {
+    id: UNIT_ID,
+    tenantId: TENANT,
+    homologationId: HOMOLOG_ID,
+    position: 1,
+    qrValue: '123_456',
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    ...overrides,
+  } as InvHomologationUnitRow;
+}
+
+export function makeRegistryRow(overrides: Partial<InvQrRegistryRow> = {}): InvQrRegistryRow {
+  return {
+    id: nextId(),
+    tenantId: TENANT,
+    qrValue: '123_456',
+    kind: 'UNIT',
+    itemId: ITEM_ID,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvQrRegistryRow;
+}
+
+export function makeMovementEvent(overrides: Partial<QrMovementEventRow> = {}): QrMovementEventRow {
+  return {
+    qrValue: '123_456',
+    boxQr: null,
+    movementId: nextId(),
+    type: 'ENTRADA',
+    location: 'ALMOXARIFADO',
+    quantity: '1',
+    reason: 'Homologação — unitário',
+    responsible: null,
+    createdBy: USER,
+    createdAt: new Date('2026-02-01T01:00:00Z'),
+    ...overrides,
+  };
+}
+
+export function makeDeliveryEvent(overrides: Partial<QrDeliveryEventRow> = {}): QrDeliveryEventRow {
+  return {
+    qrValue: '123_456',
+    boxQr: null,
+    deliveryId: nextId(),
+    orderItemId: nextId(),
+    orderId: nextId(),
+    orderTitle: 'Pedido Cliente X',
+    orderStatus: 'EM_TRANSITO',
+    createdBy: USER,
+    createdAt: new Date('2026-03-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Mock repositories/services
+// -----------------------------------------------------------------------------
+
+export type HomologRepoMock = jest.Mocked<IInventoryHomologationRepository>;
+
+export function makeHomologRepoMock(): HomologRepoMock {
+  return {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    getItem: jest.fn().mockResolvedValue(makeItem()),
+    releasedQuantity: jest.fn().mockResolvedValue(null),
+    homologatedCount: jest.fn().mockResolvedValue(0),
+    findRegistryByValues: jest.fn().mockResolvedValue([]),
+    insertRegistryRows: jest.fn().mockResolvedValue([]),
+    deleteRegistryByValues: jest.fn().mockResolvedValue(0),
+    insertHomologation: jest.fn(async (input: { tenantId: string }) =>
+      makeHomologation({ id: nextId(), ...(input as Partial<InvHomologationRow>) }),
+    ),
+    insertUnits: jest.fn(
+      async (_tenantId: string, homologationId: string, units: Array<{ qrValue: string; position?: number | null }>) =>
+        units.map((u, i) => makeUnit({ id: nextId(), homologationId, qrValue: u.qrValue, position: u.position ?? i + 1 })),
+    ),
+    getHomologationById: jest.fn().mockResolvedValue(null),
+    getUnitById: jest.fn().mockResolvedValue(null),
+    countUnits: jest.fn().mockResolvedValue(0),
+    unitsByHomologationIds: jest.fn().mockResolvedValue([]),
+    moveUnit: jest.fn().mockResolvedValue(makeUnit()),
+    deleteHomologation: jest.fn().mockResolvedValue(1),
+    list: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+    maxBoxSeq: jest.fn().mockResolvedValue(0),
+  } as unknown as HomologRepoMock;
+}
+
+export type QrRepoMock = jest.Mocked<IInventoryQrRepository>;
+
+export function makeQrRepoMock(): QrRepoMock {
+  return {
+    findRegistryByValues: jest.fn().mockResolvedValue([]),
+    findUnitsByQrValues: jest.fn().mockResolvedValue([]),
+    findBoxesByQrValues: jest.fn().mockResolvedValue([]),
+    unitsByHomologationIds: jest.fn().mockResolvedValue([]),
+    movementEventsByQrs: jest.fn().mockResolvedValue([]),
+    deliveryEventsByQrs: jest.fn().mockResolvedValue([]),
+    getExpeditionOrderItem: jest.fn().mockResolvedValue(null),
+  } as unknown as QrRepoMock;
+}
+
+export type StockServiceMock = jest.Mocked<IStockEntryService>;
+
+export function makeStockServiceMock(): StockServiceMock {
+  return {
+    createMovement: jest.fn().mockResolvedValue({ id: 'aaaaaaaa-0000-0000-0000-000000000001', qrs: [] }),
+  } as unknown as StockServiceMock;
+}

--- a/tests/unit/inventory/m5-homologation-service.test.ts
+++ b/tests/unit/inventory/m5-homologation-service.test.ts
@@ -1,0 +1,244 @@
+/**
+ * RFC-0061 M5 — InventoryHomologationService.createHomologation (mocked repo,
+ * no DB): box-size/box-QR shape rules, auto box-QR generation, GLOBAL
+ * duplicate detection (payload, registry pre-check and the 23505/err.cause
+ * backstop), remaining-to-homologate accounting, and the finishing ENTRADA
+ * into ALMOXARIFADO via the M2 stock service.
+ */
+
+import {
+  InventoryHomologationService,
+  CreateHomologationSchema,
+  boxQrPrefix,
+} from '../../../src/services/inventory/InventoryHomologationService';
+import { AppError, NotFoundError, ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  TENANT,
+  ITEM_ID,
+  RELEASE_ID,
+  makeItem,
+  makeRegistryRow,
+  makeHomologRepoMock,
+  makeStockServiceMock,
+  HomologRepoMock,
+  StockServiceMock,
+  BASE,
+} from './m5-helpers';
+
+let repo: HomologRepoMock;
+let stock: StockServiceMock;
+let service: InventoryHomologationService;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  repo = makeHomologRepoMock();
+  stock = makeStockServiceMock();
+  service = new InventoryHomologationService(repo, stock);
+});
+
+function unitDto(overrides: Record<string, unknown> = {}) {
+  return {
+    itemId: ITEM_ID,
+    boxSize: 1 as const,
+    units: [{ qrValue: '123_456' }],
+    ...overrides,
+  };
+}
+
+async function expectAppError(promise: Promise<unknown>, code: string, status: number): Promise<AppError> {
+  const err = (await promise.then(
+    () => {
+      throw new Error('expected rejection');
+    },
+    (e) => e,
+  )) as AppError;
+  expect(err).toBeInstanceOf(AppError);
+  expect(err.code).toBe(code);
+  expect(err.statusCode).toBe(status);
+  return err;
+}
+
+describe('createHomologation — shape rules', () => {
+  it('schema rejects a boxSize outside {1,10,50,100,224}', () => {
+    const parsed = CreateHomologationSchema.safeParse(unitDto({ boxSize: 5 }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('schema accepts every legal box size', () => {
+    for (const size of [1, 10, 50, 100, 224]) {
+      const parsed = CreateHomologationSchema.safeParse(unitDto({ boxSize: size }));
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it('rejects a boxQr on a unitary homologation (400)', async () => {
+    await expect(
+      service.createHomologation(CTX, unitDto({ boxQr: `${BASE}caixa-1/1` }) as never, 'k1'),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects a unitary homologation with more than one unit (400)', async () => {
+    await expect(
+      service.createHomologation(
+        CTX,
+        unitDto({ units: [{ qrValue: '1_2' }, { qrValue: '3_4' }] }) as never,
+        'k2',
+      ),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects more units than the box holds → 422 INV_BOX_TOO_BIG', async () => {
+    const dto = unitDto({
+      boxSize: 10,
+      units: Array.from({ length: 11 }, (_, i) => ({ qrValue: `1_${i}` })),
+    });
+    const err = await expectAppError(service.createHomologation(CTX, dto as never, 'k3'), 'INV_BOX_TOO_BIG', 422);
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual({ boxSize: 10, units: 11 });
+  });
+
+  it('404 when the item does not exist', async () => {
+    repo.getItem.mockResolvedValue(null);
+    await expect(service.createHomologation(CTX, unitDto() as never, 'k4')).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('400 when the item is not a PRODUCT', async () => {
+    repo.getItem.mockResolvedValue(makeItem({ domain: 'COMPONENT', isManufactured: false }));
+    await expect(service.createHomologation(CTX, unitDto() as never, 'k5')).rejects.toBeInstanceOf(ValidationError);
+  });
+});
+
+describe('createHomologation — GLOBAL QR duplicate detection (AC-3)', () => {
+  it('duplicate inside the payload → 409 INV_QR_DUPLICATE before any insert', async () => {
+    const dto = unitDto({ boxSize: 10, units: [{ qrValue: '1_2' }, { qrValue: '1_2' }] });
+    await expectAppError(service.createHomologation(CTX, dto as never, 'k6'), 'INV_QR_DUPLICATE', 409);
+    expect(repo.insertHomologation).not.toHaveBeenCalled();
+  });
+
+  it('box QR equal to a unit QR in the payload → 409 (cross box×unit)', async () => {
+    const dto = unitDto({ boxSize: 10, boxQr: '1_2', units: [{ qrValue: '1_2' }] });
+    const err = await expectAppError(service.createHomologation(CTX, dto as never, 'k7'), 'INV_QR_DUPLICATE', 409);
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual({ qrValue: '1_2' });
+  });
+
+  it('value already in inv_qr_registry (any kind) → 409 via the transactional pre-check', async () => {
+    repo.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: '123_456', kind: 'BOX' })]);
+    const err = await expectAppError(service.createHomologation(CTX, unitDto() as never, 'k8'), 'INV_QR_DUPLICATE', 409);
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual({ qrValue: '123_456' });
+    expect(repo.insertHomologation).not.toHaveBeenCalled();
+  });
+
+  it('concurrent duplicate past the pre-check → 23505 on err.cause mapped to 409', async () => {
+    // Drizzle wraps the driver error: SQLSTATE lives on cause.code (gotcha).
+    const wrapped = Object.assign(new Error('Failed query: insert into "inv_qr_registry" …'), {
+      cause: Object.assign(new Error('duplicate key value violates unique constraint "inv_qr_registry_uq"'), {
+        code: '23505',
+        detail: `Key (tenant_id, qr_value)=(${TENANT}, 123_456) already exists.`,
+      }),
+    });
+    repo.insertRegistryRows.mockRejectedValue(wrapped);
+    const err = await expectAppError(service.createHomologation(CTX, unitDto() as never, 'k9'), 'INV_QR_DUPLICATE', 409);
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual({ qrValue: '123_456' });
+  });
+});
+
+describe('createHomologation — remaining per release item (§M5)', () => {
+  it('404 when the release has no row for the item', async () => {
+    repo.releasedQuantity.mockResolvedValue(null);
+    await expect(
+      service.createHomologation(CTX, unitDto({ releaseId: RELEASE_ID }) as never, 'k10'),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('homologating above the remainder → 422 with released/homologated/remaining params', async () => {
+    repo.releasedQuantity.mockResolvedValue(10);
+    repo.homologatedCount.mockResolvedValue(8);
+    const dto = unitDto({ boxSize: 10, releaseId: RELEASE_ID, units: [{ qrValue: '1_1' }, { qrValue: '1_2' }, { qrValue: '1_3' }] });
+    const err = await expectAppError(
+      service.createHomologation(CTX, dto as never, 'k11'),
+      'INV_HOMOLOGATION_OVER_REMAINING',
+      422,
+    );
+    expect((err as AppError & { details?: Record<string, unknown> }).details).toEqual({
+      released: 10,
+      homologated: 8,
+      remaining: 2,
+      requested: 3,
+    });
+    expect(repo.insertHomologation).not.toHaveBeenCalled();
+  });
+
+  it('homologating exactly the remainder passes', async () => {
+    repo.releasedQuantity.mockResolvedValue(10);
+    repo.homologatedCount.mockResolvedValue(9);
+    const res = await service.createHomologation(CTX, unitDto({ releaseId: RELEASE_ID }) as never, 'k12');
+    expect(res.releaseId).toBe(RELEASE_ID);
+  });
+});
+
+describe('createHomologation — box QR auto-generation & stock entry', () => {
+  it('unitary: no box QR, registry gets one UNIT row, entrada "Homologação — unitário"', async () => {
+    const res = await service.createHomologation(CTX, unitDto() as never, 'k13');
+
+    expect(res.boxQr).toBeNull();
+    expect(res.units).toHaveLength(1);
+    expect(repo.insertRegistryRows).toHaveBeenCalledWith(
+      TENANT,
+      [expect.objectContaining({ qrValue: '123_456', kind: 'UNIT', itemId: ITEM_ID })],
+      expect.anything(),
+    );
+    expect(stock.createMovement).toHaveBeenCalledWith(
+      { tenantId: CTX.tenantId, userId: CTX.userId },
+      expect.objectContaining({
+        itemId: ITEM_ID,
+        location: 'ALMOXARIFADO',
+        quantity: 1,
+        type: 'ENTRADA',
+        reason: 'Homologação — unitário',
+        qrs: [expect.objectContaining({ qrValue: '123_456', homologationUnitId: expect.any(String) })],
+      }),
+      'homologation-entry:k13',
+    );
+    expect(res.movementId).toBe('aaaaaaaa-0000-0000-0000-000000000001');
+  });
+
+  it('box without boxQr: auto-generates <base>caixa-<N>/<seq> sequential per prefix', async () => {
+    repo.maxBoxSeq.mockResolvedValue(4);
+    const dto = unitDto({ boxSize: 10, units: [{ qrValue: '1_1' }, { qrValue: '1_2' }] });
+    const res = await service.createHomologation(CTX, dto as never, 'k14');
+
+    expect(repo.maxBoxSeq).toHaveBeenCalledWith(TENANT, boxQrPrefix(10), expect.anything());
+    expect(res.boxQr).toBe(`${BASE}caixa-10/5`);
+    // Registry gets the 2 UNIT rows + 1 BOX row (cross box×unit uniqueness).
+    const registryRows = repo.insertRegistryRows.mock.calls[0][1];
+    expect(registryRows).toHaveLength(3);
+    expect(registryRows[2]).toEqual(expect.objectContaining({ qrValue: `${BASE}caixa-10/5`, kind: 'BOX' }));
+    expect(stock.createMovement).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        quantity: 2,
+        reason: 'Homologação — caixa de 10',
+        qrs: [
+          expect.objectContaining({ qrValue: '1_1', boxQr: `${BASE}caixa-10/5` }),
+          expect.objectContaining({ qrValue: '1_2', boxQr: `${BASE}caixa-10/5` }),
+        ],
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('box with an explicit boxQr keeps it (no auto-generation)', async () => {
+    const dto = unitDto({ boxSize: 10, boxQr: `${BASE}caixa-10/99`, units: [{ qrValue: '1_1' }] });
+    const res = await service.createHomologation(CTX, dto as never, 'k15');
+    expect(repo.maxBoxSeq).not.toHaveBeenCalled();
+    expect(res.boxQr).toBe(`${BASE}caixa-10/99`);
+  });
+
+  it('replays the original result for the same Idempotency-Key (S1)', async () => {
+    const first = await service.createHomologation(CTX, unitDto() as never, 'same-key');
+    const second = await service.createHomologation(CTX, unitDto() as never, 'same-key');
+    expect(second).toBe(first);
+    expect(repo.insertHomologation).toHaveBeenCalledTimes(1);
+    expect(stock.createMovement).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/inventory/m5-qr-trace.test.ts
+++ b/tests/unit/inventory/m5-qr-trace.test.ts
@@ -1,0 +1,186 @@
+/**
+ * RFC-0061 M5 — GET /qr/trace/:code service logic (S5, mocked repo, no DB):
+ * input normalization (bare code vs full URL), 404 for unknown QRs, box
+ * expansion (flagged, units listed), and the normalized timeline
+ * {ts, type, actor, location, refs} merging homologation + ledger + baixas.
+ */
+
+import { InventoryQrService, normalizeQrInput } from '../../../src/services/inventory/InventoryQrService';
+import { NotFoundError } from '../../../src/shared/errors/AppError';
+import {
+  TENANT,
+  ITEM_ID,
+  BOX_ID,
+  BASE,
+  USER,
+  makeHomologation,
+  makeUnit,
+  makeMovementEvent,
+  makeDeliveryEvent,
+  makeQrRepoMock,
+  QrRepoMock,
+  nextId,
+} from './m5-helpers';
+
+let repo: QrRepoMock;
+let service: InventoryQrService;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  repo = makeQrRepoMock();
+  service = new InventoryQrService(repo);
+});
+
+describe('normalizeQrInput (S5 input contract)', () => {
+  it('keeps a bare code and adds the URL spelling as a candidate', () => {
+    const n = normalizeQrInput('123_456_789');
+    expect(n.code).toBe('123_456_789');
+    expect(n.candidates).toEqual(expect.arrayContaining(['123_456_789', `${BASE}123_456_789`]));
+  });
+
+  it('strips the https URL prefix (camera scan)', () => {
+    const n = normalizeQrInput(`${BASE}123_456`);
+    expect(n.code).toBe('123_456');
+    expect(n.candidates).toEqual(expect.arrayContaining([`${BASE}123_456`, '123_456']));
+  });
+
+  it('strips an http:// spelling and trims whitespace', () => {
+    expect(normalizeQrInput(` http://produto.myio.com.br/9_9 `).code).toBe('9_9');
+  });
+});
+
+describe('trace — unit QR', () => {
+  function setupUnit() {
+    const homologation = makeHomologation({
+      id: nextId(),
+      boxSize: 10,
+      boxQr: `${BASE}caixa-10/1`,
+      responsibleId: USER,
+      createdAt: new Date('2026-02-01T00:00:00Z'),
+    });
+    const unit = makeUnit({
+      id: nextId(),
+      homologationId: homologation.id,
+      qrValue: '123_456',
+      createdAt: new Date('2026-02-01T00:00:00Z'),
+    });
+    repo.findUnitsByQrValues.mockResolvedValue([{ unit, homologation }]);
+    return { unit, homologation };
+  }
+
+  it('unknown QR → 404', async () => {
+    await expect(service.trace(TENANT, 'does-not-exist')).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('accepts the full URL and answers with the normalized bare code', async () => {
+    setupUnit();
+    const res = await service.trace(TENANT, `${BASE}123_456`);
+    expect(res.code).toBe('123_456');
+    expect(res.isBox).toBe(false);
+  });
+
+  it('timeline merges homologation + ledger + baixa, sorted by ts, with normalized events', async () => {
+    const { homologation } = setupUnit();
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({
+        qrValue: '123_456',
+        type: 'ENTRADA',
+        location: 'ALMOXARIFADO',
+        createdAt: new Date('2026-02-01T01:00:00Z'),
+      }),
+      makeMovementEvent({
+        qrValue: '123_456',
+        type: 'SAIDA',
+        location: 'ALMOXARIFADO',
+        reason: 'Saída p/ técnico',
+        createdAt: new Date('2026-02-10T00:00:00Z'),
+      }),
+    ]);
+    repo.deliveryEventsByQrs.mockResolvedValue([
+      makeDeliveryEvent({ qrValue: '123_456', createdAt: new Date('2026-03-01T00:00:00Z') }),
+    ]);
+
+    const res = await service.trace(TENANT, '123_456');
+
+    expect(res.timeline.map((e) => e.type)).toEqual([
+      'HOMOLOGACAO',
+      'ENTRADA_ESTOQUE',
+      'SAIDA_ESTOQUE',
+      'EXPEDICAO_BAIXA',
+    ]);
+    // Every event carries the normalized envelope.
+    for (const event of res.timeline) {
+      expect(event).toEqual(
+        expect.objectContaining({
+          ts: expect.any(String),
+          type: expect.any(String),
+          refs: expect.any(Object),
+        }),
+      );
+    }
+    expect(res.timeline[0].refs).toEqual(
+      expect.objectContaining({ homologationId: homologation.id, itemId: ITEM_ID, boxQr: `${BASE}caixa-10/1` }),
+    );
+    // Latest fact is the expedition baixa → current reflects it.
+    expect(res.current).toEqual({ location: 'EXPEDICAO', status: 'EM_TRANSITO', client: 'Pedido Cliente X' });
+  });
+
+  it('current = EM_ESTOQUE at the last entry location when never exited', async () => {
+    setupUnit();
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '123_456', type: 'ENTRADA', location: 'ALMOXARIFADO' }),
+    ]);
+    const res = await service.trace(TENANT, '123_456');
+    expect(res.current).toEqual({ location: 'ALMOXARIFADO', status: 'EM_ESTOQUE', client: null });
+  });
+
+  it('current = BAIXADO when the latest ledger event is an exit', async () => {
+    setupUnit();
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '123_456', type: 'ENTRADA', createdAt: new Date('2026-02-01T01:00:00Z') }),
+      makeMovementEvent({ qrValue: '123_456', type: 'SAIDA', createdAt: new Date('2026-02-02T00:00:00Z') }),
+    ]);
+    const res = await service.trace(TENANT, '123_456');
+    expect(res.current).toEqual({ location: null, status: 'BAIXADO', client: null });
+  });
+
+  it('flags ledger events that reached the unit through its box QR', async () => {
+    setupUnit();
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: null, boxQr: `${BASE}caixa-10/1`, type: 'ENTRADA' }),
+    ]);
+    const res = await service.trace(TENANT, '123_456');
+    const entry = res.timeline.find((e) => e.type === 'ENTRADA_ESTOQUE');
+    expect(entry?.refs).toEqual(expect.objectContaining({ viaBoxQr: `${BASE}caixa-10/1` }));
+  });
+
+  it('no ledger events yet → HOMOLOGADO in ALMOXARIFADO', async () => {
+    setupUnit();
+    const res = await service.trace(TENANT, '123_456');
+    expect(res.current).toEqual({ location: 'ALMOXARIFADO', status: 'HOMOLOGADO', client: null });
+  });
+});
+
+describe('trace — box QR', () => {
+  const BOX_QR = `${BASE}caixa-50/3`;
+
+  it('expands the units and flags the response as box', async () => {
+    const box = makeHomologation({ id: BOX_ID, boxSize: 50, boxQr: BOX_QR, createdAt: new Date('2026-02-01T00:00:00Z') });
+    repo.findBoxesByQrValues.mockResolvedValue([box]);
+    repo.unitsByHomologationIds.mockResolvedValue([
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '1_1' }),
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '1_2' }),
+    ]);
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: null, boxQr: BOX_QR, type: 'ENTRADA', createdAt: new Date('2026-02-01T01:00:00Z') }),
+    ]);
+
+    const res = await service.trace(TENANT, `caixa-50/3`);
+
+    expect(res.isBox).toBe(true);
+    expect(res.units).toEqual(['1_1', '1_2']);
+    expect(res.timeline.map((e) => e.type)).toEqual(['HOMOLOGACAO', 'ENTRADA_ESTOQUE']);
+    expect(res.timeline[0].refs).toEqual(expect.objectContaining({ boxSize: 50, unitCount: 2 }));
+    expect(res.current).toEqual({ location: 'ALMOXARIFADO', status: 'EM_ESTOQUE', client: null });
+  });
+});

--- a/tests/unit/inventory/m5-qr-validate.test.ts
+++ b/tests/unit/inventory/m5-qr-validate.test.ts
@@ -1,0 +1,184 @@
+/**
+ * RFC-0061 M5 — POST /qr/validate service logic (S2, mocked repo, no DB):
+ * per-code verdicts (ok / INV_QR_NOT_IN_REGISTRY / INV_QR_ALREADY_USED /
+ * INV_QR_WRONG_ITEM), box expansion, context resolution from orderItemId,
+ * and the guarantee that a batch NEVER fails as a whole.
+ */
+
+import { InventoryQrService } from '../../../src/services/inventory/InventoryQrService';
+import {
+  TENANT,
+  ITEM_ID,
+  OTHER_ITEM_ID,
+  BOX_ID,
+  BASE,
+  makeHomologation,
+  makeUnit,
+  makeRegistryRow,
+  makeMovementEvent,
+  makeDeliveryEvent,
+  makeQrRepoMock,
+  QrRepoMock,
+  nextId,
+} from './m5-helpers';
+
+let repo: QrRepoMock;
+let service: InventoryQrService;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  repo = makeQrRepoMock();
+  service = new InventoryQrService(repo);
+});
+
+function homologatedUnit(qrValue: string, overrides: Record<string, unknown> = {}) {
+  const homologation = makeHomologation({ id: nextId(), boxSize: 1, ...overrides });
+  return { unit: makeUnit({ id: nextId(), homologationId: homologation.id, qrValue }), homologation };
+}
+
+describe('validate — unit verdicts', () => {
+  it('homologated, never exited → ok with itemId', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+    repo.movementEventsByQrs.mockResolvedValue([makeMovementEvent({ qrValue: '123_456', type: 'ENTRADA' })]);
+
+    const { results } = await service.validate(TENANT, { codes: ['123_456'] });
+    expect(results).toEqual([{ code: '123_456', ok: true, itemId: ITEM_ID }]);
+  });
+
+  it('unknown code → INV_QR_NOT_IN_REGISTRY (batch still 1 verdict per code)', async () => {
+    const { results } = await service.validate(TENANT, { codes: ['999_999'] });
+    expect(results).toEqual([{ code: '999_999', ok: false, reason: 'INV_QR_NOT_IN_REGISTRY' }]);
+  });
+
+  it('latest ledger event is an exit → INV_QR_ALREADY_USED', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '123_456', type: 'ENTRADA', createdAt: new Date('2026-02-01T00:00:00Z') }),
+      makeMovementEvent({ qrValue: '123_456', type: 'SAIDA', createdAt: new Date('2026-02-02T00:00:00Z') }),
+    ]);
+
+    const { results } = await service.validate(TENANT, { codes: ['123_456'] });
+    expect(results[0]).toEqual(expect.objectContaining({ ok: false, reason: 'INV_QR_ALREADY_USED' }));
+  });
+
+  it('re-entered after an exit (latest = ENTRADA) → ok again', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '123_456', type: 'SAIDA', createdAt: new Date('2026-02-02T00:00:00Z') }),
+      makeMovementEvent({ qrValue: '123_456', type: 'ENTRADA', createdAt: new Date('2026-02-03T00:00:00Z') }),
+    ]);
+
+    const { results } = await service.validate(TENANT, { codes: ['123_456'] });
+    expect(results[0].ok).toBe(true);
+  });
+
+  it('expedition baixa (inv_delivery_qrs row) → INV_QR_ALREADY_USED', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+    repo.deliveryEventsByQrs.mockResolvedValue([makeDeliveryEvent({ qrValue: '123_456' })]);
+
+    const { results } = await service.validate(TENANT, { codes: ['123_456'] });
+    expect(results[0]).toEqual(expect.objectContaining({ ok: false, reason: 'INV_QR_ALREADY_USED' }));
+  });
+
+  it('expectedItemId mismatch → INV_QR_WRONG_ITEM', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+
+    const { results } = await service.validate(TENANT, {
+      codes: ['123_456'],
+      expectedItemId: OTHER_ITEM_ID,
+    });
+    expect(results[0]).toEqual(
+      expect.objectContaining({ ok: false, reason: 'INV_QR_WRONG_ITEM', itemId: ITEM_ID }),
+    );
+  });
+
+  it('resolves the expected item from orderItemId when expectedItemId is absent', async () => {
+    const orderItemId = nextId();
+    repo.getExpeditionOrderItem.mockResolvedValue({ id: orderItemId, itemId: OTHER_ITEM_ID, orderId: nextId() });
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+
+    const { results } = await service.validate(TENANT, { codes: ['123_456'], orderItemId });
+    expect(repo.getExpeditionOrderItem).toHaveBeenCalledWith(TENANT, orderItemId);
+    expect(results[0].reason).toBe('INV_QR_WRONG_ITEM');
+  });
+
+  it('accepts the full URL spelling (camera scan) for a stored bare code', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('123_456')]);
+    const { results } = await service.validate(TENANT, { codes: [`${BASE}123_456`] });
+    expect(results[0]).toEqual(expect.objectContaining({ code: `${BASE}123_456`, ok: true }));
+  });
+
+  it('registry-only QR (not yet homologated locally) still validates by item', async () => {
+    repo.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: '77_77' })]);
+    const { results } = await service.validate(TENANT, { codes: ['77_77'] });
+    expect(results[0]).toEqual({ code: '77_77', ok: true, itemId: ITEM_ID });
+  });
+});
+
+describe('validate — box expansion', () => {
+  const BOX_QR = `${BASE}caixa-10/1`;
+
+  function setupBox() {
+    const box = makeHomologation({ id: BOX_ID, boxSize: 10, boxQr: BOX_QR });
+    repo.findBoxesByQrValues.mockResolvedValue([box]);
+    repo.unitsByHomologationIds.mockResolvedValue([
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '1_1' }),
+      makeUnit({ id: nextId(), homologationId: BOX_ID, qrValue: '1_2' }),
+    ]);
+    return box;
+  }
+
+  it('box QR expands its units, all active → ok with isBox + units', async () => {
+    setupBox();
+    const { results } = await service.validate(TENANT, { codes: [BOX_QR] });
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        code: BOX_QR,
+        ok: true,
+        isBox: true,
+        itemId: ITEM_ID,
+        units: [
+          { qrValue: '1_1', ok: true },
+          { qrValue: '1_2', ok: true },
+        ],
+      }),
+    );
+  });
+
+  it('box with a spent unit → ok=false, per-unit verdicts kept', async () => {
+    setupBox();
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '1_2', type: 'SAIDA', createdAt: new Date('2026-02-05T00:00:00Z') }),
+    ]);
+    const { results } = await service.validate(TENANT, { codes: [BOX_QR] });
+    expect(results[0].ok).toBe(false);
+    expect(results[0].units).toEqual([
+      { qrValue: '1_1', ok: true },
+      { qrValue: '1_2', ok: false, reason: 'INV_QR_ALREADY_USED' },
+    ]);
+  });
+
+  it('box of another material → INV_QR_WRONG_ITEM (units still listed)', async () => {
+    setupBox();
+    const { results } = await service.validate(TENANT, { codes: [BOX_QR], expectedItemId: OTHER_ITEM_ID });
+    expect(results[0]).toEqual(
+      expect.objectContaining({ ok: false, reason: 'INV_QR_WRONG_ITEM', isBox: true }),
+    );
+    expect(results[0].units).toHaveLength(2);
+  });
+});
+
+describe('validate — batch semantics (S2)', () => {
+  it('mixed batch returns one verdict per code and never throws', async () => {
+    repo.findUnitsByQrValues.mockResolvedValue([homologatedUnit('1_1')]);
+    repo.movementEventsByQrs.mockResolvedValue([
+      makeMovementEvent({ qrValue: '1_1', type: 'SAIDA', createdAt: new Date('2026-02-02T00:00:00Z') }),
+    ]);
+
+    const { results } = await service.validate(TENANT, { codes: ['1_1', 'nope', `${BASE}2_2`] });
+    expect(results).toHaveLength(3);
+    expect(results[0].reason).toBe('INV_QR_ALREADY_USED');
+    expect(results[1].reason).toBe('INV_QR_NOT_IN_REGISTRY');
+    expect(results[2].reason).toBe('INV_QR_NOT_IN_REGISTRY');
+  });
+});


### PR DESCRIPTION
## RFC-0061 — M5 Homologação & QR (P2)

Implements §M5 on top of the M1/M2/M9 base: homologation (unitário + caixas), the QR registry as identity source (A2), scan-time validation (S2) and traceability (S5).

### What's in

**`InventoryHomologationRepository`** (new)
- Owns `inv_homologations`, `inv_homologation_units`, `inv_qr_registry`; read paths over `inv_assembly_release_items` (remaining accounting), `inv_movement_qrs → inv_stock_movements` (ledger events per QR, unit **or** box spelling) and `inv_delivery_qrs → inv_item_deliveries → inv_expedition_orders` (expedition baixas — empty until M6, handled as "no baixa yet").

**`InventoryHomologationService`** (new)
- **Create homologation**: `box_size ∈ {1,10,50,100,224}` (schema-enforced); box QR mandatory for boxes — auto-generated sequentially per size prefix (`https://produto.myio.com.br/caixa-<N>/<seq>`) when not sent; unitário rejects a box QR and requires exactly 1 unit; more units than the box holds → 422 `INV_BOX_TOO_BIG`.
- **Global duplicate detection (AC-3)**: in-payload check + transactional pre-check against `inv_qr_registry` (friendly params) + the 23505 backstop read from `err.cause` (Drizzle gotcha) → 409 `INV_QR_DUPLICATE`. Units and the box QR are inserted into the registry in the same transaction (cross box×unit uniqueness by constraint).
- **Remaining per release item**: `sum(released) − count(homologated)`; homologating above the remainder → 422 `INV_HOMOLOGATION_OVER_REMAINING` with `{released, homologated, remaining, requested}` (Appendix D has no code for this case — module-local code, same envelope).
- **Finish = ENTRADA in ALMOXARIFADO** via `inventoryStockService.createMovement` (reason `Homologação — unitário` / `caixa de N`), QRs linked (`qrValue` + `boxQr` + `homologationUnitId`) so the ledger becomes the QR's event source.
- **Box ops**: `add-unit` (same-material incomplete box; `INV_BOX_FULL` / `INV_QR_WRONG_ITEM` / 404s; emptied source homologation deleted), `remove-from-box` (unit becomes a `box_size=1` homologation; an emptied box is deleted and its box-QR identity released from the registry; unit not in a box → 422 `INV_BOX_EMPTY`).
- Paginated `GET /homologations` and `GET /homologations/boxes` (with `unitCount`/`isFull`).

**`InventoryQrService`** (new)
- **`POST /qr/validate` (S2)**: batch of codes + context (`expectedItemId?`, `orderItemId?` — resolved to the order item's `item_id`); per-code verdict `ok | INV_QR_NOT_IN_REGISTRY | INV_QR_ALREADY_USED | INV_QR_WRONG_ITEM`; "used" = any expedition baixa OR latest ledger event is an exit (re-entry reactivates); box QRs expand their units with per-unit verdicts (`isBox`, `units[]`). Always 200 — the batch never fails as a whole.
- **`GET /qr/trace/:code` (S5)**: accepts the bare code (`\d+(_\d+)+`) or the full (URL-encoded) `https://produto.myio.com.br/<code>` URL; response = current-state header (`location/status/client`) + normalized timeline `{ts, type, actor, location, refs}` merging homologação, ledger entries/exits (box-membership events flagged `viaBoxQr`), expedition baixas; unknown QR → 404; box QR expands its units flagged `isBox`.

**`homologation.controller.ts`** — real routes replace the 501 defers; **`POST /qr/generate` intentionally stays 501**: it delegates QR generation to the external platform, whose client ships with M8 (v1 keeps external-only generation — RFC Unresolved q.3).

### Tests (65 new, all green)
- `m5-homologation-service`: shape rules, auto box-QR sequencing, global duplicity (payload / registry pre-check / 23505-cause backstop), remaining accounting, stock-entry wiring, idempotency replay.
- `m5-box-ops`: add-unit (full/wrong-item/404s, emptied source deletion + box-QR release), remove-from-box (solo creation, emptied-box deletion, `INV_BOX_EMPTY`).
- `m5-qr-validate`: all verdicts, box expansion, orderItemId resolution, URL normalization, batch semantics.
- `m5-qr-trace`: input normalization (bare/https/http/trim), 404, box expansion, merged sorted timeline, current-state derivation.
- `m5-contract`: real router + real auth chain, services mocked — guards (`INV_IDEMPOTENCY_KEY_MISSING`, DTO 400), 201/200 flows, trace URL-decoding, `/qr/generate` 501.

`inventory.contract.test.ts` had no remaining M5 cases (all four supersessions were dropped in 08dc614), so it is untouched and still green.

### Verification
- `tsc --noEmit` ✅ · `eslint --max-warnings 0` on all new/changed files ✅ · `jest tests/unit/inventory + inventory.contract` → 17 suites / 189 tests ✅

### Boundary
Only `homologation.controller.ts` edited; everything else is new files under `repositories/inventory`, `services/inventory`, `tests/unit/inventory`. M1/M2 imported, not modified. No schema/DTO/error/app.ts changes — M5 request DTOs are defined in the service module (RFC allows later phases to finalize DTOs at implementation time).

### Follow-ups
1. **Atomicity of the finishing ENTRADA**: the stock movement runs in `InventoryStockService`'s own transaction after the homologation transaction commits (M2 owns the ledger boundary). A failure between the two leaves a homologation without its stock entry. Suggest a shared-transaction seam (stock service accepting an external `tx`) or an outbox-style completion.
2. **`POST /qr/generate`** stays 501 until the M8 external-platform client lands (P4).
3. **Box-QR sequence reuse**: an emptied box releases its QR from the registry; a later auto-generation could reuse the freed `caixa-<N>/<seq>` tail (historic ledger rows keep the old spelling). Harmless for the current flows; revisit if box QRs must be eternally unique.
4. **Durable idempotency** (`inv_idempotency_keys`) still pending — M5 reuses the M2 per-process cache pattern (same standing follow-up as the M2 PR).
5. `trace` client field currently surfaces the expedition order's title; once M6/M7 land, wire it to the customer snapshot (`inv_unit_products.client_name_snapshot`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
