### PR TITLE
feat(inventory): M7 field tracking (P3)

### DIFF
--- a/src/controllers/inventory/field.controller.ts
+++ b/src/controllers/inventory/field.controller.ts
@@ -1,18 +1,145 @@
-import { Router } from 'express';
-import { defer, requireUuid } from './shared';
-import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireIdempotencyKey } from './shared';
+import {
+  inventoryFieldService,
+  UnitProductListQuerySchema,
+  CreateUnitProductSchema,
+  UpdateUnitProductSchema,
+  MoveUnitProductSchema,
+  TechnicianItemsQuerySchema,
+  CreateTechnicianMoveSchema,
+  DamagedListQuerySchema,
+  CreateDamagedItemSchema,
+  RecoverDamagedItemSchema,
+} from '../../services/inventory/InventoryFieldService';
+import { sendSuccess, sendCreated } from '../../middleware/response';
 
-// M7 — Campo (P3)
+// M7 — Campo (P3). Real routes (RFC-0061 §M7): unit products at the client
+// (install toggle + move-out), technician custody (dispatches = SAIDAs with a
+// responsible; per-dispatch remaining) and damaged items (report + recovery).
+// ANTI-DOUBLE-COUNT: field moves are tracking-only — only destination
+// ALMOXARIFADO writes an ENTRADA (with QR re-link so the M8 sync keeps it);
+// the movement-writing POSTs therefore require an Idempotency-Key (S1).
 const router = Router();
 
-router.get('/unit-products', defer('M7', 'P3', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.post('/unit-products', defer('M7', 'P3'));
-router.patch('/unit-products/:id', defer('M7', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.post('/unit-products/:id/move', defer('M7', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.get('/technician-items', defer('M7', 'P3'));
-router.post('/technician-moves', defer('M7', 'P3'));
-router.get('/damaged-items', defer('M7', 'P3', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.post('/damaged-items', defer('M7', 'P3'));
-router.post('/damaged-items/:id/recover', defer('M7', 'P3', (req) => { requireUuid('id', req.params.id); }));
+// GET /unit-products — paginated; default shows active units (moved_to IS NULL).
+router.get('/unit-products', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = UnitProductListQuerySchema.parse(req.query);
+    const data = await inventoryFieldService.listUnitProducts(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /unit-products — create at the client (status PARADO; optional label =
+// available homologated QR, validated against the M5 registry).
+router.post('/unit-products', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const dto = CreateUnitProductSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.createUnitProduct({ tenantId, userId }, dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PATCH /unit-products/:id — INSTALADO/PARADO toggle (stamps installed_at).
+router.patch('/unit-products/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = UpdateUnitProductSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.updateUnitProduct({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /unit-products/:id/move — destino TECNICO|ALMOXARIFADO|PERDIDO|AVARIADO.
+// Only ALMOXARIFADO writes stock (ENTRADA "Devolução do cliente" + QR re-link).
+router.post('/unit-products/:id/move', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = MoveUnitProductSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.moveUnitProduct({ tenantId, userId }, req.params.id, dto, idempotencyKey);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /technician-items — dispatches grouped by technician; zeroed omitted.
+router.get('/technician-items', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = TechnicianItemsQuerySchema.parse(req.query);
+    const data = await inventoryFieldService.listTechnicianItems(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /technician-moves — destino UNIDADE|PERDIDO|ALMOXARIFADO|AVARIADO; qty
+// 1..restante. Only ALMOXARIFADO writes stock ("Devolução do técnico <nome>").
+router.post('/technician-moves', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateTechnicianMoveSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.createTechnicianMove({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /damaged-items — paginated, AVARIADO first.
+router.get('/damaged-items', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = DamagedListQuerySchema.parse(req.query);
+    const data = await inventoryFieldService.listDamagedItems(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /damaged-items — report damage FROM STOCK (balance-guarded SAIDA
+// "Item avariado — <motivo>"); client/technician damage comes via the moves.
+router.post('/damaged-items', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = CreateDamagedItemSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.createDamagedItem({ tenantId, userId }, dto, idempotencyKey);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /damaged-items/:id/recover — destino ESTOQUE|TECNICO|UNIDADE; always an
+// ENTRADA "Recuperação de item avariado" (+ QR re-link from source_detail).
+router.post('/damaged-items/:id/recover', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const idempotencyKey = requireIdempotencyKey(req);
+    const dto = RecoverDamagedItemSchema.parse(req.body ?? {});
+    const data = await inventoryFieldService.recoverDamagedItem({ tenantId, userId }, req.params.id, dto, idempotencyKey);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/repositories/inventory/InventoryFieldRepository.ts
+++ b/src/repositories/inventory/InventoryFieldRepository.ts
@@ -1,0 +1,505 @@
+// =============================================================================
+// RFC-0061 M7 — Field repository (data access only).
+//
+// Owns `inv_unit_products`, `inv_technician_moves` and `inv_damaged_items`,
+// plus the M7 read views over the M2 ledger (technician dispatches = SAIDA
+// movements with a responsible). All mutating methods accept an optional
+// executor so the service composes them inside ONE transaction with the M2
+// stock repository (same seam pattern as M4 — "every mutating method accepts
+// an optional executor"); `withTransaction` exposes the boundary.
+// =============================================================================
+
+import { and, desc, eq, inArray, isNull, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+
+const {
+  invItems,
+  invProjects,
+  invStockMovements,
+  invMovementQrs,
+  invUnitProducts,
+  invTechnicianMoves,
+  invDamagedItems,
+} = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as InventoryStockRepository)
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type FieldTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type FieldDbClient = typeof db | FieldTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvUnitProductRow = typeof invUnitProducts.$inferSelect;
+export type InvTechnicianMoveRow = typeof invTechnicianMoves.$inferSelect;
+export type InvDamagedItemRow = typeof invDamagedItems.$inferSelect;
+export type InvStockMovementRow = typeof invStockMovements.$inferSelect;
+export type InvMovementQrRow = typeof invMovementQrs.$inferSelect;
+export type InvProjectRow = typeof invProjects.$inferSelect;
+
+/** Unit-product listing row (joined names for the client screen). */
+export interface UnitProductListRow {
+  unit: InvUnitProductRow;
+  itemName: string | null;
+  projectName: string | null;
+}
+
+export interface UnitProductListFilters {
+  page: number;
+  pageSize: number;
+  /** Default listing shows only ACTIVE units (moved_to IS NULL). */
+  includeMoved?: boolean;
+  projectId?: string;
+  status?: string;
+}
+
+export interface NewUnitProductInput {
+  tenantId: string;
+  itemId?: string | null;
+  label?: string | null;
+  status?: string;
+  projectId?: string | null;
+  customerId?: string | null;
+  clientNameSnapshot?: string | null;
+  expeditionOrderId?: string | null;
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface UnitMoveFields {
+  movedTo: string;
+  movedTechnician?: string | null;
+  movePhotoFileId?: string | null;
+  movedAt: Date;
+  moveNotes?: string | null;
+}
+
+/** One technician dispatch = SAIDA movement with a responsible (§M7). */
+export interface DispatchRow {
+  movementId: string;
+  itemId: string;
+  itemName: string | null;
+  technician: string;
+  location: string;
+  quantity: string;
+  /** Σ inv_technician_moves.quantity already consumed from this dispatch. */
+  movedQuantity: number;
+  reason: string | null;
+  createdAt: Date;
+}
+
+export interface NewTechnicianMoveInput {
+  tenantId: string;
+  movementId: string;
+  itemId?: string | null;
+  technician?: string | null;
+  destination: string;
+  projectId?: string | null;
+  quantity: number;
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewDamagedItemInput {
+  tenantId: string;
+  itemId?: string | null;
+  productNameSnapshot?: string | null;
+  quantity: number;
+  source?: string | null;
+  sourceDetail?: string | null;
+  reason?: string | null;
+  photoFileId?: string | null;
+  createdBy?: string | null;
+}
+
+export interface DamagedListFilters {
+  page: number;
+  pageSize: number;
+  status?: string;
+}
+
+export interface DamagedRecoveryFields {
+  recoveredTo: string;
+  recoveryNotes?: string | null;
+  recoveredBy?: string | null;
+  recoveredAt: Date;
+}
+
+export class InventoryFieldRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  /** Runs `fn` inside one DB transaction (M7 composition seam — M4 pattern). */
+  async withTransaction<T>(fn: (tx: FieldTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unit products (Cliente)
+  // ---------------------------------------------------------------------------
+
+  async listUnitProducts(
+    tenantId: string,
+    filters: UnitProductListFilters,
+    client: FieldDbClient = db,
+  ): Promise<{ rows: UnitProductListRow[]; total: number }> {
+    const conditions: (SQL | undefined)[] = [eq(invUnitProducts.tenantId, tenantId)];
+    if (!filters.includeMoved) conditions.push(isNull(invUnitProducts.movedTo));
+    if (filters.projectId) conditions.push(eq(invUnitProducts.projectId, filters.projectId));
+    if (filters.status) conditions.push(eq(invUnitProducts.status, filters.status));
+    const where = and(...conditions);
+
+    const rows = await client
+      .select({
+        unit: invUnitProducts,
+        itemName: invItems.name,
+        projectName: invProjects.name,
+      })
+      .from(invUnitProducts)
+      .leftJoin(invItems, eq(invItems.id, invUnitProducts.itemId))
+      .leftJoin(invProjects, eq(invProjects.id, invUnitProducts.projectId))
+      .where(where)
+      .orderBy(desc(invUnitProducts.createdAt), desc(invUnitProducts.id))
+      .limit(filters.pageSize)
+      .offset((filters.page - 1) * filters.pageSize);
+
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invUnitProducts)
+      .where(where);
+
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  async getUnitProduct(
+    tenantId: string,
+    id: string,
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow | null> {
+    const [row] = await client
+      .select()
+      .from(invUnitProducts)
+      .where(and(eq(invUnitProducts.tenantId, tenantId), eq(invUnitProducts.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /** Lock the unit row for the move/toggle transaction (`FOR UPDATE`). */
+  async getUnitProductForUpdate(
+    tenantId: string,
+    id: string,
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow | null> {
+    const [row] = await client
+      .select()
+      .from(invUnitProducts)
+      .where(and(eq(invUnitProducts.tenantId, tenantId), eq(invUnitProducts.id, id)))
+      .limit(1)
+      .for('update');
+    return row ?? null;
+  }
+
+  /**
+   * Find a unit product holding `label`. `activeOnly` restricts to units still
+   * at the client (moved_to IS NULL) — the M5-label validation rule; the DB
+   * unique index however spans ALL rows, so callers that insert should check
+   * without the flag (a moved unit keeps its label for history).
+   */
+  async findUnitByLabel(
+    tenantId: string,
+    label: string,
+    activeOnly: boolean,
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow | null> {
+    const conditions: (SQL | undefined)[] = [
+      eq(invUnitProducts.tenantId, tenantId),
+      eq(invUnitProducts.label, label),
+    ];
+    if (activeOnly) conditions.push(isNull(invUnitProducts.movedTo));
+    const [row] = await client
+      .select()
+      .from(invUnitProducts)
+      .where(and(...conditions))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async insertUnitProducts(
+    inputs: NewUnitProductInput[],
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow[]> {
+    if (inputs.length === 0) return [];
+    return client
+      .insert(invUnitProducts)
+      .values(
+        inputs.map((input) => ({
+          tenantId: input.tenantId,
+          itemId: input.itemId ?? null,
+          label: input.label ?? null,
+          status: input.status ?? 'PARADO',
+          projectId: input.projectId ?? null,
+          customerId: input.customerId ?? null,
+          clientNameSnapshot: input.clientNameSnapshot ?? null,
+          expeditionOrderId: input.expeditionOrderId ?? null,
+          notes: input.notes ?? null,
+          createdBy: input.createdBy ?? null,
+        })),
+      )
+      .returning();
+  }
+
+  /** INSTALADO/PARADO toggle — installed_at set/cleared with the status. */
+  async updateUnitStatus(
+    tenantId: string,
+    id: string,
+    status: string,
+    installedAt: Date | null,
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow | null> {
+    const [row] = await client
+      .update(invUnitProducts)
+      .set({ status, installedAt, updatedAt: new Date() })
+      .where(and(eq(invUnitProducts.tenantId, tenantId), eq(invUnitProducts.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  async markUnitMoved(
+    tenantId: string,
+    id: string,
+    fields: UnitMoveFields,
+    client: FieldDbClient = db,
+  ): Promise<InvUnitProductRow | null> {
+    const [row] = await client
+      .update(invUnitProducts)
+      .set({
+        movedTo: fields.movedTo,
+        movedTechnician: fields.movedTechnician ?? null,
+        movePhotoFileId: fields.movePhotoFileId ?? null,
+        movedAt: fields.movedAt,
+        moveNotes: fields.moveNotes ?? null,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(invUnitProducts.tenantId, tenantId), eq(invUnitProducts.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Technician custody (Técnico)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Technician dispatches: SAIDA movements with a responsible (§M7), each with
+   * the Σ of its inv_technician_moves (correlated subquery — the per-dispatch
+   * remaining is quantity − movedQuantity, computed by the service).
+   */
+  async listDispatches(tenantId: string, client: FieldDbClient = db): Promise<DispatchRow[]> {
+    const movedQuantityExpr = sql<number>`coalesce((
+      select sum(tm.quantity)::int
+      from inv_technician_moves tm
+      where tm.movement_id = ${invStockMovements.id}
+    ), 0)`;
+
+    const rows = await client
+      .select({
+        movementId: invStockMovements.id,
+        itemId: invStockMovements.itemId,
+        itemName: invItems.name,
+        technician: invStockMovements.responsible,
+        location: invStockMovements.location,
+        quantity: invStockMovements.quantity,
+        movedQuantity: movedQuantityExpr,
+        reason: invStockMovements.reason,
+        createdAt: invStockMovements.createdAt,
+      })
+      .from(invStockMovements)
+      .leftJoin(invItems, eq(invItems.id, invStockMovements.itemId))
+      .where(
+        and(
+          eq(invStockMovements.tenantId, tenantId),
+          eq(invStockMovements.type, 'SAIDA'),
+          sql`${invStockMovements.responsible} IS NOT NULL AND btrim(${invStockMovements.responsible}) <> ''`,
+        ),
+      )
+      .orderBy(invStockMovements.responsible, desc(invStockMovements.createdAt), desc(invStockMovements.id));
+
+    return rows.map((r) => ({ ...r, technician: r.technician as string }));
+  }
+
+  /** Lock one dispatch row so concurrent technician-moves serialize (§M7). */
+  async lockDispatch(
+    tenantId: string,
+    movementId: string,
+    client: FieldDbClient = db,
+  ): Promise<InvStockMovementRow | null> {
+    const [row] = await client
+      .select()
+      .from(invStockMovements)
+      .where(and(eq(invStockMovements.tenantId, tenantId), eq(invStockMovements.id, movementId)))
+      .limit(1)
+      .for('update');
+    return row ?? null;
+  }
+
+  /** Σ quantity already consumed from a dispatch (under the dispatch lock). */
+  async sumTechnicianMoves(
+    tenantId: string,
+    movementId: string,
+    client: FieldDbClient = db,
+  ): Promise<number> {
+    const [row] = await client
+      .select({ total: sql<number>`coalesce(sum(${invTechnicianMoves.quantity}), 0)::int` })
+      .from(invTechnicianMoves)
+      .where(and(eq(invTechnicianMoves.tenantId, tenantId), eq(invTechnicianMoves.movementId, movementId)));
+    return row?.total ?? 0;
+  }
+
+  async insertTechnicianMove(
+    input: NewTechnicianMoveInput,
+    client: FieldDbClient = db,
+  ): Promise<InvTechnicianMoveRow> {
+    const [row] = await client
+      .insert(invTechnicianMoves)
+      .values({
+        tenantId: input.tenantId,
+        movementId: input.movementId,
+        itemId: input.itemId ?? null,
+        technician: input.technician ?? null,
+        destination: input.destination,
+        projectId: input.projectId ?? null,
+        quantity: input.quantity,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  /** QR links of the given movements (dispatch attachments for the UI). */
+  async listMovementQrs(
+    tenantId: string,
+    movementIds: string[],
+    client: FieldDbClient = db,
+  ): Promise<InvMovementQrRow[]> {
+    if (movementIds.length === 0) return [];
+    return client
+      .select()
+      .from(invMovementQrs)
+      .where(and(eq(invMovementQrs.tenantId, tenantId), inArray(invMovementQrs.movementId, movementIds)));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Damaged items (Avarias)
+  // ---------------------------------------------------------------------------
+
+  /** AVARIADO first (…then RECUPERADO), newest first inside each status. */
+  async listDamagedItems(
+    tenantId: string,
+    filters: DamagedListFilters,
+    client: FieldDbClient = db,
+  ): Promise<{ rows: InvDamagedItemRow[]; total: number }> {
+    const conditions: (SQL | undefined)[] = [eq(invDamagedItems.tenantId, tenantId)];
+    if (filters.status) conditions.push(eq(invDamagedItems.status, filters.status));
+    const where = and(...conditions);
+
+    const rows = await client
+      .select()
+      .from(invDamagedItems)
+      .where(where)
+      // 'AVARIADO' < 'RECUPERADO' lexicographically — asc puts open damage first.
+      .orderBy(invDamagedItems.status, desc(invDamagedItems.createdAt), desc(invDamagedItems.id))
+      .limit(filters.pageSize)
+      .offset((filters.page - 1) * filters.pageSize);
+
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invDamagedItems)
+      .where(where);
+
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  /** Lock the damaged row for the recovery transaction (`FOR UPDATE`). */
+  async getDamagedItemForUpdate(
+    tenantId: string,
+    id: string,
+    client: FieldDbClient = db,
+  ): Promise<InvDamagedItemRow | null> {
+    const [row] = await client
+      .select()
+      .from(invDamagedItems)
+      .where(and(eq(invDamagedItems.tenantId, tenantId), eq(invDamagedItems.id, id)))
+      .limit(1)
+      .for('update');
+    return row ?? null;
+  }
+
+  async insertDamagedItem(
+    input: NewDamagedItemInput,
+    client: FieldDbClient = db,
+  ): Promise<InvDamagedItemRow> {
+    const [row] = await client
+      .insert(invDamagedItems)
+      .values({
+        tenantId: input.tenantId,
+        itemId: input.itemId ?? null,
+        productNameSnapshot: input.productNameSnapshot ?? null,
+        quantity: input.quantity,
+        source: input.source ?? null,
+        sourceDetail: input.sourceDetail ?? null,
+        reason: input.reason ?? null,
+        photoFileId: input.photoFileId ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async markDamagedRecovered(
+    tenantId: string,
+    id: string,
+    fields: DamagedRecoveryFields,
+    client: FieldDbClient = db,
+  ): Promise<InvDamagedItemRow | null> {
+    const [row] = await client
+      .update(invDamagedItems)
+      .set({
+        status: 'RECUPERADO',
+        recoveredTo: fields.recoveredTo,
+        recoveryNotes: fields.recoveryNotes ?? null,
+        recoveredBy: fields.recoveredBy ?? null,
+        recoveredAt: fields.recoveredAt,
+      })
+      .where(and(eq(invDamagedItems.tenantId, tenantId), eq(invDamagedItems.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared lookups
+  // ---------------------------------------------------------------------------
+
+  /** Project lookup with the composing transaction's executor (M9 stays as-is). */
+  async getProject(
+    tenantId: string,
+    id: string,
+    client: FieldDbClient = db,
+  ): Promise<InvProjectRow | null> {
+    const [row] = await client
+      .select()
+      .from(invProjects)
+      .where(and(eq(invProjects.tenantId, tenantId), eq(invProjects.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+}
+
+export const inventoryFieldRepository = new InventoryFieldRepository();

--- a/src/services/inventory/InventoryFieldService.ts
+++ b/src/services/inventory/InventoryFieldService.ts
@@ -1,0 +1,1219 @@
+// =============================================================================
+// RFC-0061 M7 — Campo service (Cliente / Técnico / Avarias).
+//
+// ANTI-DOUBLE-COUNT RULE (§M7, ported from the source): moves out of the
+// client and out of a technician's custody are TRACKING-ONLY — they never
+// touch the stock ledger — EXCEPT when the destination is the warehouse
+// (ALMOXARIFADO), which writes an ENTRADA *and re-links the QR on the new
+// movement* (inv_movement_qrs). Without the re-link the M8 sync would see the
+// QR's latest ledger event as the original SAIDA and "correct" the return
+// away. Matrix:
+//
+//   unit-product move   TECNICO | PERDIDO | AVARIADO → no ledger write
+//   unit-product move   ALMOXARIFADO → ENTRADA "Devolução do cliente" + QR link
+//   technician move     UNIDADE | PERDIDO → no ledger write
+//   technician move     ALMOXARIFADO → ENTRADA "Devolução do técnico <nome>" + QR links
+//   technician move     AVARIADO → inv_damaged_items only (no ledger)
+//   damaged report      from stock → SAIDA "Item avariado — <motivo>" (balance-guarded)
+//   damaged recovery    always ENTRADA "Recuperação de item avariado" (+ QR re-link
+//                       when source_detail carries a QR code); TECNICO/UNIDADE add a
+//                       paired SAIDA in the same tx (net-zero — custody leaves stock)
+//
+// Composing with M2 (same trade-off as M4, documented there): this service
+// drives inventoryStockRepository.lockItem / getBalance / insertMovement /
+// insertMovementQrs with the FIELD transaction's executor, so every
+// multi-write composition (move + ENTRADA + QR link, technician-move +
+// damaged report, recovery + movements + unit rows) commits or rolls back
+// atomically.
+//
+// M7 DTOs live here (exported Zod schemas): the RFC finalizes later-phase DTOs
+// at implementation time and src/dto is frozen for this PR (module-boundary
+// rule) — follow-up: fold them into src/dto/request/InventoryDTO.ts in a
+// consolidating PR.
+// =============================================================================
+
+import { z } from 'zod';
+import {
+  InventoryFieldRepository,
+  inventoryFieldRepository,
+  FieldDbClient,
+  InvUnitProductRow,
+  InvDamagedItemRow,
+  InvStockMovementRow,
+  DispatchRow,
+  NewUnitProductInput,
+} from '../../repositories/inventory/InventoryFieldRepository';
+import {
+  InventoryStockRepository,
+  inventoryStockRepository,
+} from '../../repositories/inventory/InventoryStockRepository';
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../shared/errors/AppError';
+import {
+  alreadyInState,
+  insufficientStock,
+  qrDuplicate,
+  qrNotInRegistry,
+} from '../../shared/errors/InventoryError';
+import { QR_CODE_REGEX, normalizeQrInput } from './InventoryQrService';
+import type { InvPaginatedResponse } from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Request DTOs (M7 — finalized at implementation time per the RFC)
+// -----------------------------------------------------------------------------
+
+const uuid = z.string().uuid();
+const pagination = {
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).default(20),
+};
+
+export const UnitProductListQuerySchema = z.object({
+  ...pagination,
+  /** Default listing = active units (moved_to IS NULL); true includes moved. */
+  includeMoved: z
+    .union([z.boolean(), z.enum(['true', 'false']).transform((v) => v === 'true')])
+    .default(false),
+  projectId: uuid.optional(),
+  status: z.enum(['PARADO', 'INSTALADO']).optional(),
+});
+export type UnitProductListQuery = z.infer<typeof UnitProductListQuerySchema>;
+
+export const CreateUnitProductSchema = z
+  .object({
+    itemId: uuid,
+    /** Optional label = an available homologated QR (validated against M5). */
+    label: z.string().min(1).max(120).optional(),
+    projectId: uuid.optional(),
+    notes: z.string().max(4096).optional(),
+  })
+  .strict();
+export type CreateUnitProductDTO = z.infer<typeof CreateUnitProductSchema>;
+
+export const UpdateUnitProductSchema = z
+  .object({ status: z.enum(['PARADO', 'INSTALADO']) })
+  .strict();
+export type UpdateUnitProductDTO = z.infer<typeof UpdateUnitProductSchema>;
+
+export const MoveUnitProductSchema = z
+  .object({
+    destination: z.enum(['TECNICO', 'ALMOXARIFADO', 'PERDIDO', 'AVARIADO']),
+    technician: z.string().min(1).max(200).optional(),
+    photoFileId: uuid.optional(),
+    notes: z.string().max(4096).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (v.destination === 'TECNICO' && !v.technician) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'technician is required for destination TECNICO',
+        path: ['technician'],
+      });
+    }
+    if (v.destination === 'AVARIADO' && !v.notes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'notes is required for destination AVARIADO',
+        path: ['notes'],
+      });
+    }
+  });
+export type MoveUnitProductDTO = z.infer<typeof MoveUnitProductSchema>;
+
+export const TechnicianItemsQuerySchema = z.object({ ...pagination });
+export type TechnicianItemsQuery = z.infer<typeof TechnicianItemsQuerySchema>;
+
+export const CreateTechnicianMoveSchema = z
+  .object({
+    /** The dispatch (SAIDA with responsible) this move consumes from. */
+    movementId: uuid,
+    destination: z.enum(['UNIDADE', 'PERDIDO', 'ALMOXARIFADO', 'AVARIADO']),
+    quantity: z.number().int().min(1).max(100000),
+    projectId: uuid.optional(),
+    notes: z.string().max(4096).optional(),
+    photoFileId: uuid.optional(),
+    /** Which dispatch QRs return with an ALMOXARIFADO move (re-link — §M7). */
+    qrValues: z.array(z.string().min(1).max(200)).max(1000).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (v.destination === 'UNIDADE' && !v.projectId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'projectId is required for destination UNIDADE',
+        path: ['projectId'],
+      });
+    }
+    if (v.destination === 'AVARIADO' && !v.notes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'notes (motivo) is required for destination AVARIADO',
+        path: ['notes'],
+      });
+    }
+    if (v.qrValues && new Set(v.qrValues).size !== v.qrValues.length) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'duplicate qrValues', path: ['qrValues'] });
+    }
+  });
+export type CreateTechnicianMoveDTO = z.infer<typeof CreateTechnicianMoveSchema>;
+
+export const DamagedListQuerySchema = z.object({
+  ...pagination,
+  status: z.enum(['AVARIADO', 'RECUPERADO']).optional(),
+});
+export type DamagedListQuery = z.infer<typeof DamagedListQuerySchema>;
+
+export const CreateDamagedItemSchema = z
+  .object({
+    itemId: uuid,
+    quantity: z.number().int().min(1).max(100000),
+    /** Which stock the damaged units leave from (SAIDA is balance-guarded). */
+    location: z.enum(['FABRICA', 'ALMOXARIFADO', 'ALMOXARIFADO_GERAL']),
+    reason: z.string().min(1).max(4096),
+    photoFileId: uuid.optional(),
+    sourceDetail: z.string().max(500).optional(),
+    qrValues: z.array(z.string().min(1).max(200)).max(1000).optional(),
+  })
+  .strict();
+export type CreateDamagedItemDTO = z.infer<typeof CreateDamagedItemSchema>;
+
+export const RecoverDamagedItemSchema = z
+  .object({
+    destination: z.enum(['ESTOQUE', 'TECNICO', 'UNIDADE']),
+    /** Stock the recovery re-enters (and leaves again for TECNICO/UNIDADE). */
+    location: z.enum(['FABRICA', 'ALMOXARIFADO', 'ALMOXARIFADO_GERAL']).default('ALMOXARIFADO'),
+    technician: z.string().min(1).max(200).optional(),
+    projectId: uuid.optional(),
+    notes: z.string().max(4096).optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (v.destination === 'TECNICO' && !v.technician) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'technician is required for destination TECNICO',
+        path: ['technician'],
+      });
+    }
+    if (v.destination === 'UNIDADE' && !v.projectId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'projectId is required for destination UNIDADE',
+        path: ['projectId'],
+      });
+    }
+  });
+export type RecoverDamagedItemDTO = z.infer<typeof RecoverDamagedItemSchema>;
+
+// -----------------------------------------------------------------------------
+// Response read models
+// -----------------------------------------------------------------------------
+
+export interface InvUnitProductResponse {
+  id: string;
+  itemId: string | null;
+  itemName: string | null;
+  label: string | null;
+  status: string;
+  installedAt: string | null;
+  projectId: string | null;
+  projectName: string | null;
+  customerId: string | null;
+  clientNameSnapshot: string | null;
+  expeditionOrderId: string | null;
+  movedTo: string | null;
+  movedTechnician: string | null;
+  movePhotoFileId: string | null;
+  movedAt: string | null;
+  moveNotes: string | null;
+  notes: string | null;
+  createdAt: string;
+  createdBy: string | null;
+}
+
+export interface InvUnitMoveResponse {
+  unit: InvUnitProductResponse;
+  /** The ENTRADA written for destination ALMOXARIFADO; null otherwise (§M7). */
+  stockMovementId: string | null;
+  /** The damage report created for destination AVARIADO; null otherwise. */
+  damagedItemId: string | null;
+}
+
+export interface InvDispatchQr {
+  qrValue: string | null;
+  boxQr: string | null;
+}
+
+export interface InvTechnicianDispatchResponse {
+  movementId: string;
+  itemId: string;
+  itemName: string | null;
+  quantity: number;
+  movedQuantity: number;
+  remaining: number;
+  location: string;
+  reason: string | null;
+  createdAt: string;
+  qrs: InvDispatchQr[];
+}
+
+export interface InvTechnicianGroupResponse {
+  technician: string;
+  totalRemaining: number;
+  dispatches: InvTechnicianDispatchResponse[];
+}
+
+export interface InvTechnicianMoveResponse {
+  id: string;
+  movementId: string;
+  itemId: string | null;
+  technician: string | null;
+  destination: string;
+  projectId: string | null;
+  quantity: number;
+  notes: string | null;
+  createdAt: string;
+  /** ENTRADA written for destination ALMOXARIFADO; null otherwise (§M7). */
+  stockMovementId: string | null;
+  damagedItemId: string | null;
+  createdUnitProductIds: string[];
+}
+
+export interface InvDamagedItemResponse {
+  id: string;
+  itemId: string | null;
+  productNameSnapshot: string | null;
+  quantity: number;
+  source: string | null;
+  sourceDetail: string | null;
+  reason: string | null;
+  photoFileId: string | null;
+  status: string;
+  recoveredTo: string | null;
+  recoveryNotes: string | null;
+  recoveredBy: string | null;
+  recoveredAt: string | null;
+  createdAt: string;
+  createdBy: string | null;
+}
+
+export interface InvCreateDamagedResponse {
+  damaged: InvDamagedItemResponse;
+  stockMovementId: string;
+}
+
+export interface InvRecoverDamagedResponse {
+  damaged: InvDamagedItemResponse;
+  entryMovementId: string;
+  exitMovementId: string | null;
+  createdUnitProductIds: string[];
+  /** QR code re-linked from source_detail (null when none was found). */
+  relinkedQr: string | null;
+}
+
+// -----------------------------------------------------------------------------
+// Seams (mocked in unit tests)
+// -----------------------------------------------------------------------------
+
+export type IInventoryFieldRepository = Pick<
+  InventoryFieldRepository,
+  | 'withTransaction'
+  | 'listUnitProducts'
+  | 'getUnitProduct'
+  | 'getUnitProductForUpdate'
+  | 'findUnitByLabel'
+  | 'insertUnitProducts'
+  | 'updateUnitStatus'
+  | 'markUnitMoved'
+  | 'listDispatches'
+  | 'lockDispatch'
+  | 'sumTechnicianMoves'
+  | 'insertTechnicianMove'
+  | 'listMovementQrs'
+  | 'listDamagedItems'
+  | 'getDamagedItemForUpdate'
+  | 'insertDamagedItem'
+  | 'markDamagedRecovered'
+  | 'getProject'
+>;
+
+/** The M2 seam this service composes inside the field transactions. */
+export type IFieldStockRepository = Pick<
+  InventoryStockRepository,
+  'lockItem' | 'getBalance' | 'insertMovement' | 'insertMovementQrs'
+>;
+
+/** The M5 seam — homologated-QR registry lookups (label validation). */
+export type IFieldQrRegistryRepository = Pick<
+  InventoryHomologationRepository,
+  'findRegistryByValues' | 'getItem'
+>;
+
+export interface FieldContext {
+  tenantId: string;
+  userId?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Constants & helpers
+// -----------------------------------------------------------------------------
+
+/** Returns from the field re-enter the warehouse (§M7). */
+export const RETURN_LOCATION = 'ALMOXARIFADO';
+export const REASON_CLIENT_RETURN = 'Devolução do cliente';
+export const REASON_DAMAGED_RECOVERY = 'Recuperação de item avariado';
+export function reasonTechnicianReturn(technician: string): string {
+  return `Devolução do técnico ${technician}`;
+}
+export function reasonDamaged(motivo: string): string {
+  return `Item avariado — ${motivo}`;
+}
+
+/** A QR code embedded anywhere in free text (source_detail — recovery re-link). */
+const EMBEDDED_QR_REGEX = /\d+(?:_\d+)+/;
+
+/** Extract the QR code carried by a damage report's source_detail, if any. */
+export function extractQrFromSourceDetail(sourceDetail: string | null | undefined): string | null {
+  if (!sourceDetail) return null;
+  const match = EMBEDDED_QR_REGEX.exec(sourceDetail);
+  return match ? match[0] : null;
+}
+
+// Idempotency cache tuning (best-effort, per-process — same M2/M4 pattern).
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_MAX_ENTRIES = 5000;
+
+export class InventoryFieldService {
+  private repository: IInventoryFieldRepository;
+
+  private stockRepository: IFieldStockRepository;
+
+  private qrRepository: IFieldQrRegistryRepository;
+
+  private idempotencyCache = new Map<string, { at: number; promise: Promise<unknown> }>();
+
+  constructor(
+    repository?: IInventoryFieldRepository,
+    stockRepository?: IFieldStockRepository,
+    qrRepository?: IFieldQrRegistryRepository,
+  ) {
+    this.repository = repository ?? inventoryFieldRepository;
+    this.stockRepository = stockRepository ?? inventoryStockRepository;
+    this.qrRepository = qrRepository ?? inventoryHomologationRepository;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unit products (Cliente)
+  // ---------------------------------------------------------------------------
+
+  async listUnitProducts(
+    tenantId: string,
+    query: UnitProductListQuery,
+  ): Promise<InvPaginatedResponse<InvUnitProductResponse>> {
+    const { rows, total } = await this.repository.listUnitProducts(tenantId, {
+      page: query.page,
+      pageSize: query.pageSize,
+      includeMoved: query.includeMoved,
+      projectId: query.projectId,
+      status: query.status,
+    });
+    return {
+      items: rows.map((r) => this.toUnitResponse(r.unit, r.itemName, r.projectName)),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: Math.ceil(total / query.pageSize),
+    };
+  }
+
+  /**
+   * Create a unit product at the client. Optional label must be an available
+   * homologated QR (M5 registry) not already used as the label of another
+   * ACTIVE unit; the DB unique index (which spans moved units too) is the
+   * backstop → 23505 maps to INV_QR_DUPLICATE.
+   */
+  async createUnitProduct(ctx: FieldContext, dto: CreateUnitProductDTO): Promise<InvUnitProductResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const item = await this.qrRepository.getItem(ctx.tenantId, dto.itemId, tx);
+        if (!item) throw new NotFoundError(`Item ${dto.itemId} not found`);
+
+        const label = dto.label ? normalizeQrInput(dto.label).code : undefined;
+        if (label) await this.assertLabelAvailable(ctx.tenantId, label, tx);
+
+        const project = dto.projectId ? await this.getProjectOr404(ctx.tenantId, dto.projectId, tx) : null;
+
+        const [unit] = await this.repository.insertUnitProducts(
+          [
+            {
+              tenantId: ctx.tenantId,
+              itemId: dto.itemId,
+              label: label ?? null,
+              status: 'PARADO',
+              projectId: project?.id ?? null,
+              customerId: project?.customerId ?? null,
+              // Source rule "Projeto = Cliente": client name = project name.
+              clientNameSnapshot: project?.name ?? null,
+              notes: dto.notes ?? null,
+              createdBy: ctx.userId ?? null,
+            },
+          ],
+          tx,
+        );
+        return this.toUnitResponse(unit, item.name, project?.name ?? null);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /** INSTALADO/PARADO toggle; installs stamp installed_at (§M7). */
+  async updateUnitProduct(
+    ctx: FieldContext,
+    id: string,
+    dto: UpdateUnitProductDTO,
+  ): Promise<InvUnitProductResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const unit = await this.repository.getUnitProductForUpdate(ctx.tenantId, id, tx);
+        if (!unit) throw new NotFoundError(`Unit product ${id} not found`);
+        if (unit.movedTo) {
+          throw new ConflictError(`Unidade já movida para ${unit.movedTo} — status não pode ser alterado`);
+        }
+        if (unit.status === dto.status) throw alreadyInState(unit.status);
+
+        const installedAt = dto.status === 'INSTALADO' ? new Date() : null;
+        const updated = await this.repository.updateUnitStatus(ctx.tenantId, id, dto.status, installedAt, tx);
+        return this.toUnitResponse(updated ?? unit, null, null);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /**
+   * Move a unit out of the client. ANTI-DOUBLE-COUNT (§M7): only destination
+   * ALMOXARIFADO writes stock — ENTRADA "Devolução do cliente" + QR re-link on
+   * the new movement so the M8 sync doesn't undo the return; TECNICO/PERDIDO
+   * are tracking-only; AVARIADO additionally opens an inv_damaged_items report
+   * (source "Cliente", source_detail = project/label — the label keeps the QR
+   * recoverable later).
+   */
+  async moveUnitProduct(
+    ctx: FieldContext,
+    id: string,
+    dto: MoveUnitProductDTO,
+    idempotencyKey: string,
+  ): Promise<InvUnitMoveResponse> {
+    return this.idempotent(ctx.tenantId, `unit-move:${idempotencyKey}`, () =>
+      this.doMoveUnitProduct(ctx, id, dto),
+    );
+  }
+
+  private async doMoveUnitProduct(
+    ctx: FieldContext,
+    id: string,
+    dto: MoveUnitProductDTO,
+  ): Promise<InvUnitMoveResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const unit = await this.repository.getUnitProductForUpdate(ctx.tenantId, id, tx);
+        if (!unit) throw new NotFoundError(`Unit product ${id} not found`);
+        if (unit.movedTo) throw alreadyInState(unit.movedTo);
+
+        let stockMovementId: string | null = null;
+        let damagedItemId: string | null = null;
+
+        if (dto.destination === 'ALMOXARIFADO') {
+          // The ONLY move destination that touches the ledger (§M7).
+          const movement = await this.writeReturnEntry(ctx, unit, tx);
+          stockMovementId = movement.id;
+        } else if (dto.destination === 'AVARIADO') {
+          const itemName = unit.itemId
+            ? (await this.qrRepository.getItem(ctx.tenantId, unit.itemId, tx))?.name ?? null
+            : null;
+          const project = unit.projectId
+            ? await this.repository.getProject(ctx.tenantId, unit.projectId, tx)
+            : null;
+          const sourceDetail = [project?.name ?? unit.clientNameSnapshot, unit.label]
+            .filter((v): v is string => !!v)
+            .join(' / ');
+          const damaged = await this.repository.insertDamagedItem(
+            {
+              tenantId: ctx.tenantId,
+              itemId: unit.itemId,
+              productNameSnapshot: itemName,
+              quantity: 1,
+              source: 'Cliente',
+              sourceDetail: sourceDetail || null,
+              reason: dto.notes ?? null,
+              photoFileId: dto.photoFileId ?? null,
+              createdBy: ctx.userId ?? null,
+            },
+            tx,
+          );
+          damagedItemId = damaged.id;
+        }
+        // TECNICO / PERDIDO: tracking-only — no ledger write.
+
+        const moved = await this.repository.markUnitMoved(
+          ctx.tenantId,
+          id,
+          {
+            movedTo: dto.destination,
+            movedTechnician: dto.destination === 'TECNICO' ? dto.technician ?? null : null,
+            movePhotoFileId: dto.photoFileId ?? null,
+            movedAt: new Date(),
+            moveNotes: dto.notes ?? null,
+          },
+          tx,
+        );
+
+        return {
+          unit: this.toUnitResponse(moved ?? unit, null, null),
+          stockMovementId,
+          damagedItemId,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /** ENTRADA "Devolução do cliente" + QR re-link for the returned unit. */
+  private async writeReturnEntry(
+    ctx: FieldContext,
+    unit: InvUnitProductRow,
+    tx: FieldDbClient,
+  ): Promise<InvStockMovementRow> {
+    if (!unit.itemId) {
+      throw new ValidationError('Unidade sem item vinculado não pode retornar ao estoque');
+    }
+    const movement = await this.stockRepository.insertMovement(
+      {
+        tenantId: ctx.tenantId,
+        itemId: unit.itemId,
+        location: RETURN_LOCATION,
+        quantity: '1',
+        type: 'ENTRADA',
+        reason: REASON_CLIENT_RETURN,
+        createdBy: ctx.userId ?? null,
+      },
+      tx,
+    );
+    // Re-link the unit's QR to the ENTRADA: the QR's latest ledger event
+    // becomes this return, so the M8 sync will not "correct" it back out.
+    if (unit.label && QR_CODE_REGEX.test(unit.label)) {
+      await this.stockRepository.insertMovementQrs(ctx.tenantId, movement.id, [{ qrValue: unit.label }], tx);
+    }
+    return movement;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Technician custody (Técnico)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Items with technicians: dispatches (SAIDAs with a responsible) grouped by
+   * technician; per-dispatch remaining = quantity − Σ technician moves;
+   * fully-consumed dispatches are omitted; dispatch QRs attached. Grouping and
+   * pagination happen in memory — dispatch volume is operational-scale (one
+   * company); revisit with a SQL GROUP BY if it ever grows (follow-up).
+   */
+  async listTechnicianItems(
+    tenantId: string,
+    query: TechnicianItemsQuery,
+  ): Promise<InvPaginatedResponse<InvTechnicianGroupResponse>> {
+    const dispatches = await this.repository.listDispatches(tenantId);
+    const open = dispatches.filter((d) => Number(d.quantity) - d.movedQuantity > 0);
+    const qrs = await this.repository.listMovementQrs(tenantId, open.map((d) => d.movementId));
+    const qrsByMovement = new Map<string, InvDispatchQr[]>();
+    for (const qr of qrs) {
+      const list = qrsByMovement.get(qr.movementId) ?? [];
+      list.push({ qrValue: qr.qrValue ?? null, boxQr: qr.boxQr ?? null });
+      qrsByMovement.set(qr.movementId, list);
+    }
+
+    const groups = new Map<string, InvTechnicianGroupResponse>();
+    for (const d of open) {
+      const group = groups.get(d.technician) ?? {
+        technician: d.technician,
+        totalRemaining: 0,
+        dispatches: [],
+      };
+      const remaining = Number(d.quantity) - d.movedQuantity;
+      group.totalRemaining += remaining;
+      group.dispatches.push(this.toDispatchResponse(d, remaining, qrsByMovement.get(d.movementId) ?? []));
+      groups.set(d.technician, group);
+    }
+
+    const all = [...groups.values()].sort((a, b) => a.technician.localeCompare(b.technician));
+    const start = (query.page - 1) * query.pageSize;
+    return {
+      items: all.slice(start, start + query.pageSize),
+      page: query.page,
+      pageSize: query.pageSize,
+      total: all.length,
+      totalPages: Math.ceil(all.length / query.pageSize),
+    };
+  }
+
+  /**
+   * Move units out of a technician's custody. ANTI-DOUBLE-COUNT (§M7):
+   * UNIDADE/PERDIDO are pure tracking (no ledger); ALMOXARIFADO writes an
+   * ENTRADA "Devolução do técnico <nome>" + QR re-links; AVARIADO opens an
+   * inv_damaged_items report (source "Técnico") without touching the ledger.
+   */
+  async createTechnicianMove(
+    ctx: FieldContext,
+    dto: CreateTechnicianMoveDTO,
+    idempotencyKey: string,
+  ): Promise<InvTechnicianMoveResponse> {
+    return this.idempotent(ctx.tenantId, `tech-move:${idempotencyKey}`, () =>
+      this.doCreateTechnicianMove(ctx, dto),
+    );
+  }
+
+  private async doCreateTechnicianMove(
+    ctx: FieldContext,
+    dto: CreateTechnicianMoveDTO,
+  ): Promise<InvTechnicianMoveResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        // Lock the dispatch row: concurrent moves against the same dispatch
+        // serialize here, so the remaining check cannot race.
+        const dispatch = await this.repository.lockDispatch(ctx.tenantId, dto.movementId, tx);
+        if (!dispatch) throw new NotFoundError(`Dispatch ${dto.movementId} not found`);
+        const technician = (dispatch.responsible ?? '').trim();
+        if (dispatch.type !== 'SAIDA' || technician === '') {
+          throw new ValidationError('Movimento não é um despacho para técnico (SAIDA com responsável)');
+        }
+
+        const consumed = await this.repository.sumTechnicianMoves(ctx.tenantId, dto.movementId, tx);
+        const remaining = Number(dispatch.quantity) - consumed;
+        if (dto.quantity > remaining) {
+          throw new ValidationError(
+            `Quantidade (${dto.quantity}) excede o restante do despacho (${remaining})`,
+          );
+        }
+
+        const qrValues = await this.resolveDispatchQrs(ctx.tenantId, dto, tx);
+
+        const move = await this.repository.insertTechnicianMove(
+          {
+            tenantId: ctx.tenantId,
+            movementId: dto.movementId,
+            itemId: dispatch.itemId,
+            technician,
+            destination: dto.destination,
+            projectId: dto.projectId ?? null,
+            quantity: dto.quantity,
+            notes: dto.notes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        let stockMovementId: string | null = null;
+        let damagedItemId: string | null = null;
+        let createdUnitProductIds: string[] = [];
+
+        if (dto.destination === 'ALMOXARIFADO') {
+          // The ONLY technician destination that touches the ledger (§M7).
+          const entry = await this.stockRepository.insertMovement(
+            {
+              tenantId: ctx.tenantId,
+              itemId: dispatch.itemId,
+              location: RETURN_LOCATION,
+              quantity: String(dto.quantity),
+              type: 'ENTRADA',
+              reason: reasonTechnicianReturn(technician),
+              createdBy: ctx.userId ?? null,
+            },
+            tx,
+          );
+          stockMovementId = entry.id;
+          if (qrValues.length > 0) {
+            // Re-link the returning QRs so the M8 sync doesn't undo the return.
+            await this.stockRepository.insertMovementQrs(
+              ctx.tenantId,
+              entry.id,
+              qrValues.map((qrValue) => ({ qrValue })),
+              tx,
+            );
+          }
+        } else if (dto.destination === 'UNIDADE') {
+          const project = await this.getProjectOr404(ctx.tenantId, dto.projectId as string, tx);
+          const inputs: NewUnitProductInput[] = Array.from({ length: dto.quantity }, () => ({
+            tenantId: ctx.tenantId,
+            itemId: dispatch.itemId,
+            label: null, // §M7: unit products created from technician moves have no label
+            status: 'PARADO',
+            projectId: project.id,
+            customerId: project.customerId ?? null,
+            clientNameSnapshot: project.name,
+            createdBy: ctx.userId ?? null,
+          }));
+          const units = await this.repository.insertUnitProducts(inputs, tx);
+          createdUnitProductIds = units.map((u) => u.id);
+        } else if (dto.destination === 'AVARIADO') {
+          const item = await this.qrRepository.getItem(ctx.tenantId, dispatch.itemId, tx);
+          const damaged = await this.repository.insertDamagedItem(
+            {
+              tenantId: ctx.tenantId,
+              itemId: dispatch.itemId,
+              productNameSnapshot: item?.name ?? null,
+              quantity: dto.quantity,
+              source: 'Técnico',
+              sourceDetail: technician,
+              reason: dto.notes ?? null,
+              photoFileId: dto.photoFileId ?? null,
+              createdBy: ctx.userId ?? null,
+            },
+            tx,
+          );
+          damagedItemId = damaged.id;
+        }
+        // PERDIDO: tracking-only — no ledger write.
+
+        return {
+          id: move.id,
+          movementId: move.movementId as string,
+          itemId: move.itemId ?? null,
+          technician: move.technician ?? null,
+          destination: move.destination,
+          projectId: move.projectId ?? null,
+          quantity: move.quantity,
+          notes: move.notes ?? null,
+          createdAt: this.iso(move.createdAt),
+          stockMovementId,
+          damagedItemId,
+          createdUnitProductIds,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /** qrValues must belong to the dispatch and match the quantity (when given). */
+  private async resolveDispatchQrs(
+    tenantId: string,
+    dto: CreateTechnicianMoveDTO,
+    tx: FieldDbClient,
+  ): Promise<string[]> {
+    if (!dto.qrValues?.length) return [];
+    const codes = dto.qrValues.map((v) => normalizeQrInput(v).code);
+    if (codes.length !== dto.quantity) {
+      throw new ValidationError(
+        `qrValues (${codes.length}) deve igualar a quantidade devolvida (${dto.quantity})`,
+      );
+    }
+    const dispatchQrs = await this.repository.listMovementQrs(tenantId, [dto.movementId], tx);
+    const known = new Set(dispatchQrs.map((q) => q.qrValue).filter((v): v is string => !!v));
+    for (const code of codes) {
+      if (!known.has(code)) {
+        throw new ValidationError(`QR ${code} não pertence ao despacho informado`);
+      }
+    }
+    return codes;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Damaged items (Avarias)
+  // ---------------------------------------------------------------------------
+
+  async listDamagedItems(
+    tenantId: string,
+    query: DamagedListQuery,
+  ): Promise<InvPaginatedResponse<InvDamagedItemResponse>> {
+    const { rows, total } = await this.repository.listDamagedItems(tenantId, {
+      page: query.page,
+      pageSize: query.pageSize,
+      status: query.status,
+    });
+    return {
+      items: rows.map((r) => this.toDamagedResponse(r)),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: Math.ceil(total / query.pageSize),
+    };
+  }
+
+  /**
+   * Report damage FROM STOCK: qty is capped by the location balance (checked
+   * under the item lock — M2 guard re-applied) and leaves the ledger as a
+   * SAIDA "Item avariado — <motivo>". Damage found at the client or with a
+   * technician arrives through the move routes above, not here.
+   */
+  async createDamagedItem(
+    ctx: FieldContext,
+    dto: CreateDamagedItemDTO,
+    idempotencyKey: string,
+  ): Promise<InvCreateDamagedResponse> {
+    return this.idempotent(ctx.tenantId, `damaged:${idempotencyKey}`, () =>
+      this.doCreateDamagedItem(ctx, dto),
+    );
+  }
+
+  private async doCreateDamagedItem(
+    ctx: FieldContext,
+    dto: CreateDamagedItemDTO,
+  ): Promise<InvCreateDamagedResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const item = await this.stockRepository.lockItem(ctx.tenantId, dto.itemId, tx);
+        if (!item) throw new NotFoundError(`Item ${dto.itemId} not found`);
+
+        const totals = await this.stockRepository.getBalance(ctx.tenantId, dto.itemId, dto.location, tx);
+        const balance = Number(totals.balance);
+        if (dto.quantity > balance) {
+          throw insufficientStock(dto.itemId, dto.location, balance, dto.quantity);
+        }
+
+        const exit = await this.stockRepository.insertMovement(
+          {
+            tenantId: ctx.tenantId,
+            itemId: dto.itemId,
+            location: dto.location,
+            quantity: String(dto.quantity),
+            type: 'SAIDA',
+            reason: reasonDamaged(dto.reason),
+            photoFileId: dto.photoFileId ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        if (dto.qrValues?.length) {
+          await this.stockRepository.insertMovementQrs(
+            ctx.tenantId,
+            exit.id,
+            dto.qrValues.map((v) => ({ qrValue: normalizeQrInput(v).code })),
+            tx,
+          );
+        }
+
+        const damaged = await this.repository.insertDamagedItem(
+          {
+            tenantId: ctx.tenantId,
+            itemId: dto.itemId,
+            productNameSnapshot: item.name,
+            quantity: dto.quantity,
+            source: 'Estoque',
+            sourceDetail: dto.sourceDetail ?? dto.location,
+            reason: dto.reason,
+            photoFileId: dto.photoFileId ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        return { damaged: this.toDamagedResponse(damaged), stockMovementId: exit.id };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /**
+   * Recover a damaged item to ESTOQUE | TECNICO | UNIDADE (§M7):
+   *   - always an ENTRADA "Recuperação de item avariado" at dto.location;
+   *   - TECNICO: plus a SAIDA with responsible = technician (net-zero — the
+   *     recovered units go straight into the technician's custody);
+   *   - UNIDADE: plus a SAIDA and `quantity` inv_unit_products rows in the
+   *     project — the FIRST unit inherits the QR as its label.
+   *
+   * QR RE-LINK (source rule, kept): when source_detail carries a QR code
+   * (`\d+(_\d+)+`), it is re-linked on the new movement(s) in
+   * inv_movement_qrs. Without this the M8 sync — which reads each QR's LATEST
+   * ledger event — would still see the pre-damage exit and revert the
+   * recovery on its next 5-minute run.
+   *
+   * The paired SAIDA needs no negative-stock guard: it consumes exactly the
+   * quantity the ENTRADA added in the same transaction.
+   */
+  async recoverDamagedItem(
+    ctx: FieldContext,
+    id: string,
+    dto: RecoverDamagedItemDTO,
+    idempotencyKey: string,
+  ): Promise<InvRecoverDamagedResponse> {
+    return this.idempotent(ctx.tenantId, `recover:${idempotencyKey}`, () =>
+      this.doRecoverDamagedItem(ctx, id, dto),
+    );
+  }
+
+  private async doRecoverDamagedItem(
+    ctx: FieldContext,
+    id: string,
+    dto: RecoverDamagedItemDTO,
+  ): Promise<InvRecoverDamagedResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const damaged = await this.repository.getDamagedItemForUpdate(ctx.tenantId, id, tx);
+        if (!damaged) throw new NotFoundError(`Damaged item ${id} not found`);
+        if (damaged.status !== 'AVARIADO') throw alreadyInState(damaged.status);
+        if (!damaged.itemId) {
+          throw new ValidationError('Item avariado sem produto vinculado não pode ser recuperado');
+        }
+
+        const relinkedQr = extractQrFromSourceDetail(damaged.sourceDetail);
+        const qrLinks = relinkedQr ? [{ qrValue: relinkedQr }] : [];
+
+        const entry = await this.stockRepository.insertMovement(
+          {
+            tenantId: ctx.tenantId,
+            itemId: damaged.itemId,
+            location: dto.location,
+            quantity: String(damaged.quantity),
+            type: 'ENTRADA',
+            reason: REASON_DAMAGED_RECOVERY,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        if (qrLinks.length > 0) {
+          await this.stockRepository.insertMovementQrs(ctx.tenantId, entry.id, qrLinks, tx);
+        }
+
+        let exitMovementId: string | null = null;
+        let createdUnitProductIds: string[] = [];
+
+        if (dto.destination === 'TECNICO' || dto.destination === 'UNIDADE') {
+          const exit = await this.stockRepository.insertMovement(
+            {
+              tenantId: ctx.tenantId,
+              itemId: damaged.itemId,
+              location: dto.location,
+              quantity: String(damaged.quantity),
+              type: 'SAIDA',
+              reason: REASON_DAMAGED_RECOVERY,
+              responsible: dto.destination === 'TECNICO' ? (dto.technician as string) : null,
+              createdBy: ctx.userId ?? null,
+            },
+            tx,
+          );
+          exitMovementId = exit.id;
+          if (qrLinks.length > 0) {
+            // Latest ledger event for the QR must reflect where it went.
+            await this.stockRepository.insertMovementQrs(ctx.tenantId, exit.id, qrLinks, tx);
+          }
+
+          if (dto.destination === 'UNIDADE') {
+            const project = await this.getProjectOr404(ctx.tenantId, dto.projectId as string, tx);
+            // First unit inherits the QR as label — unless another unit row
+            // already holds it (the label unique index spans moved units too).
+            let inheritedLabel: string | null = null;
+            if (relinkedQr) {
+              const holder = await this.repository.findUnitByLabel(ctx.tenantId, relinkedQr, false, tx);
+              if (!holder) inheritedLabel = relinkedQr;
+            }
+            const inputs: NewUnitProductInput[] = Array.from({ length: damaged.quantity }, (_, i) => ({
+              tenantId: ctx.tenantId,
+              itemId: damaged.itemId,
+              label: i === 0 ? inheritedLabel : null,
+              status: 'PARADO',
+              projectId: project.id,
+              customerId: project.customerId ?? null,
+              clientNameSnapshot: project.name,
+              createdBy: ctx.userId ?? null,
+            }));
+            const units = await this.repository.insertUnitProducts(inputs, tx);
+            createdUnitProductIds = units.map((u) => u.id);
+          }
+        }
+
+        const updated = await this.repository.markDamagedRecovered(
+          ctx.tenantId,
+          id,
+          {
+            recoveredTo: dto.destination,
+            recoveryNotes: dto.notes ?? null,
+            recoveredBy: ctx.userId ?? null,
+            recoveredAt: new Date(),
+          },
+          tx,
+        );
+
+        return {
+          damaged: this.toDamagedResponse(updated ?? damaged),
+          entryMovementId: entry.id,
+          exitMovementId,
+          createdUnitProductIds,
+          relinkedQr,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Guards & lookups
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A label must be a homologated QR (M5 registry, kind UNIT) not already used
+   * by another ACTIVE unit (INV_QR_DUPLICATE). NOTE: the DB unique index spans
+   * moved units too, so a QR whose historical unit kept its label also fails —
+   * surfaced by the same 409 through mapRepoError.
+   */
+  private async assertLabelAvailable(tenantId: string, label: string, tx: FieldDbClient): Promise<void> {
+    const [registry] = await this.qrRepository.findRegistryByValues(tenantId, [label], tx);
+    if (!registry || registry.kind !== 'UNIT') throw qrNotInRegistry(label);
+    const active = await this.repository.findUnitByLabel(tenantId, label, true, tx);
+    if (active) throw qrDuplicate(label);
+  }
+
+  private async getProjectOr404(tenantId: string, projectId: string, tx: FieldDbClient) {
+    const project = await this.repository.getProject(tenantId, projectId, tx);
+    if (!project) throw new NotFoundError(`Project ${projectId} not found`);
+    return project;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotency (best-effort, per-process — same M2/M4 pattern)
+  // ---------------------------------------------------------------------------
+
+  private async idempotent<T>(tenantId: string, key: string, run: () => Promise<T>): Promise<T> {
+    const cacheKey = `${tenantId}:${key}`;
+    const now = Date.now();
+    const hit = this.idempotencyCache.get(cacheKey);
+    if (hit && now - hit.at < IDEMPOTENCY_TTL_MS) {
+      return hit.promise as Promise<T>;
+    }
+
+    const promise = run();
+    this.idempotencyCache.set(cacheKey, { at: now, promise });
+    // A failed attempt must NOT poison the key (client retries the same key).
+    promise.catch(() => this.idempotencyCache.delete(cacheKey));
+    this.evictStaleIdempotencyEntries(now);
+    return promise;
+  }
+
+  private evictStaleIdempotencyEntries(now: number): void {
+    if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    for (const [key, entry] of this.idempotencyCache) {
+      if (now - entry.at >= IDEMPOTENCY_TTL_MS) this.idempotencyCache.delete(key);
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    }
+    for (const key of this.idempotencyCache.keys()) {
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+      this.idempotencyCache.delete(key);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------------
+
+  private iso(value: Date | string | null | undefined): string {
+    return value ? new Date(value).toISOString() : new Date().toISOString();
+  }
+
+  private toUnitResponse(
+    row: InvUnitProductRow,
+    itemName: string | null,
+    projectName: string | null,
+  ): InvUnitProductResponse {
+    return {
+      id: row.id,
+      itemId: row.itemId ?? null,
+      itemName,
+      label: row.label ?? null,
+      status: row.status,
+      installedAt: row.installedAt ? new Date(row.installedAt).toISOString() : null,
+      projectId: row.projectId ?? null,
+      projectName,
+      customerId: row.customerId ?? null,
+      clientNameSnapshot: row.clientNameSnapshot ?? null,
+      expeditionOrderId: row.expeditionOrderId ?? null,
+      movedTo: row.movedTo ?? null,
+      movedTechnician: row.movedTechnician ?? null,
+      movePhotoFileId: row.movePhotoFileId ?? null,
+      movedAt: row.movedAt ? new Date(row.movedAt).toISOString() : null,
+      moveNotes: row.moveNotes ?? null,
+      notes: row.notes ?? null,
+      createdAt: this.iso(row.createdAt),
+      createdBy: row.createdBy ?? null,
+    };
+  }
+
+  private toDispatchResponse(
+    d: DispatchRow,
+    remaining: number,
+    qrs: InvDispatchQr[],
+  ): InvTechnicianDispatchResponse {
+    return {
+      movementId: d.movementId,
+      itemId: d.itemId,
+      itemName: d.itemName,
+      quantity: Number(d.quantity),
+      movedQuantity: d.movedQuantity,
+      remaining,
+      location: d.location,
+      reason: d.reason,
+      createdAt: this.iso(d.createdAt),
+      qrs,
+    };
+  }
+
+  private toDamagedResponse(row: InvDamagedItemRow): InvDamagedItemResponse {
+    return {
+      id: row.id,
+      itemId: row.itemId ?? null,
+      productNameSnapshot: row.productNameSnapshot ?? null,
+      quantity: row.quantity,
+      source: row.source ?? null,
+      sourceDetail: row.sourceDetail ?? null,
+      reason: row.reason ?? null,
+      photoFileId: row.photoFileId ?? null,
+      status: row.status,
+      recoveredTo: row.recoveredTo ?? null,
+      recoveryNotes: row.recoveryNotes ?? null,
+      recoveredBy: row.recoveredBy ?? null,
+      recoveredAt: row.recoveredAt ? new Date(row.recoveredAt).toISOString() : null,
+      createdAt: this.iso(row.createdAt),
+      createdBy: row.createdBy ?? null,
+    };
+  }
+
+  /**
+   * Map low-level DB errors to the RFC contract. Drizzle wraps the driver
+   * error (DrizzleQueryError): the real SQLSTATE lives on `err.cause.code`,
+   * not `err.code`/`err.message` — inspect both (known gotcha).
+   */
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      if (/inv_unit_products_label_uq/i.test(message)) {
+        throw new ConflictError('Label (QR) já utilizado por outra unidade');
+      }
+      throw new ConflictError('Registro duplicado (violação de unicidade)');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (item, projeto, foto ou movimento)');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+export const inventoryFieldService = new InventoryFieldService();

--- a/tests/unit/inventory/m7-anti-double-count.test.ts
+++ b/tests/unit/inventory/m7-anti-double-count.test.ts
@@ -1,0 +1,290 @@
+/**
+ * RFC-0061 M7 — the ANTI-DOUBLE-COUNT rule (§M7), destination by destination.
+ *
+ * Field moves are tracking-only: they must NOT touch the stock ledger — with
+ * exactly one exception, destination ALMOXARIFADO, which writes an ENTRADA and
+ * re-links the QR on the new movement (inv_movement_qrs) so the M8 sync's
+ * latest-event-per-QR reconciliation keeps the return instead of undoing it.
+ */
+
+import {
+  InventoryFieldService,
+  REASON_CLIENT_RETURN,
+  reasonTechnicianReturn,
+  reasonDamaged,
+  RETURN_LOCATION,
+} from '../../../src/services/inventory/InventoryFieldService';
+import {
+  CTX,
+  TENANT,
+  ITEM_ID,
+  UNIT_ID,
+  DISPATCH_ID,
+  QR,
+  TECHNICIAN,
+  makeFieldRepo,
+  makeStockRepo,
+  makeQrRepo,
+  makeUnit,
+  makeDispatchMovement,
+} from './m7-helpers';
+
+function build(overrides: {
+  field?: Record<string, jest.Mock>;
+  stock?: Record<string, jest.Mock>;
+  qr?: Record<string, jest.Mock>;
+} = {}) {
+  const fieldRepo = makeFieldRepo(overrides.field);
+  const stockRepo = makeStockRepo(overrides.stock);
+  const qrRepo = makeQrRepo(overrides.qr);
+  const service = new InventoryFieldService(fieldRepo, stockRepo, qrRepo);
+  return { service, fieldRepo, stockRepo, qrRepo };
+}
+
+describe('M7 unit-product move × ledger (anti-double-count)', () => {
+  it.each([
+    ['TECNICO', { destination: 'TECNICO' as const, technician: TECHNICIAN }],
+    ['PERDIDO', { destination: 'PERDIDO' as const }],
+  ])('destination %s is tracking-only — NO stock movement', async (_dest, dto) => {
+    const { service, fieldRepo, stockRepo } = build();
+    const result = await service.moveUnitProduct(CTX, UNIT_ID, dto, `k-${_dest}`);
+
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(stockRepo.insertMovementQrs).not.toHaveBeenCalled();
+    expect(fieldRepo.insertDamagedItem).not.toHaveBeenCalled();
+    expect(result.stockMovementId).toBeNull();
+    expect(result.damagedItemId).toBeNull();
+    expect(fieldRepo.markUnitMoved).toHaveBeenCalledWith(
+      TENANT,
+      UNIT_ID,
+      expect.objectContaining({ movedTo: dto.destination }),
+      expect.anything(),
+    );
+  });
+
+  it('destination TECNICO stamps moved_technician', async () => {
+    const { service, fieldRepo } = build();
+    await service.moveUnitProduct(CTX, UNIT_ID, { destination: 'TECNICO', technician: TECHNICIAN }, 'k-tec');
+    expect(fieldRepo.markUnitMoved).toHaveBeenCalledWith(
+      TENANT,
+      UNIT_ID,
+      expect.objectContaining({ movedTo: 'TECNICO', movedTechnician: TECHNICIAN }),
+      expect.anything(),
+    );
+  });
+
+  it('destination ALMOXARIFADO writes ENTRADA "Devolução do cliente" + re-links the QR', async () => {
+    const { service, stockRepo } = build();
+    const result = await service.moveUnitProduct(CTX, UNIT_ID, { destination: 'ALMOXARIFADO' }, 'k-alm');
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: TENANT,
+        itemId: ITEM_ID,
+        type: 'ENTRADA',
+        location: RETURN_LOCATION,
+        quantity: '1',
+        reason: REASON_CLIENT_RETURN,
+      }),
+      expect.anything(),
+    );
+    expect(result.stockMovementId).not.toBeNull();
+    // QR re-link so the M8 sync does not revert the return (§M7).
+    expect(stockRepo.insertMovementQrs).toHaveBeenCalledWith(
+      TENANT,
+      result.stockMovementId,
+      [{ qrValue: QR }],
+      expect.anything(),
+    );
+  });
+
+  it('destination ALMOXARIFADO without a QR-shaped label skips the re-link (still ENTRADA)', async () => {
+    const { service, stockRepo } = build({
+      field: { getUnitProductForUpdate: jest.fn(async () => makeUnit({ label: null })) },
+    });
+    const result = await service.moveUnitProduct(CTX, UNIT_ID, { destination: 'ALMOXARIFADO' }, 'k-alm2');
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(stockRepo.insertMovementQrs).not.toHaveBeenCalled();
+    expect(result.stockMovementId).not.toBeNull();
+  });
+
+  it('destination AVARIADO creates the damage report (source Cliente) and NO stock movement', async () => {
+    const { service, fieldRepo, stockRepo } = build();
+    const result = await service.moveUnitProduct(
+      CTX,
+      UNIT_ID,
+      { destination: 'AVARIADO', notes: 'display quebrado' },
+      'k-ava',
+    );
+
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(fieldRepo.insertDamagedItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: TENANT,
+        itemId: ITEM_ID,
+        quantity: 1,
+        source: 'Cliente',
+        sourceDetail: expect.stringContaining(QR), // projeto/label — keeps the QR recoverable
+        reason: 'display quebrado',
+      }),
+      expect.anything(),
+    );
+    expect(result.damagedItemId).not.toBeNull();
+  });
+
+  it('a unit already moved cannot move again → 409 INV_ALREADY_IN_STATE', async () => {
+    const { service, stockRepo } = build({
+      field: { getUnitProductForUpdate: jest.fn(async () => makeUnit({ movedTo: 'TECNICO' })) },
+    });
+    await expect(
+      service.moveUnitProduct(CTX, UNIT_ID, { destination: 'ALMOXARIFADO' }, 'k-dup'),
+    ).rejects.toMatchObject({ statusCode: 409, code: 'INV_ALREADY_IN_STATE' });
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('return to stock without a linked item → 400 (no orphan ENTRADA)', async () => {
+    const { service, stockRepo } = build({
+      field: { getUnitProductForUpdate: jest.fn(async () => makeUnit({ itemId: null })) },
+    });
+    await expect(
+      service.moveUnitProduct(CTX, UNIT_ID, { destination: 'ALMOXARIFADO' }, 'k-noitem'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+});
+
+describe('M7 technician move × ledger (anti-double-count)', () => {
+  it.each([
+    ['UNIDADE', { movementId: DISPATCH_ID, destination: 'UNIDADE' as const, quantity: 2, projectId: '11111111-2222-4333-8444-555555555555' }],
+    ['PERDIDO', { movementId: DISPATCH_ID, destination: 'PERDIDO' as const, quantity: 2 }],
+  ])('destination %s is tracking-only — NO stock movement', async (_dest, dto) => {
+    const { service, stockRepo } = build();
+    const result = await service.createTechnicianMove(CTX, dto, `t-${_dest}`);
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(result.stockMovementId).toBeNull();
+  });
+
+  it('destination UNIDADE creates quantity inv_unit_products WITHOUT label in the project', async () => {
+    const { service, fieldRepo } = build();
+    const result = await service.createTechnicianMove(
+      CTX,
+      { movementId: DISPATCH_ID, destination: 'UNIDADE', quantity: 3, projectId: '11111111-2222-4333-8444-555555555555' },
+      't-uni',
+    );
+    expect(fieldRepo.insertUnitProducts).toHaveBeenCalledTimes(1);
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs).toHaveLength(3);
+    for (const input of inputs) {
+      expect(input.label).toBeNull();
+      expect(input.itemId).toBe(ITEM_ID);
+      expect(input.clientNameSnapshot).toBe('Projeto Moxuara'); // Projeto = Cliente
+    }
+    expect(result.createdUnitProductIds).toHaveLength(3);
+  });
+
+  it('destination ALMOXARIFADO writes ENTRADA "Devolução do técnico <nome>" + re-links QRs', async () => {
+    const { service, fieldRepo, stockRepo } = build({
+      field: {
+        listMovementQrs: jest.fn(async () => [
+          { id: 'q1', tenantId: TENANT, movementId: DISPATCH_ID, qrValue: '1_1', boxQr: null, homologationUnitId: null },
+          { id: 'q2', tenantId: TENANT, movementId: DISPATCH_ID, qrValue: '1_2', boxQr: null, homologationUnitId: null },
+        ]),
+      },
+    });
+    const result = await service.createTechnicianMove(
+      CTX,
+      { movementId: DISPATCH_ID, destination: 'ALMOXARIFADO', quantity: 2, qrValues: ['1_1', '1_2'] },
+      't-alm',
+    );
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ENTRADA',
+        location: RETURN_LOCATION,
+        quantity: '2',
+        reason: reasonTechnicianReturn(TECHNICIAN),
+      }),
+      expect.anything(),
+    );
+    expect(stockRepo.insertMovementQrs).toHaveBeenCalledWith(
+      TENANT,
+      result.stockMovementId,
+      [{ qrValue: '1_1' }, { qrValue: '1_2' }],
+      expect.anything(),
+    );
+    expect(fieldRepo.insertTechnicianMove).toHaveBeenCalledWith(
+      expect.objectContaining({ movementId: DISPATCH_ID, destination: 'ALMOXARIFADO', quantity: 2 }),
+      expect.anything(),
+    );
+  });
+
+  it('destination AVARIADO creates the damage report (source Técnico) and NO stock movement', async () => {
+    const { service, fieldRepo, stockRepo } = build();
+    const result = await service.createTechnicianMove(
+      CTX,
+      { movementId: DISPATCH_ID, destination: 'AVARIADO', quantity: 2, notes: 'queimou na instalação' },
+      't-ava',
+    );
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(fieldRepo.insertDamagedItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: ITEM_ID,
+        quantity: 2,
+        source: 'Técnico',
+        sourceDetail: TECHNICIAN,
+        reason: 'queimou na instalação',
+      }),
+      expect.anything(),
+    );
+    expect(result.damagedItemId).not.toBeNull();
+  });
+
+  it('a non-dispatch movement (no responsible) is rejected', async () => {
+    const { service } = build({
+      field: { lockDispatch: jest.fn(async () => makeDispatchMovement({ responsible: null }) as never) },
+    });
+    await expect(
+      service.createTechnicianMove(CTX, { movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 1 }, 't-bad'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe('M7 damaged report from stock × ledger', () => {
+  it('POST damage from stock writes a balance-guarded SAIDA "Item avariado — <motivo>"', async () => {
+    const { service, fieldRepo, stockRepo } = build();
+    const result = await service.createDamagedItem(
+      CTX,
+      { itemId: ITEM_ID, quantity: 2, location: 'ALMOXARIFADO', reason: 'oxidação' },
+      'd-1',
+    );
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SAIDA',
+        location: 'ALMOXARIFADO',
+        quantity: '2',
+        reason: reasonDamaged('oxidação'),
+      }),
+      expect.anything(),
+    );
+    expect(fieldRepo.insertDamagedItem).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'Estoque', quantity: 2, reason: 'oxidação' }),
+      expect.anything(),
+    );
+    expect(result.stockMovementId).toBeDefined();
+  });
+
+  it('quantity above the location balance → 409 INV_INSUFFICIENT_STOCK (no writes)', async () => {
+    const { service, fieldRepo, stockRepo } = build({
+      stock: {
+        getBalance: jest.fn(async () => ({ balance: '1', totalIn: '1', totalOut: '0', lastMovementAt: null })),
+      },
+    });
+    await expect(
+      service.createDamagedItem(CTX, { itemId: ITEM_ID, quantity: 2, location: 'FABRICA', reason: 'x' }, 'd-2'),
+    ).rejects.toMatchObject({ statusCode: 409, code: 'INV_INSUFFICIENT_STOCK' });
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+    expect(fieldRepo.insertDamagedItem).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/inventory/m7-contract.test.ts
+++ b/tests/unit/inventory/m7-contract.test.ts
@@ -1,0 +1,427 @@
+/**
+ * RFC-0061 M7 — wired-contract test for the REAL field routes.
+ *
+ * Same harness as m1..m5-contract: real router + real auth middleware, auth
+ * leaves mocked, the M7 service mocked (no DB). Documents the standing guards:
+ * the movement-writing POSTs (move / technician-moves / damaged-items /
+ * recover) require an Idempotency-Key; DTO validation → 400; malformed path
+ * ids → 400.
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryFieldService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryFieldService');
+  return {
+    ...actual,
+    inventoryFieldService: {
+      listUnitProducts: jest.fn(),
+      createUnitProduct: jest.fn(),
+      updateUnitProduct: jest.fn(),
+      moveUnitProduct: jest.fn(),
+      listTechnicianItems: jest.fn(),
+      createTechnicianMove: jest.fn(),
+      listDamagedItems: jest.fn(),
+      createDamagedItem: jest.fn(),
+      recoverDamagedItem: jest.fn(),
+    },
+  };
+});
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryFieldService } from '../../../src/services/inventory/InventoryFieldService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const UNIT_ID = '99999999-9999-4999-8999-999999999999';
+const DAMAGED_ID = 'dddddddd-4444-4444-8444-444444444444';
+const DISPATCH_ID = 'cccccccc-3333-4333-8333-333333333333';
+const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T };
+
+const fieldSvc = inventoryFieldService as jest.Mocked<typeof inventoryFieldService>;
+
+const emptyPage = { items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M7 unit-product routes — real contract (was 501)', () => {
+  it('GET /unit-products → 200; defaults to active-only listing', async () => {
+    fieldSvc.listUnitProducts.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/unit-products?page=1&pageSize=20'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(fieldSvc.listUnitProducts).toHaveBeenCalledWith(
+        TENANT,
+        expect.objectContaining({ page: 1, pageSize: 20, includeMoved: false }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /unit-products?includeMoved=true passes the filter through', async () => {
+    fieldSvc.listUnitProducts.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/unit-products?includeMoved=true'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(fieldSvc.listUnitProducts).toHaveBeenCalledWith(TENANT, expect.objectContaining({ includeMoved: true }));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products with a valid body → 201 (no Idempotency-Key needed — no ledger write)', async () => {
+    fieldSvc.createUnitProduct.mockResolvedValue({ id: UNIT_ID, status: 'PARADO' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/unit-products'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId: ITEM_ID, label: '1_2' }),
+      });
+      expect(res.status).toBe(201);
+      expect(fieldSvc.createUnitProduct).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        expect.objectContaining({ itemId: ITEM_ID, label: '1_2' }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products with a bad body → 400 VALIDATION_ERROR', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/unit-products'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: '1_2' }), // itemId missing
+      });
+      expect(res.status).toBe(400);
+      expect(fieldSvc.createUnitProduct).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('PATCH /unit-products/:id toggles the status; malformed id → 400', async () => {
+    fieldSvc.updateUnitProduct.mockResolvedValue({ id: UNIT_ID, status: 'INSTALADO' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const ok = await fetch(U(srv.url, `/unit-products/${UNIT_ID}`), {
+        method: 'PATCH',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'INSTALADO' }),
+      });
+      expect(ok.status).toBe(200);
+      expect(fieldSvc.updateUnitProduct).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        UNIT_ID,
+        { status: 'INSTALADO' },
+      );
+
+      const bad = await fetch(U(srv.url, '/unit-products/not-a-uuid'), {
+        method: 'PATCH',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'INSTALADO' }),
+      });
+      expect(bad.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products/:id/move without Idempotency-Key → 400 INV_IDEMPOTENCY_KEY_MISSING', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/unit-products/${UNIT_ID}/move`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ destination: 'ALMOXARIFADO' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(fieldSvc.moveUnitProduct).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products/:id/move — TECNICO without technician → 400 (DTO superRefine)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/unit-products/${UNIT_ID}/move`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'k-1' },
+        body: JSON.stringify({ destination: 'TECNICO' }),
+      });
+      expect(res.status).toBe(400);
+      expect(fieldSvc.moveUnitProduct).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products/:id/move — AVARIADO without notes → 400 (DTO superRefine)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/unit-products/${UNIT_ID}/move`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'k-2' },
+        body: JSON.stringify({ destination: 'AVARIADO' }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /unit-products/:id/move with key + valid body → 200', async () => {
+    fieldSvc.moveUnitProduct.mockResolvedValue({ unit: { id: UNIT_ID }, stockMovementId: null, damagedItemId: null } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/unit-products/${UNIT_ID}/move`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'k-3' },
+        body: JSON.stringify({ destination: 'PERDIDO' }),
+      });
+      expect(res.status).toBe(200);
+      expect(fieldSvc.moveUnitProduct).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        UNIT_ID,
+        expect.objectContaining({ destination: 'PERDIDO' }),
+        'k-3',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M7 technician routes — real contract', () => {
+  it('GET /technician-items → 200 grouped listing', async () => {
+    fieldSvc.listTechnicianItems.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/technician-items'), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ items: unknown[] }>;
+      expect(body.data.items).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /technician-moves without Idempotency-Key → 400', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/technician-moves'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 1 }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /technician-moves — UNIDADE without projectId → 400 (DTO superRefine)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/technician-moves'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 't-1' },
+        body: JSON.stringify({ movementId: DISPATCH_ID, destination: 'UNIDADE', quantity: 1 }),
+      });
+      expect(res.status).toBe(400);
+      expect(fieldSvc.createTechnicianMove).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /technician-moves with key + valid body → 201', async () => {
+    fieldSvc.createTechnicianMove.mockResolvedValue({ id: 'm-1', destination: 'PERDIDO' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/technician-moves'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 't-2' },
+        body: JSON.stringify({ movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 1 }),
+      });
+      expect(res.status).toBe(201);
+      expect(fieldSvc.createTechnicianMove).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        expect.objectContaining({ movementId: DISPATCH_ID, quantity: 1 }),
+        't-2',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M7 damaged routes — real contract', () => {
+  it('GET /damaged-items → 200', async () => {
+    fieldSvc.listDamagedItems.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/damaged-items?status=AVARIADO'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(fieldSvc.listDamagedItems).toHaveBeenCalledWith(TENANT, expect.objectContaining({ status: 'AVARIADO' }));
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /damaged-items without Idempotency-Key → 400 (it writes a SAIDA)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/damaged-items'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId: ITEM_ID, quantity: 1, location: 'ALMOXARIFADO', reason: 'x' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /damaged-items with key + valid body → 201', async () => {
+    fieldSvc.createDamagedItem.mockResolvedValue({ damaged: { id: DAMAGED_ID }, stockMovementId: 'mv-1' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/damaged-items'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'd-1' },
+        body: JSON.stringify({ itemId: ITEM_ID, quantity: 1, location: 'ALMOXARIFADO', reason: 'oxidação' }),
+      });
+      expect(res.status).toBe(201);
+      expect(fieldSvc.createDamagedItem).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        expect.objectContaining({ itemId: ITEM_ID, location: 'ALMOXARIFADO' }),
+        'd-1',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /damaged-items/:id/recover — TECNICO without technician → 400; valid → 200', async () => {
+    fieldSvc.recoverDamagedItem.mockResolvedValue({
+      damaged: { id: DAMAGED_ID, status: 'RECUPERADO' },
+      entryMovementId: 'mv-2',
+      exitMovementId: null,
+      createdUnitProductIds: [],
+      relinkedQr: null,
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const bad = await fetch(U(srv.url, `/damaged-items/${DAMAGED_ID}/recover`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'r-1' },
+        body: JSON.stringify({ destination: 'TECNICO' }),
+      });
+      expect(bad.status).toBe(400);
+
+      const ok = await fetch(U(srv.url, `/damaged-items/${DAMAGED_ID}/recover`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json', 'Idempotency-Key': 'r-2' },
+        body: JSON.stringify({ destination: 'ESTOQUE' }),
+      });
+      expect(ok.status).toBe(200);
+      expect(fieldSvc.recoverDamagedItem).toHaveBeenCalledWith(
+        { tenantId: TENANT, userId: 'key-1' },
+        DAMAGED_ID,
+        expect.objectContaining({ destination: 'ESTOQUE', location: 'ALMOXARIFADO' }),
+        'r-2',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /damaged-items/:id/recover without Idempotency-Key → 400', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/damaged-items/${DAMAGED_ID}/recover`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ destination: 'ESTOQUE' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(fieldSvc.recoverDamagedItem).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m7-helpers.ts
+++ b/tests/unit/inventory/m7-helpers.ts
@@ -1,0 +1,269 @@
+// Shared fixtures/mocks for the RFC-0061 M7 unit suites (service with mocked
+// field + stock + QR-registry repositories — no DB). Reuses the M2 item and
+// movement factories.
+
+import type {
+  IInventoryFieldRepository,
+  IFieldStockRepository,
+  IFieldQrRegistryRepository,
+} from '../../../src/services/inventory/InventoryFieldService';
+import type {
+  InvUnitProductRow,
+  InvTechnicianMoveRow,
+  InvDamagedItemRow,
+  DispatchRow,
+  NewUnitProductInput,
+  NewTechnicianMoveInput,
+  NewDamagedItemInput,
+  InvProjectRow,
+} from '../../../src/repositories/inventory/InventoryFieldRepository';
+import type {
+  NewMovementInput,
+  NewMovementQrInput,
+  InvMovementQrRow,
+} from '../../../src/repositories/inventory/InventoryStockRepository';
+import type { InvQrRegistryRow } from '../../../src/repositories/inventory/InventoryHomologationRepository';
+import { makeItem, movementRowFrom, TENANT, USER, ITEM_ID } from './m2-helpers';
+
+export { TENANT, USER, ITEM_ID };
+export const CTX = { tenantId: TENANT, userId: USER };
+
+export const UNIT_ID = '99999999-9999-4999-8999-999999999999';
+export const PROJECT_ID = 'aaaaaaaa-1111-4111-8111-111111111111';
+export const CUSTOMER_ID = 'bbbbbbbb-2222-4222-8222-222222222222';
+export const DISPATCH_ID = 'cccccccc-3333-4333-8333-333333333333';
+export const DAMAGED_ID = 'dddddddd-4444-4444-8444-444444444444';
+export const PHOTO_ID = '44444444-4444-4444-4444-444444444444';
+export const QR = '250101_000123';
+export const TECHNICIAN = 'João da Silva';
+
+let seq = 0;
+function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+}
+
+export function makeUnit(overrides: Partial<InvUnitProductRow> = {}): InvUnitProductRow {
+  return {
+    id: UNIT_ID,
+    tenantId: TENANT,
+    itemId: ITEM_ID,
+    label: QR,
+    status: 'PARADO',
+    installedAt: null,
+    projectId: PROJECT_ID,
+    customerId: CUSTOMER_ID,
+    clientNameSnapshot: 'Cliente Moxuara',
+    expeditionOrderId: null,
+    movedTo: null,
+    movedTechnician: null,
+    movePhotoFileId: null,
+    movedAt: null,
+    moveNotes: null,
+    notes: null,
+    createdAt: new Date('2026-03-01T00:00:00Z'),
+    createdBy: USER,
+    updatedAt: new Date('2026-03-01T00:00:00Z'),
+    ...overrides,
+  } as InvUnitProductRow;
+}
+
+export function makeProject(overrides: Partial<InvProjectRow> = {}): InvProjectRow {
+  return {
+    id: PROJECT_ID,
+    tenantId: TENANT,
+    name: 'Projeto Moxuara',
+    description: null,
+    customerId: CUSTOMER_ID,
+    legacyClientName: null,
+    legacyClientCnpj: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    createdBy: null,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    updatedBy: null,
+    ...overrides,
+  } as InvProjectRow;
+}
+
+export function makeDamaged(overrides: Partial<InvDamagedItemRow> = {}): InvDamagedItemRow {
+  return {
+    id: DAMAGED_ID,
+    tenantId: TENANT,
+    itemId: ITEM_ID,
+    productNameSnapshot: 'Item de teste',
+    quantity: 1,
+    source: 'Cliente',
+    sourceDetail: `Projeto Moxuara / ${QR}`,
+    reason: 'display quebrado',
+    photoFileId: null,
+    status: 'AVARIADO',
+    recoveredTo: null,
+    recoveryNotes: null,
+    recoveredBy: null,
+    recoveredAt: null,
+    createdAt: new Date('2026-04-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvDamagedItemRow;
+}
+
+export function makeDispatchRow(overrides: Partial<DispatchRow> = {}): DispatchRow {
+  return {
+    movementId: DISPATCH_ID,
+    itemId: ITEM_ID,
+    itemName: 'Item de teste',
+    technician: TECHNICIAN,
+    location: 'ALMOXARIFADO',
+    quantity: '5',
+    movedQuantity: 0,
+    reason: 'Saída para técnico',
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+/** The dispatch as its raw inv_stock_movements row (for lockDispatch). */
+export function makeDispatchMovement(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DISPATCH_ID,
+    tenantId: TENANT,
+    itemId: ITEM_ID,
+    location: 'ALMOXARIFADO',
+    quantity: '5',
+    type: 'SAIDA',
+    reason: 'Saída para técnico',
+    responsible: TECHNICIAN,
+    photoFileId: null,
+    purchaseOrderId: null,
+    transferGroupId: null,
+    imported: false,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  };
+}
+
+export function makeRegistryRow(overrides: Partial<InvQrRegistryRow> = {}): InvQrRegistryRow {
+  return {
+    id: nextId('eeeeeeee'),
+    tenantId: TENANT,
+    qrValue: QR,
+    kind: 'UNIT',
+    itemId: ITEM_ID,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: null,
+    ...overrides,
+  } as InvQrRegistryRow;
+}
+
+export type MockFieldRepo = jest.Mocked<IInventoryFieldRepository>;
+export type MockStockRepo = jest.Mocked<IFieldStockRepository>;
+export type MockQrRepo = jest.Mocked<IFieldQrRegistryRepository>;
+
+/** Field repo mock: withTransaction just runs the callback. */
+export function makeFieldRepo(overrides: Record<string, jest.Mock> = {}): MockFieldRepo {
+  const repo = {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    listUnitProducts: jest.fn(async () => ({ rows: [], total: 0 })),
+    getUnitProduct: jest.fn(async () => null),
+    getUnitProductForUpdate: jest.fn(async () => makeUnit()),
+    findUnitByLabel: jest.fn(async () => null),
+    insertUnitProducts: jest.fn(async (inputs: NewUnitProductInput[]) =>
+      inputs.map((input) =>
+        makeUnit({
+          id: nextId('99999999'),
+          itemId: input.itemId ?? null,
+          label: input.label ?? null,
+          status: input.status ?? 'PARADO',
+          projectId: input.projectId ?? null,
+          customerId: input.customerId ?? null,
+          clientNameSnapshot: input.clientNameSnapshot ?? null,
+          notes: input.notes ?? null,
+        }),
+      ),
+    ),
+    updateUnitStatus: jest.fn(async (_t: string, id: string, status: string, installedAt: Date | null) =>
+      makeUnit({ id, status, installedAt }),
+    ),
+    markUnitMoved: jest.fn(async (_t: string, id: string, fields: Record<string, unknown>) =>
+      makeUnit({ id, ...(fields as Partial<InvUnitProductRow>) }),
+    ),
+    listDispatches: jest.fn(async () => [] as DispatchRow[]),
+    lockDispatch: jest.fn(async () => makeDispatchMovement() as never),
+    sumTechnicianMoves: jest.fn(async () => 0),
+    insertTechnicianMove: jest.fn(async (input: NewTechnicianMoveInput) =>
+      ({
+        id: nextId('ffffffff'),
+        tenantId: input.tenantId,
+        movementId: input.movementId,
+        itemId: input.itemId ?? null,
+        technician: input.technician ?? null,
+        destination: input.destination,
+        projectId: input.projectId ?? null,
+        quantity: input.quantity,
+        notes: input.notes ?? null,
+        createdAt: new Date('2026-05-02T00:00:00Z'),
+        createdBy: input.createdBy ?? null,
+      }) as InvTechnicianMoveRow,
+    ),
+    listMovementQrs: jest.fn(async () => [] as InvMovementQrRow[]),
+    listDamagedItems: jest.fn(async () => ({ rows: [], total: 0 })),
+    getDamagedItemForUpdate: jest.fn(async () => makeDamaged()),
+    insertDamagedItem: jest.fn(async (input: NewDamagedItemInput) =>
+      makeDamaged({
+        id: nextId('dddddddd'),
+        itemId: input.itemId ?? null,
+        productNameSnapshot: input.productNameSnapshot ?? null,
+        quantity: input.quantity,
+        source: input.source ?? null,
+        sourceDetail: input.sourceDetail ?? null,
+        reason: input.reason ?? null,
+        photoFileId: input.photoFileId ?? null,
+      }),
+    ),
+    markDamagedRecovered: jest.fn(async (_t: string, id: string, fields: Record<string, unknown>) =>
+      makeDamaged({
+        id,
+        status: 'RECUPERADO',
+        ...(fields as Partial<InvDamagedItemRow>),
+      }),
+    ),
+    getProject: jest.fn(async () => makeProject()),
+  } as unknown as MockFieldRepo;
+  return Object.assign(repo, overrides);
+}
+
+/** Stock repo mock (the M2 seam composed inside the field tx). */
+export function makeStockRepo(overrides: Record<string, jest.Mock> = {}): MockStockRepo {
+  const repo = {
+    lockItem: jest.fn(async (_tenant: string, itemId: string) => makeItem({ id: itemId })),
+    getBalance: jest.fn(async () => ({ balance: '100', totalIn: '100', totalOut: '0', lastMovementAt: null })),
+    insertMovement: jest.fn(async (input: NewMovementInput) => movementRowFrom(input)),
+    insertMovementQrs: jest.fn(
+      async (tenantId: string, movementId: string, qrs: NewMovementQrInput[]) =>
+        qrs.map(
+          (q, i) =>
+            ({
+              id: `55555555-0000-4000-8000-${String(i).padStart(12, '0')}`,
+              tenantId,
+              movementId,
+              qrValue: q.qrValue ?? null,
+              boxQr: q.boxQr ?? null,
+              homologationUnitId: q.homologationUnitId ?? null,
+            }) as InvMovementQrRow,
+        ),
+    ),
+  } as unknown as MockStockRepo;
+  return Object.assign(repo, overrides);
+}
+
+/** QR-registry repo mock (M5 seam): every code is a homologated UNIT QR. */
+export function makeQrRepo(overrides: Record<string, jest.Mock> = {}): MockQrRepo {
+  const repo = {
+    findRegistryByValues: jest.fn(async (_tenant: string, values: string[]) =>
+      values.map((qrValue) => makeRegistryRow({ qrValue })),
+    ),
+    getItem: jest.fn(async (_tenant: string, itemId: string) => makeItem({ id: itemId })),
+  } as unknown as MockQrRepo;
+  return Object.assign(repo, overrides);
+}

--- a/tests/unit/inventory/m7-recover.test.ts
+++ b/tests/unit/inventory/m7-recover.test.ts
@@ -1,0 +1,213 @@
+/**
+ * RFC-0061 M7 — damaged-item recovery (3 destinations + QR re-link).
+ *
+ * Every recovery writes an ENTRADA "Recuperação de item avariado"; TECNICO and
+ * UNIDADE add a paired SAIDA in the same transaction (custody leaves stock
+ * again); UNIDADE also creates the unit products, the FIRST inheriting the QR
+ * as label. When source_detail carries a QR code (`\d+(_\d+)+`) it is
+ * re-linked on the new movements — without it the M8 sync would revert the
+ * recovery on its next run.
+ */
+
+import {
+  InventoryFieldService,
+  REASON_DAMAGED_RECOVERY,
+  extractQrFromSourceDetail,
+} from '../../../src/services/inventory/InventoryFieldService';
+import {
+  CTX,
+  TENANT,
+  ITEM_ID,
+  DAMAGED_ID,
+  QR,
+  TECHNICIAN,
+  PROJECT_ID,
+  makeFieldRepo,
+  makeStockRepo,
+  makeQrRepo,
+  makeDamaged,
+  makeUnit,
+} from './m7-helpers';
+
+function build(overrides: {
+  field?: Record<string, jest.Mock>;
+  stock?: Record<string, jest.Mock>;
+} = {}) {
+  const fieldRepo = makeFieldRepo(overrides.field);
+  const stockRepo = makeStockRepo(overrides.stock);
+  const service = new InventoryFieldService(fieldRepo, stockRepo, makeQrRepo());
+  return { service, fieldRepo, stockRepo };
+}
+
+describe('extractQrFromSourceDetail', () => {
+  it.each([
+    [`Projeto Moxuara / ${QR}`, QR],
+    [QR, QR],
+    ['sem código aqui', null],
+    ['técnico João', null],
+    [null, null],
+    [undefined, null],
+    ['1234', null], // a bare number is not a QR code (needs at least one _)
+    ['prefixo 12_34_56 sufixo', '12_34_56'],
+  ])('%p → %p', (input, expected) => {
+    expect(extractQrFromSourceDetail(input)).toBe(expected);
+  });
+});
+
+describe('M7 recover — destination ESTOQUE', () => {
+  it('writes ONE ENTRADA with the recovery reason and re-links the QR from source_detail', async () => {
+    const { service, fieldRepo, stockRepo } = build();
+    const result = await service.recoverDamagedItem(CTX, DAMAGED_ID, { destination: 'ESTOQUE', location: 'ALMOXARIFADO' }, 'rc-1');
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(1);
+    expect(stockRepo.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ENTRADA',
+        location: 'ALMOXARIFADO',
+        quantity: '1',
+        itemId: ITEM_ID,
+        reason: REASON_DAMAGED_RECOVERY,
+      }),
+      expect.anything(),
+    );
+    // Re-link — the sync's latest-event-per-QR must see this ENTRADA.
+    expect(stockRepo.insertMovementQrs).toHaveBeenCalledWith(
+      TENANT,
+      result.entryMovementId,
+      [{ qrValue: QR }],
+      expect.anything(),
+    );
+    expect(result.exitMovementId).toBeNull();
+    expect(result.createdUnitProductIds).toEqual([]);
+    expect(result.relinkedQr).toBe(QR);
+    expect(fieldRepo.markDamagedRecovered).toHaveBeenCalledWith(
+      TENANT,
+      DAMAGED_ID,
+      expect.objectContaining({ recoveredTo: 'ESTOQUE', recoveredBy: CTX.userId }),
+      expect.anything(),
+    );
+    expect(result.damaged.status).toBe('RECUPERADO');
+  });
+
+  it('no QR in source_detail → no re-link, recovery still lands', async () => {
+    const { service, stockRepo } = build({
+      field: { getDamagedItemForUpdate: jest.fn(async () => makeDamaged({ sourceDetail: 'avaria interna' })) },
+    });
+    const result = await service.recoverDamagedItem(CTX, DAMAGED_ID, { destination: 'ESTOQUE', location: 'FABRICA' }, 'rc-2');
+    expect(stockRepo.insertMovementQrs).not.toHaveBeenCalled();
+    expect(result.relinkedQr).toBeNull();
+  });
+});
+
+describe('M7 recover — destination TECNICO', () => {
+  it('writes ENTRADA + SAIDA with responsible, both QR-linked', async () => {
+    const { service, stockRepo } = build();
+    const result = await service.recoverDamagedItem(
+      CTX,
+      DAMAGED_ID,
+      { destination: 'TECNICO', location: 'ALMOXARIFADO', technician: TECHNICIAN },
+      'rc-3',
+    );
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(2);
+    expect(stockRepo.insertMovement).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ type: 'ENTRADA', reason: REASON_DAMAGED_RECOVERY }),
+      expect.anything(),
+    );
+    expect(stockRepo.insertMovement).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ type: 'SAIDA', responsible: TECHNICIAN, quantity: '1' }),
+      expect.anything(),
+    );
+    expect(result.exitMovementId).not.toBeNull();
+    // Both legs carry the QR — the latest event reflects the technician custody.
+    expect(stockRepo.insertMovementQrs).toHaveBeenCalledTimes(2);
+    expect(stockRepo.insertMovementQrs).toHaveBeenLastCalledWith(
+      TENANT,
+      result.exitMovementId,
+      [{ qrValue: QR }],
+      expect.anything(),
+    );
+  });
+});
+
+describe('M7 recover — destination UNIDADE', () => {
+  it('writes ENTRADA + SAIDA and creates the unit products; the FIRST inherits the QR', async () => {
+    const { service, fieldRepo, stockRepo } = build({
+      field: { getDamagedItemForUpdate: jest.fn(async () => makeDamaged({ quantity: 3 })) },
+    });
+    const result = await service.recoverDamagedItem(
+      CTX,
+      DAMAGED_ID,
+      { destination: 'UNIDADE', location: 'ALMOXARIFADO', projectId: PROJECT_ID },
+      'rc-4',
+    );
+
+    expect(stockRepo.insertMovement).toHaveBeenCalledTimes(2);
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs).toHaveLength(3);
+    expect(inputs[0].label).toBe(QR);
+    expect(inputs[1].label).toBeNull();
+    expect(inputs[2].label).toBeNull();
+    expect(inputs[0].projectId).toBe(PROJECT_ID);
+    expect(inputs[0].clientNameSnapshot).toBe('Projeto Moxuara');
+    expect(result.createdUnitProductIds).toHaveLength(3);
+  });
+
+  it('does NOT inherit the QR when another unit row already holds that label', async () => {
+    const { service, fieldRepo } = build({
+      field: { findUnitByLabel: jest.fn(async () => makeUnit({ label: QR, movedTo: 'ALMOXARIFADO' })) },
+    });
+    await service.recoverDamagedItem(
+      CTX,
+      DAMAGED_ID,
+      { destination: 'UNIDADE', location: 'ALMOXARIFADO', projectId: PROJECT_ID },
+      'rc-5',
+    );
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs[0].label).toBeNull();
+  });
+
+  it('unknown project → 404 (nothing persisted after the guard)', async () => {
+    const { service, fieldRepo } = build({ field: { getProject: jest.fn(async () => null) } });
+    await expect(
+      service.recoverDamagedItem(
+        CTX,
+        DAMAGED_ID,
+        { destination: 'UNIDADE', location: 'ALMOXARIFADO', projectId: PROJECT_ID },
+        'rc-6',
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 });
+    expect(fieldRepo.insertUnitProducts).not.toHaveBeenCalled();
+    expect(fieldRepo.markDamagedRecovered).not.toHaveBeenCalled();
+  });
+});
+
+describe('M7 recover — guards', () => {
+  it('already RECUPERADO → 409 INV_ALREADY_IN_STATE (no movements)', async () => {
+    const { service, stockRepo } = build({
+      field: { getDamagedItemForUpdate: jest.fn(async () => makeDamaged({ status: 'RECUPERADO' })) },
+    });
+    await expect(
+      service.recoverDamagedItem(CTX, DAMAGED_ID, { destination: 'ESTOQUE', location: 'ALMOXARIFADO' }, 'rc-7'),
+    ).rejects.toMatchObject({ statusCode: 409, code: 'INV_ALREADY_IN_STATE' });
+    expect(stockRepo.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('unknown damaged item → 404', async () => {
+    const { service } = build({ field: { getDamagedItemForUpdate: jest.fn(async () => null) } });
+    await expect(
+      service.recoverDamagedItem(CTX, DAMAGED_ID, { destination: 'ESTOQUE', location: 'ALMOXARIFADO' }, 'rc-8'),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('damaged row without item → 400 (cannot write ledger movements)', async () => {
+    const { service } = build({
+      field: { getDamagedItemForUpdate: jest.fn(async () => makeDamaged({ itemId: null })) },
+    });
+    await expect(
+      service.recoverDamagedItem(CTX, DAMAGED_ID, { destination: 'ESTOQUE', location: 'ALMOXARIFADO' }, 'rc-9'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});

--- a/tests/unit/inventory/m7-technician-remaining.test.ts
+++ b/tests/unit/inventory/m7-technician-remaining.test.ts
@@ -1,0 +1,162 @@
+/**
+ * RFC-0061 M7 — technician custody: per-dispatch remaining.
+ *
+ * A dispatch = SAIDA with a responsible; remaining = quantity − Σ
+ * inv_technician_moves.quantity. GET groups by technician, omits zeroed
+ * dispatches and attaches the dispatch QRs; POST validates 1..remaining under
+ * the dispatch row lock.
+ */
+
+import { InventoryFieldService } from '../../../src/services/inventory/InventoryFieldService';
+import {
+  CTX,
+  TENANT,
+  DISPATCH_ID,
+  TECHNICIAN,
+  makeFieldRepo,
+  makeStockRepo,
+  makeQrRepo,
+  makeDispatchRow,
+} from './m7-helpers';
+
+function build(overrides: { field?: Record<string, jest.Mock> } = {}) {
+  const fieldRepo = makeFieldRepo(overrides.field);
+  const service = new InventoryFieldService(fieldRepo, makeStockRepo(), makeQrRepo());
+  return { service, fieldRepo };
+}
+
+describe('M7 GET technician-items — remaining & grouping', () => {
+  it('computes remaining = quantity − Σ moves and groups by technician', async () => {
+    const { service } = build({
+      field: {
+        listDispatches: jest.fn(async () => [
+          makeDispatchRow({ movementId: 'a1a1a1a1-0000-4000-8000-000000000001', quantity: '5', movedQuantity: 2 }),
+          makeDispatchRow({
+            movementId: 'a1a1a1a1-0000-4000-8000-000000000002',
+            technician: 'Maria',
+            quantity: '3',
+            movedQuantity: 0,
+          }),
+        ]),
+      },
+    });
+
+    const result = await service.listTechnicianItems(TENANT, { page: 1, pageSize: 20 });
+    expect(result.total).toBe(2);
+    const joao = result.items.find((g) => g.technician === TECHNICIAN);
+    const maria = result.items.find((g) => g.technician === 'Maria');
+    expect(joao?.totalRemaining).toBe(3);
+    expect(joao?.dispatches[0]).toMatchObject({ quantity: 5, movedQuantity: 2, remaining: 3 });
+    expect(maria?.totalRemaining).toBe(3);
+  });
+
+  it('omits fully-consumed dispatches (and technicians left with none)', async () => {
+    const { service } = build({
+      field: {
+        listDispatches: jest.fn(async () => [
+          makeDispatchRow({ movementId: 'a1a1a1a1-0000-4000-8000-000000000003', quantity: '5', movedQuantity: 5 }),
+          makeDispatchRow({
+            movementId: 'a1a1a1a1-0000-4000-8000-000000000004',
+            technician: 'Maria',
+            quantity: '2',
+            movedQuantity: 1,
+          }),
+        ]),
+      },
+    });
+
+    const result = await service.listTechnicianItems(TENANT, { page: 1, pageSize: 20 });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].technician).toBe('Maria');
+    expect(result.items[0].dispatches[0].remaining).toBe(1);
+  });
+
+  it('attaches the dispatch QRs to each open dispatch', async () => {
+    const { service, fieldRepo } = build({
+      field: {
+        listDispatches: jest.fn(async () => [makeDispatchRow({ quantity: '2', movedQuantity: 0 })]),
+        listMovementQrs: jest.fn(async () => [
+          { id: 'q1', tenantId: TENANT, movementId: DISPATCH_ID, qrValue: '1_1', boxQr: null, homologationUnitId: null },
+        ]),
+      },
+    });
+
+    const result = await service.listTechnicianItems(TENANT, { page: 1, pageSize: 20 });
+    expect(fieldRepo.listMovementQrs).toHaveBeenCalledWith(TENANT, [DISPATCH_ID]);
+    expect(result.items[0].dispatches[0].qrs).toEqual([{ qrValue: '1_1', boxQr: null }]);
+  });
+});
+
+describe('M7 POST technician-moves — remaining guard', () => {
+  it('accepts quantity exactly equal to the remaining', async () => {
+    const { service, fieldRepo } = build({
+      field: { sumTechnicianMoves: jest.fn(async () => 3) }, // dispatch qty 5 → remaining 2
+    });
+    await service.createTechnicianMove(CTX, { movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 2 }, 'r-1');
+    expect(fieldRepo.insertTechnicianMove).toHaveBeenCalledWith(
+      expect.objectContaining({ quantity: 2, technician: TECHNICIAN }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects quantity above the remaining → 400 (no writes)', async () => {
+    const { service, fieldRepo } = build({
+      field: { sumTechnicianMoves: jest.fn(async () => 4) }, // remaining 1
+    });
+    await expect(
+      service.createTechnicianMove(CTX, { movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 2 }, 'r-2'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(fieldRepo.insertTechnicianMove).not.toHaveBeenCalled();
+  });
+
+  it('locks the dispatch row before summing (remaining check is race-free)', async () => {
+    const order: string[] = [];
+    const { service } = build({
+      field: {
+        lockDispatch: jest.fn(async () => {
+          order.push('lock');
+          return (await import('./m7-helpers')).makeDispatchMovement() as never;
+        }),
+        sumTechnicianMoves: jest.fn(async () => {
+          order.push('sum');
+          return 0;
+        }),
+      },
+    });
+    await service.createTechnicianMove(CTX, { movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 1 }, 'r-3');
+    expect(order).toEqual(['lock', 'sum']);
+  });
+
+  it('unknown dispatch → 404', async () => {
+    const { service } = build({ field: { lockDispatch: jest.fn(async () => null) } });
+    await expect(
+      service.createTechnicianMove(CTX, { movementId: DISPATCH_ID, destination: 'PERDIDO', quantity: 1 }, 'r-4'),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('qrValues must match quantity and belong to the dispatch', async () => {
+    const { service } = build({
+      field: {
+        listMovementQrs: jest.fn(async () => [
+          { id: 'q1', tenantId: TENANT, movementId: DISPATCH_ID, qrValue: '1_1', boxQr: null, homologationUnitId: null },
+        ]),
+      },
+    });
+    // count mismatch (2 QRs would be required for quantity 2)
+    await expect(
+      service.createTechnicianMove(
+        CTX,
+        { movementId: DISPATCH_ID, destination: 'ALMOXARIFADO', quantity: 2, qrValues: ['1_1'] },
+        'r-5',
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    // foreign QR
+    await expect(
+      service.createTechnicianMove(
+        CTX,
+        { movementId: DISPATCH_ID, destination: 'ALMOXARIFADO', quantity: 1, qrValues: ['9_9'] },
+        'r-6',
+      ),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});

--- a/tests/unit/inventory/m7-unit-label.test.ts
+++ b/tests/unit/inventory/m7-unit-label.test.ts
@@ -1,0 +1,161 @@
+/**
+ * RFC-0061 M7 — unit-product creation: label = available homologated QR.
+ *
+ * The optional label is validated against M5: it must exist in
+ * inv_qr_registry as a UNIT QR and must not be the label of another ACTIVE
+ * unit product (the DB unique index — spanning moved units too — is the
+ * backstop, mapped to 409).
+ */
+
+import { InventoryFieldService } from '../../../src/services/inventory/InventoryFieldService';
+import {
+  CTX,
+  TENANT,
+  ITEM_ID,
+  QR,
+  PROJECT_ID,
+  makeFieldRepo,
+  makeStockRepo,
+  makeQrRepo,
+  makeUnit,
+  makeRegistryRow,
+} from './m7-helpers';
+
+function build(overrides: {
+  field?: Record<string, jest.Mock>;
+  qr?: Record<string, jest.Mock>;
+} = {}) {
+  const fieldRepo = makeFieldRepo(overrides.field);
+  const qrRepo = makeQrRepo(overrides.qr);
+  const service = new InventoryFieldService(fieldRepo, makeStockRepo(), qrRepo);
+  return { service, fieldRepo, qrRepo };
+}
+
+describe('M7 POST unit-products — label validation', () => {
+  it('valid homologated label → creates the unit with status PARADO', async () => {
+    const { service, fieldRepo, qrRepo } = build();
+    const result = await service.createUnitProduct(CTX, { itemId: ITEM_ID, label: QR, projectId: PROJECT_ID });
+
+    expect(qrRepo.findRegistryByValues).toHaveBeenCalledWith(TENANT, [QR], expect.anything());
+    expect(fieldRepo.findUnitByLabel).toHaveBeenCalledWith(TENANT, QR, true, expect.anything());
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs[0]).toMatchObject({
+      itemId: ITEM_ID,
+      label: QR,
+      status: 'PARADO',
+      projectId: PROJECT_ID,
+      clientNameSnapshot: 'Projeto Moxuara', // Projeto = Cliente
+    });
+    expect(result.label).toBe(QR);
+    expect(result.status).toBe('PARADO');
+  });
+
+  it('label given as the full QR URL is normalized to the bare code', async () => {
+    const { service, fieldRepo } = build();
+    await service.createUnitProduct(CTX, { itemId: ITEM_ID, label: `https://produto.myio.com.br/${QR}` });
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs[0].label).toBe(QR);
+  });
+
+  it('label not in the M5 registry → 422 INV_QR_NOT_IN_REGISTRY', async () => {
+    const { service, fieldRepo } = build({
+      qr: { findRegistryByValues: jest.fn(async () => []) },
+    });
+    await expect(service.createUnitProduct(CTX, { itemId: ITEM_ID, label: QR })).rejects.toMatchObject({
+      statusCode: 422,
+      code: 'INV_QR_NOT_IN_REGISTRY',
+    });
+    expect(fieldRepo.insertUnitProducts).not.toHaveBeenCalled();
+  });
+
+  it('a BOX QR cannot be a unit label → 422 INV_QR_NOT_IN_REGISTRY', async () => {
+    const { service } = build({
+      qr: { findRegistryByValues: jest.fn(async () => [makeRegistryRow({ kind: 'BOX' })]) },
+    });
+    await expect(service.createUnitProduct(CTX, { itemId: ITEM_ID, label: QR })).rejects.toMatchObject({
+      statusCode: 422,
+      code: 'INV_QR_NOT_IN_REGISTRY',
+    });
+  });
+
+  it('label already used by another ACTIVE unit → 409 INV_QR_DUPLICATE', async () => {
+    const { service, fieldRepo } = build({
+      field: { findUnitByLabel: jest.fn(async () => makeUnit()) },
+    });
+    await expect(service.createUnitProduct(CTX, { itemId: ITEM_ID, label: QR })).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'INV_QR_DUPLICATE',
+    });
+    expect(fieldRepo.insertUnitProducts).not.toHaveBeenCalled();
+  });
+
+  it('DB unique-index race (23505) maps to a 409 conflict', async () => {
+    const dbErr = Object.assign(new Error('Failed query'), {
+      cause: Object.assign(new Error('duplicate key value violates unique constraint "inv_unit_products_label_uq"'), {
+        code: '23505',
+      }),
+    });
+    const { service } = build({
+      field: { insertUnitProducts: jest.fn(async () => { throw dbErr; }) },
+    });
+    await expect(service.createUnitProduct(CTX, { itemId: ITEM_ID, label: QR })).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+
+  it('no label is fine (units from technician moves have none)', async () => {
+    const { service, fieldRepo, qrRepo } = build();
+    await service.createUnitProduct(CTX, { itemId: ITEM_ID });
+    expect(qrRepo.findRegistryByValues).not.toHaveBeenCalled();
+    const inputs = fieldRepo.insertUnitProducts.mock.calls[0][0];
+    expect(inputs[0].label).toBeNull();
+  });
+
+  it('unknown item → 404', async () => {
+    const { service } = build({ qr: { getItem: jest.fn(async () => null) } });
+    await expect(service.createUnitProduct(CTX, { itemId: ITEM_ID })).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('M7 PATCH unit-products — install toggle', () => {
+  it('PARADO → INSTALADO stamps installed_at', async () => {
+    const { service, fieldRepo } = build();
+    await service.updateUnitProduct(CTX, makeUnit().id, { status: 'INSTALADO' });
+    expect(fieldRepo.updateUnitStatus).toHaveBeenCalledWith(
+      TENANT,
+      makeUnit().id,
+      'INSTALADO',
+      expect.any(Date),
+      expect.anything(),
+    );
+  });
+
+  it('INSTALADO → PARADO clears installed_at', async () => {
+    const { service, fieldRepo } = build({
+      field: {
+        getUnitProductForUpdate: jest.fn(async () =>
+          makeUnit({ status: 'INSTALADO', installedAt: new Date('2026-03-02T00:00:00Z') }),
+        ),
+      },
+    });
+    await service.updateUnitProduct(CTX, makeUnit().id, { status: 'PARADO' });
+    expect(fieldRepo.updateUnitStatus).toHaveBeenCalledWith(TENANT, makeUnit().id, 'PARADO', null, expect.anything());
+  });
+
+  it('toggle to the SAME status → 409 INV_ALREADY_IN_STATE', async () => {
+    const { service } = build();
+    await expect(service.updateUnitProduct(CTX, makeUnit().id, { status: 'PARADO' })).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'INV_ALREADY_IN_STATE',
+    });
+  });
+
+  it('a moved unit cannot be toggled → 409', async () => {
+    const { service } = build({
+      field: { getUnitProductForUpdate: jest.fn(async () => makeUnit({ movedTo: 'PERDIDO' })) },
+    });
+    await expect(service.updateUnitProduct(CTX, makeUnit().id, { status: 'INSTALADO' })).rejects.toMatchObject({
+      statusCode: 409,
+    });
+  });
+});


### PR DESCRIPTION
## RFC-0061 §M7 — Campo (Cliente / Técnico / Avarias) — P3

Implements the field-tracking module on top of the M2 ledger, M5 QR registry and M9 projects, replacing the 501 defers in `field.controller.ts` with real routes.

### What's in

**New files**
- `src/repositories/inventory/InventoryFieldRepository.ts` — `inv_unit_products` / `inv_technician_moves` / `inv_damaged_items` + dispatch views over the M2 ledger. Every mutating method accepts an optional executor (M4 composition pattern); `FOR UPDATE` locks on the unit row, the dispatch movement and the damaged row make the guards race-free.
- `src/services/inventory/InventoryFieldService.ts` — business rules + M7 Zod DTOs (exported from the service module; **follow-up**: fold into `src/dto/request/InventoryDTO.ts` in a consolidating PR, same as M4/M5).
- `tests/unit/inventory/m7-*.test.ts` — 71 cases (see below).

**Edited (only allowed file)**
- `src/controllers/inventory/field.controller.ts` — real routes; movement-writing POSTs (`move`, `technician-moves`, `damaged-items`, `recover`) require `Idempotency-Key` (S1).

### Rules implemented (§M7)

- **unit-products**: GET paginated (default: active = `moved_to IS NULL`; `includeMoved=true` to include moved; `projectId`/`status` filters); POST creates at status `PARADO` with optional label = available homologated QR — validated against M5 (`inv_qr_registry`, kind `UNIT` → 422 `INV_QR_NOT_IN_REGISTRY`; label of another active unit → 409 `INV_QR_DUPLICATE`; DB unique index is the backstop). PATCH toggles `INSTALADO`/`PARADO` stamping/clearing `installed_at` (same status → 409 `INV_ALREADY_IN_STATE`).
- **move** (`/unit-products/:id/move`): destinations `TECNICO|ALMOXARIFADO|PERDIDO|AVARIADO`; `technician` required for TECNICO, `notes` required for AVARIADO (DTO superRefine); records `moved_to`/`moved_technician`/`move_photo_file_id`/`moved_at`/`move_notes`.
  **ANTI-DOUBLE-COUNT**: only `ALMOXARIFADO` writes stock — ENTRADA "Devolução do cliente" **with the QR re-linked in `inv_movement_qrs`** so the M8 sync (latest-event-per-QR) keeps the return instead of reverting it. `AVARIADO` additionally opens `inv_damaged_items` (source "Cliente", `source_detail` = projeto/label — the label keeps the QR recoverable later).
- **technician-items** (GET): dispatches = SAIDAs with `responsible`; per-dispatch remaining = `quantity − Σ inv_technician_moves.quantity`; grouped by technician; zeroed dispatches omitted; dispatch QRs attached. Grouping/pagination in memory (operational scale — noted follow-up for SQL GROUP BY if it grows).
- **technician-moves** (POST): destinations `UNIDADE|PERDIDO|ALMOXARIFADO|AVARIADO`; qty 1..remaining validated **under the dispatch row lock**; `UNIDADE` requires project and creates `quantity` unit products **without label** (Projeto = Cliente snapshot); `ALMOXARIFADO` → ENTRADA "Devolução do técnico <nome>" with QR re-links (optional `qrValues` must match qty and belong to the dispatch); `AVARIADO` → `inv_damaged_items` (source "Técnico"). Pure-tracking moves (`UNIDADE`/`PERDIDO`) never touch the ledger.
- **damaged-items**: GET paginated, `AVARIADO` first; POST reports from stock — qty capped by the location balance (M2 guard under the item lock → 409 `INV_INSUFFICIENT_STOCK`) writing SAIDA "Item avariado — <motivo>". Client/technician damage arrives via the move routes above, never here.
- **recover** (`/damaged-items/:id/recover`): destinations `ESTOQUE|TECNICO|UNIDADE`; always an ENTRADA "Recuperação de item avariado"; `TECNICO` adds a paired SAIDA with `responsible`; `UNIDADE` adds the SAIDA + unit products, the **first inheriting the QR as label** (skipped when another row already holds it — the label index spans moved units). When `source_detail` carries a QR code (`\d+(_\d+)+`) it is **re-linked on the new movement(s)** — documented in the service: without it the 5-minute sync would revert the recovery. Marks `RECUPERADO` with `recovered_to/by/at`. Already recovered → 409 `INV_ALREADY_IN_STATE`.
- All multi-write compositions run in ONE transaction via the field repository's executor seam (M4 pattern); Drizzle error unwrapping via `err.cause` (known gotcha).

### Tests (71 cases, all passing)

| Suite | Covers |
|---|---|
| `m7-anti-double-count` | each move destination × writes/does-not-write ledger (client + technician), damaged-from-stock SAIDA + balance guard |
| `m7-technician-remaining` | remaining computation, grouping, zeroed omission, QR attachment, over-qty rejection, lock-before-sum ordering |
| `m7-recover` | 3 destinations, QR re-link (+extraction table), first-unit label inheritance & conflict skip, guards |
| `m7-unit-label` | label valid / not-in-registry / BOX / duplicate-active / 23505 race / URL normalization; install toggle |
| `m7-contract` | real router + auth, mocked service: Idempotency-Key guards, DTO superRefines, path-id validation, status codes |

### Verification

- `tsc --noEmit` ✅ clean
- `eslint --max-warnings 0` on all new/edited files ✅ clean
- `jest tests/unit/inventory` ✅ 28 suites / 392 tests passing (71 are M7)
- `tests/unit/controllers/inventory.contract.test.ts` — **verified: contains no M7 cases** (no `unit-products`/`technician`/`damaged` references), so it needed no retargeting.
- No changes to `app.ts`, `schema.ts`, `dto/`, errors, `shared.ts`, other modules or the DB.

### Follow-ups

1. Fold the M7 Zod DTOs from the service into `src/dto/request/InventoryDTO.ts` (consolidating PR, same as M4/M5).
2. `inv_unit_products` label unique index spans moved units — a QR returned to stock and re-delivered later cannot become a label again; M6 delivery flow will hit this (decide: partial index on active rows vs clearing labels on return).
3. Technician-items grouping/pagination is in-memory; move to SQL GROUP BY if dispatch volume grows.
4. M8 push outbox: the return/recovery ENTRADAs should enqueue pushes when M8 lands (DEC-6) — the seams are ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvWKPT4KpwdZYVNVAis2qK
