### PR TITLE
feat(inventory): M6 expedition + demand resolution (P3)

### DIFF
--- a/src/controllers/inventory/expedition.controller.ts
+++ b/src/controllers/inventory/expedition.controller.ts
@@ -1,21 +1,198 @@
-import { Router } from 'express';
-import { defer, requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
 import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+import {
+  inventoryExpeditionService,
+  CreateExpeditionOrderSchema,
+  UpdateExpeditionOrderSchema,
+  ExpeditionOrderListQuerySchema,
+  ExpeditionStatusSchema,
+  DeliverItemSchema,
+  ShipExpeditionSchema,
+  ReturnExpeditionSchema,
+  LostExpeditionSchema,
+  FoundExpeditionSchema,
+} from '../../services/inventory/InventoryExpeditionService';
+import { sendSuccess, sendCreated } from '../../middleware/response';
 
-// M6 — Expedição (P3)
+// M6 — Expedição (P3). Real routes (RFC-0061 §M6):
+// - CRUD with project required + items by FK (DEC-5); PATCH replaces items
+//   only while PENDENTE; DELETE requires a confirmationToken.
+// - Server-side state machine (DEC-4): /status for the manual transitions;
+//   EM_TRANSITO and PERDIDO are owned by /ship and /lost (mandatory payloads).
+// - Baixa (deliver): Idempotency-Key required (S1) — photo + stockOnly QRs
+//   (one per manufactured unit, boxes expand) + SAIDA in one transaction.
+// - /return, /lost, /found keep the timestamped note stamps; /transit-progress
+//   reads inv_external_states per delivered QR ("X de Y em transporte").
 const router = Router();
 
-router.get('/expedition-orders', defer('M6', 'P3', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.post('/expedition-orders', defer('M6', 'P3'));
-router.get('/expedition-orders/:id', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.patch('/expedition-orders/:id', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.delete('/expedition-orders/:id', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); requireConfirmation(req); }));
-router.post('/expedition-orders/:id/status', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.post('/expedition-orders/:id/items/:itemId/deliver', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); requireUuid('itemId', req.params.itemId); requireIdempotencyKey(req); }));
-router.post('/expedition-orders/:id/ship', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.post('/expedition-orders/:id/return', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.post('/expedition-orders/:id/lost', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.post('/expedition-orders/:id/found', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
-router.get('/expedition-orders/:id/transit-progress', defer('M6', 'P3', (req) => { requireUuid('id', req.params.id); }));
+// GET /expedition-orders — paginated listing (status/projectId filters).
+router.get('/expedition-orders', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const query = ExpeditionOrderListQuerySchema.parse(req.query);
+    const data = await inventoryExpeditionService.list({ tenantId, userId }, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders — project required, items reference inv_items (DEC-5).
+router.post('/expedition-orders', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const dto = CreateExpeditionOrderSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.create({ tenantId, userId }, dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /expedition-orders/:id — detail with items + allowedTransitions (S3).
+router.get('/expedition-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const data = await inventoryExpeditionService.getById({ tenantId, userId }, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PATCH /expedition-orders/:id — header anywhere; item replace only PENDENTE.
+router.patch('/expedition-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = UpdateExpeditionOrderSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.update({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /expedition-orders/:id — destructive (S3): confirmationToken required.
+router.delete('/expedition-orders/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    requireConfirmation(req);
+    const data = await inventoryExpeditionService.delete({ tenantId, userId }, req.params.id);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders/:id/status — manual transitions (DEC-4).
+router.post('/expedition-orders/:id/status', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = ExpeditionStatusSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.changeStatus({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders/:id/items/:itemId/deliver — baixa (Idempotency-Key).
+router.post(
+  '/expedition-orders/:id/items/:itemId/deliver',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { tenantId, userId, requestId } = req.context;
+      requireUuid('id', req.params.id);
+      requireUuid('itemId', req.params.itemId);
+      const idempotencyKey = requireIdempotencyKey(req);
+      const dto = DeliverItemSchema.parse(req.body ?? {});
+      const data = await inventoryExpeditionService.deliverItem(
+        { tenantId, userId },
+        req.params.id,
+        req.params.itemId,
+        dto,
+        idempotencyKey,
+      );
+      sendCreated(res, data, requestId);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /expedition-orders/:id/ship — mandatory shipment payload → EM_TRANSITO.
+router.post('/expedition-orders/:id/ship', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = ShipExpeditionSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.ship({ tenantId, userId }, req.params.id, dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders/:id/return — motivo obrigatório, back to PRONTO_ENTREGA.
+router.post('/expedition-orders/:id/return', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = ReturnExpeditionSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.returnToExpedition({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders/:id/lost — motivo obrigatório → PERDIDO.
+router.post('/expedition-orders/:id/lost', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = LostExpeditionSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.markLost({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /expedition-orders/:id/found — sector → status mapping (§M6).
+router.post('/expedition-orders/:id/found', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const dto = FoundExpeditionSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.markFound({ tenantId, userId }, req.params.id, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /expedition-orders/:id/transit-progress — "X de Y em transporte".
+router.get('/expedition-orders/:id/transit-progress', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    requireUuid('id', req.params.id);
+    const { page, pageSize } = PaginationQuerySchema.parse(req.query);
+    const data = await inventoryExpeditionService.transitProgress(
+      { tenantId, userId },
+      req.params.id,
+      page,
+      pageSize,
+    );
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/controllers/inventory/production.controller.ts
+++ b/src/controllers/inventory/production.controller.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { defer, requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
+import { requireUuid, requireIdempotencyKey, requireConfirmation } from './shared';
 import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
 import {
   inventoryProductionService,
@@ -9,6 +9,10 @@ import {
   CorrectAssemblyReleaseSchema,
   SimulatorPreviewSchema,
 } from '../../services/inventory/InventoryProductionService';
+import {
+  inventoryExpeditionService,
+  ResolveDemandSchema,
+} from '../../services/inventory/InventoryExpeditionService';
 import { sendSuccess, sendCreated } from '../../middleware/response';
 
 // M4 — Produção (P2). Real routes (RFC-0061 §M4):
@@ -17,7 +21,7 @@ import { sendSuccess, sendCreated } from '../../middleware/response';
 //   BOM explosion into component SAIDAs — one service transaction.
 // - Divergências (issues) + correction with the homologated floor.
 // - Capacity and the preview-only simulator (DEC-13).
-// Demand resolution stays deferred to P3 with M6 (A4).
+// Demand resolution ships with M6 (P3, A4) — served by the expedition service.
 const router = Router();
 
 // GET /production/demands — pending demands grouped by product (paginated).
@@ -32,8 +36,20 @@ router.get('/production/demands', async (req: Request, res: Response, next: Next
   }
 });
 
-// POST /production/resolve-demand — P3 (depends on expedition orders, A4).
-router.post('/production/resolve-demand', defer('M4', 'P3'));
+// POST /production/resolve-demand — §M4 demand resolution (P3, with M6/A4):
+// expedition items short on ALMOXARIFADO stock → production demand
+// (manufactured) or automatic purchase order + purchase demand (purchasable);
+// idempotent per expedition_order_item_id (UNIQUE).
+router.post('/production/resolve-demand', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, userId, requestId } = req.context;
+    const dto = ResolveDemandSchema.parse(req.body ?? {});
+    const data = await inventoryExpeditionService.resolveDemand({ tenantId, userId }, dto);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 // GET /production/capacity — min over BOM components; limiting flagged.
 router.get('/production/capacity', async (req: Request, res: Response, next: NextFunction) => {

--- a/src/repositories/inventory/InventoryExpeditionRepository.ts
+++ b/src/repositories/inventory/InventoryExpeditionRepository.ts
@@ -1,0 +1,652 @@
+// =============================================================================
+// RFC-0061 M6 — Expedition repository (data access only).
+//
+// Owns `inv_expedition_orders`, `inv_expedition_order_items`,
+// `inv_item_deliveries`, `inv_delivery_qrs`, `inv_shipments`,
+// `inv_unit_products` (creation on ENTREGUE_CLIENTE), the two demand tables
+// (`inv_production_demands`, `inv_purchase_demands` — §M4 demand resolution
+// ships with M6, A4), the read path over `inv_external_states` (transit
+// progress) and the `inv_external_push_outbox` enqueue (DEC-6 — rows are
+// inserted in the SAME transaction as the domain write; the drain worker is
+// M8).
+//
+// Conventions (matched from InventoryStockRepository / InventoryProduction-
+// Repository): shared `db` client, tenant-scoped reads, every mutating method
+// accepts an optional executor so the service composes them inside ONE
+// transaction; `withTransaction` exposes the boundary; FOR UPDATE row lock on
+// the order serializes concurrent transitions (DEC-4).
+// =============================================================================
+
+import { and, asc, desc, eq, inArray, or, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+import type { StockTx, StockDbClient } from './InventoryStockRepository';
+
+const {
+  invItems,
+  invProjects,
+  invExpeditionOrders,
+  invExpeditionOrderItems,
+  invItemDeliveries,
+  invDeliveryQrs,
+  invShipments,
+  invUnitProducts,
+  invProductionDemands,
+  invPurchaseDemands,
+  invExternalStates,
+  invExternalPushOutbox,
+} = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as InventoryStockRepository)
+// -----------------------------------------------------------------------------
+
+export type ExpeditionTx = StockTx;
+export type ExpeditionDbClient = StockDbClient;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvExpeditionOrderRow = typeof invExpeditionOrders.$inferSelect;
+export type InvExpeditionOrderItemRow = typeof invExpeditionOrderItems.$inferSelect;
+export type InvItemDeliveryRow = typeof invItemDeliveries.$inferSelect;
+export type InvDeliveryQrRow = typeof invDeliveryQrs.$inferSelect;
+export type InvShipmentRow = typeof invShipments.$inferSelect;
+export type InvUnitProductRow = typeof invUnitProducts.$inferSelect;
+export type InvProductionDemandRow = typeof invProductionDemands.$inferSelect;
+export type InvPurchaseDemandRow = typeof invPurchaseDemands.$inferSelect;
+export type InvProjectRow = typeof invProjects.$inferSelect;
+
+export interface NewExpeditionOrderInput {
+  tenantId: string;
+  title?: string | null;
+  projectId: string;
+  customerId?: string | null;
+  deliveryDate: Date;
+  isReplacement?: boolean;
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface ExpeditionOrderPatch {
+  title?: string | null;
+  projectId?: string;
+  customerId?: string | null;
+  deliveryDate?: Date;
+  isReplacement?: boolean;
+  notes?: string | null;
+  status?: string;
+  updatedBy?: string | null;
+}
+
+export interface NewOrderItemInput {
+  tenantId: string;
+  orderId: string;
+  itemId: string;
+  quantity: number;
+}
+
+export interface OrderItemWithName {
+  id: string;
+  orderId: string;
+  itemId: string;
+  itemName: string;
+  isManufactured: boolean;
+  domain: string;
+  quantity: number;
+}
+
+export interface ExpeditionListFilters {
+  status?: string;
+  projectId?: string;
+}
+
+export interface NewDeliveryInput {
+  tenantId: string;
+  orderId: string;
+  orderItemId: string;
+  quantity: number;
+  photoFileId: string;
+  createdBy?: string | null;
+}
+
+export interface NewDeliveryQrInput {
+  qrValue: string;
+  boxQr?: string | null;
+  homologationUnitId?: string | null;
+}
+
+export interface NewShipmentInput {
+  tenantId: string;
+  orderId: string;
+  address: string;
+  shippingMethod: string;
+  responsible: string;
+  trackingCode: string;
+  proofFileId: string;
+  notes?: string | null;
+  createdBy?: string | null;
+}
+
+export interface NewUnitProductInput {
+  tenantId: string;
+  itemId: string | null;
+  label: string;
+  projectId: string | null;
+  customerId: string | null;
+  clientNameSnapshot: string | null;
+  expeditionOrderId: string;
+  createdBy?: string | null;
+}
+
+/** One delivered QR joined with its order item (labels for unit products). */
+export interface DeliveredQrRow {
+  orderItemId: string;
+  itemId: string;
+  qrValue: string | null;
+  boxQr: string | null;
+  homologationUnitId: string | null;
+}
+
+export interface ExternalStateLiteRow {
+  code: string;
+  qrValue: string | null;
+  location: string | null;
+  status: string | null;
+}
+
+export interface NewPushOutboxInput {
+  qrCodes: string[];
+  location: string;
+  technician?: string | null;
+  clientName?: string | null;
+}
+
+export interface NewProductionDemandInput {
+  tenantId: string;
+  expeditionOrderItemId: string;
+  expeditionOrderId: string;
+  itemId: string;
+  quantity: number;
+}
+
+export interface NewPurchaseDemandInput {
+  tenantId: string;
+  expeditionOrderItemId: string;
+  expeditionOrderId: string;
+  itemId: string;
+  quantity: number;
+  purchaseOrderId?: string | null;
+}
+
+export class InventoryExpeditionRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  async withTransaction<T>(fn: (tx: ExpeditionTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orders
+  // ---------------------------------------------------------------------------
+
+  async list(
+    tenantId: string,
+    page: number,
+    pageSize: number,
+    filters: ExpeditionListFilters = {},
+    client: ExpeditionDbClient = db,
+  ): Promise<{ rows: InvExpeditionOrderRow[]; total: number }> {
+    const conditions: (SQL | undefined)[] = [eq(invExpeditionOrders.tenantId, tenantId)];
+    if (filters.status) conditions.push(eq(invExpeditionOrders.status, filters.status));
+    if (filters.projectId) conditions.push(eq(invExpeditionOrders.projectId, filters.projectId));
+    const where = and(...conditions);
+
+    const rows = await client
+      .select()
+      .from(invExpeditionOrders)
+      .where(where)
+      .orderBy(desc(invExpeditionOrders.createdAt), desc(invExpeditionOrders.id))
+      .limit(pageSize)
+      .offset((page - 1) * pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invExpeditionOrders)
+      .where(where);
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  async getById(
+    tenantId: string,
+    id: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<InvExpeditionOrderRow | null> {
+    const [row] = await client
+      .select()
+      .from(invExpeditionOrders)
+      .where(and(eq(invExpeditionOrders.tenantId, tenantId), eq(invExpeditionOrders.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  /** FOR UPDATE lock — serializes concurrent transitions/deliveries (DEC-4). */
+  async lockById(tenantId: string, id: string, tx: ExpeditionTx): Promise<InvExpeditionOrderRow | null> {
+    const [row] = await tx
+      .select()
+      .from(invExpeditionOrders)
+      .where(and(eq(invExpeditionOrders.tenantId, tenantId), eq(invExpeditionOrders.id, id)))
+      .limit(1)
+      .for('update');
+    return row ?? null;
+  }
+
+  async insertOrder(input: NewExpeditionOrderInput, client: ExpeditionDbClient = db): Promise<InvExpeditionOrderRow> {
+    const [row] = await client
+      .insert(invExpeditionOrders)
+      .values({
+        tenantId: input.tenantId,
+        title: input.title ?? null,
+        projectId: input.projectId,
+        customerId: input.customerId ?? null,
+        deliveryDate: input.deliveryDate,
+        isReplacement: input.isReplacement ?? false,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+        updatedBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async updateOrder(
+    tenantId: string,
+    id: string,
+    patch: ExpeditionOrderPatch,
+    client: ExpeditionDbClient = db,
+  ): Promise<InvExpeditionOrderRow | null> {
+    const [row] = await client
+      .update(invExpeditionOrders)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(and(eq(invExpeditionOrders.tenantId, tenantId), eq(invExpeditionOrders.id, id)))
+      .returning();
+    return row ?? null;
+  }
+
+  /** Hard delete — items/deliveries/QRs/shipments CASCADE by schema. */
+  async deleteOrder(tenantId: string, id: string, client: ExpeditionDbClient = db): Promise<boolean> {
+    const rows = await client
+      .delete(invExpeditionOrders)
+      .where(and(eq(invExpeditionOrders.tenantId, tenantId), eq(invExpeditionOrders.id, id)))
+      .returning({ id: invExpeditionOrders.id });
+    return rows.length > 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Order items
+  // ---------------------------------------------------------------------------
+
+  async listItemsByOrders(
+    tenantId: string,
+    orderIds: string[],
+    client: ExpeditionDbClient = db,
+  ): Promise<OrderItemWithName[]> {
+    if (orderIds.length === 0) return [];
+    return client
+      .select({
+        id: invExpeditionOrderItems.id,
+        orderId: invExpeditionOrderItems.orderId,
+        itemId: invExpeditionOrderItems.itemId,
+        itemName: invItems.name,
+        isManufactured: invItems.isManufactured,
+        domain: invItems.domain,
+        quantity: invExpeditionOrderItems.quantity,
+      })
+      .from(invExpeditionOrderItems)
+      .innerJoin(invItems, eq(invItems.id, invExpeditionOrderItems.itemId))
+      .where(and(eq(invExpeditionOrderItems.tenantId, tenantId), inArray(invExpeditionOrderItems.orderId, orderIds)))
+      .orderBy(asc(invItems.name), asc(invExpeditionOrderItems.id));
+  }
+
+  async getOrderItem(
+    tenantId: string,
+    orderItemId: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<OrderItemWithName | null> {
+    const [row] = await client
+      .select({
+        id: invExpeditionOrderItems.id,
+        orderId: invExpeditionOrderItems.orderId,
+        itemId: invExpeditionOrderItems.itemId,
+        itemName: invItems.name,
+        isManufactured: invItems.isManufactured,
+        domain: invItems.domain,
+        quantity: invExpeditionOrderItems.quantity,
+      })
+      .from(invExpeditionOrderItems)
+      .innerJoin(invItems, eq(invItems.id, invExpeditionOrderItems.itemId))
+      .where(and(eq(invExpeditionOrderItems.tenantId, tenantId), eq(invExpeditionOrderItems.id, orderItemId)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async insertItems(
+    rows: NewOrderItemInput[],
+    client: ExpeditionDbClient = db,
+  ): Promise<InvExpeditionOrderItemRow[]> {
+    if (rows.length === 0) return [];
+    return client.insert(invExpeditionOrderItems).values(rows).returning();
+  }
+
+  /** PATCH item replace: wipes the order's items (deliveries CASCADE with them). */
+  async deleteItemsByOrder(tenantId: string, orderId: string, client: ExpeditionDbClient = db): Promise<number> {
+    const rows = await client
+      .delete(invExpeditionOrderItems)
+      .where(and(eq(invExpeditionOrderItems.tenantId, tenantId), eq(invExpeditionOrderItems.orderId, orderId)))
+      .returning({ id: invExpeditionOrderItems.id });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Deliveries (baixa/separação)
+  // ---------------------------------------------------------------------------
+
+  /** Σ delivered per order item (drives auto-status + the "disponível" guard). */
+  async deliveredQuantities(
+    tenantId: string,
+    orderId: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<Map<string, number>> {
+    const rows = await client
+      .select({
+        orderItemId: invItemDeliveries.orderItemId,
+        total: sql<number>`coalesce(sum(${invItemDeliveries.quantity}), 0)::int`,
+      })
+      .from(invItemDeliveries)
+      .where(and(eq(invItemDeliveries.tenantId, tenantId), eq(invItemDeliveries.orderId, orderId)))
+      .groupBy(invItemDeliveries.orderItemId);
+    return new Map(rows.map((r) => [r.orderItemId, r.total]));
+  }
+
+  async insertDelivery(input: NewDeliveryInput, client: ExpeditionDbClient = db): Promise<InvItemDeliveryRow> {
+    const [row] = await client
+      .insert(invItemDeliveries)
+      .values({
+        tenantId: input.tenantId,
+        orderId: input.orderId,
+        orderItemId: input.orderItemId,
+        quantity: input.quantity,
+        photoFileId: input.photoFileId,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async insertDeliveryQrs(
+    tenantId: string,
+    deliveryId: string,
+    orderItemId: string,
+    qrs: NewDeliveryQrInput[],
+    client: ExpeditionDbClient = db,
+  ): Promise<InvDeliveryQrRow[]> {
+    if (qrs.length === 0) return [];
+    return client
+      .insert(invDeliveryQrs)
+      .values(
+        qrs.map((q) => ({
+          tenantId,
+          deliveryId,
+          orderItemId,
+          qrValue: q.qrValue,
+          boxQr: q.boxQr ?? null,
+          homologationUnitId: q.homologationUnitId ?? null,
+        })),
+      )
+      .returning();
+  }
+
+  /** All delivered QRs of one order, joined with the order item (labels). */
+  async deliveredQrsByOrder(
+    tenantId: string,
+    orderId: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<DeliveredQrRow[]> {
+    return client
+      .select({
+        orderItemId: invDeliveryQrs.orderItemId,
+        itemId: invExpeditionOrderItems.itemId,
+        qrValue: invDeliveryQrs.qrValue,
+        boxQr: invDeliveryQrs.boxQr,
+        homologationUnitId: invDeliveryQrs.homologationUnitId,
+      })
+      .from(invDeliveryQrs)
+      .innerJoin(invItemDeliveries, eq(invItemDeliveries.id, invDeliveryQrs.deliveryId))
+      .innerJoin(invExpeditionOrderItems, eq(invExpeditionOrderItems.id, invDeliveryQrs.orderItemId))
+      .where(and(eq(invDeliveryQrs.tenantId, tenantId), eq(invItemDeliveries.orderId, orderId)))
+      .orderBy(asc(invItemDeliveries.createdAt), asc(invDeliveryQrs.id));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shipments
+  // ---------------------------------------------------------------------------
+
+  async insertShipment(input: NewShipmentInput, client: ExpeditionDbClient = db): Promise<InvShipmentRow> {
+    const [row] = await client
+      .insert(invShipments)
+      .values({
+        tenantId: input.tenantId,
+        orderId: input.orderId,
+        address: input.address,
+        shippingMethod: input.shippingMethod,
+        responsible: input.responsible,
+        trackingCode: input.trackingCode,
+        proofFileId: input.proofFileId,
+        notes: input.notes ?? null,
+        createdBy: input.createdBy ?? null,
+      })
+      .returning();
+    return row;
+  }
+
+  async listShipments(
+    tenantId: string,
+    orderId: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<InvShipmentRow[]> {
+    return client
+      .select()
+      .from(invShipments)
+      .where(and(eq(invShipments.tenantId, tenantId), eq(invShipments.orderId, orderId)))
+      .orderBy(desc(invShipments.createdAt), desc(invShipments.id));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Unit products (ENTREGUE_CLIENTE — M7 table, creation owned by M6)
+  // ---------------------------------------------------------------------------
+
+  /** Labels already taken tenant-wide among the candidates (unique per tenant). */
+  async existingUnitProductLabels(
+    tenantId: string,
+    labels: string[],
+    client: ExpeditionDbClient = db,
+  ): Promise<Set<string>> {
+    if (labels.length === 0) return new Set();
+    const rows = await client
+      .select({ label: invUnitProducts.label })
+      .from(invUnitProducts)
+      .where(and(eq(invUnitProducts.tenantId, tenantId), inArray(invUnitProducts.label, labels)));
+    return new Set(rows.map((r) => r.label).filter((l): l is string => !!l));
+  }
+
+  async insertUnitProducts(
+    rows: NewUnitProductInput[],
+    client: ExpeditionDbClient = db,
+  ): Promise<InvUnitProductRow[]> {
+    if (rows.length === 0) return [];
+    return client
+      .insert(invUnitProducts)
+      .values(
+        rows.map((r) => ({
+          tenantId: r.tenantId,
+          itemId: r.itemId,
+          label: r.label,
+          status: 'PARADO',
+          projectId: r.projectId,
+          customerId: r.customerId,
+          clientNameSnapshot: r.clientNameSnapshot,
+          expeditionOrderId: r.expeditionOrderId,
+          createdBy: r.createdBy ?? null,
+        })),
+      )
+      .returning();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Projects (read-only helper — "Projeto = Cliente" rule)
+  // ---------------------------------------------------------------------------
+
+  async getProject(tenantId: string, id: string, client: ExpeditionDbClient = db): Promise<InvProjectRow | null> {
+    const [row] = await client
+      .select()
+      .from(invProjects)
+      .where(and(eq(invProjects.tenantId, tenantId), eq(invProjects.id, id)))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // External states (transit progress) + push outbox (DEC-6)
+  // ---------------------------------------------------------------------------
+
+  /** Mirror rows matching any candidate spelling (code or qr_value). */
+  async externalStatesByCodes(
+    tenantId: string,
+    values: string[],
+    client: ExpeditionDbClient = db,
+  ): Promise<ExternalStateLiteRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select({
+        code: invExternalStates.code,
+        qrValue: invExternalStates.qrValue,
+        location: invExternalStates.location,
+        status: invExternalStates.status,
+      })
+      .from(invExternalStates)
+      .where(
+        and(
+          eq(invExternalStates.tenantId, tenantId),
+          or(inArray(invExternalStates.code, values), inArray(invExternalStates.qrValue, values)),
+        ),
+      );
+  }
+
+  /** Enqueue one push-outbox row IN the caller's transaction (DEC-6). */
+  async enqueuePush(
+    tenantId: string,
+    input: NewPushOutboxInput,
+    client: ExpeditionDbClient = db,
+  ): Promise<void> {
+    if (input.qrCodes.length === 0) return;
+    await client.insert(invExternalPushOutbox).values({
+      tenantId,
+      qrCodes: input.qrCodes,
+      location: input.location,
+      technician: input.technician ?? null,
+      clientName: input.clientName ?? null,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Demand resolution (§M4, A4 — idempotent per expedition_order_item_id)
+  // ---------------------------------------------------------------------------
+
+  async findProductionDemandsByOrderItemIds(
+    tenantId: string,
+    orderItemIds: string[],
+    client: ExpeditionDbClient = db,
+  ): Promise<InvProductionDemandRow[]> {
+    if (orderItemIds.length === 0) return [];
+    return client
+      .select()
+      .from(invProductionDemands)
+      .where(
+        and(
+          eq(invProductionDemands.tenantId, tenantId),
+          inArray(invProductionDemands.expeditionOrderItemId, orderItemIds),
+        ),
+      );
+  }
+
+  async findPurchaseDemandsByOrderItemIds(
+    tenantId: string,
+    orderItemIds: string[],
+    client: ExpeditionDbClient = db,
+  ): Promise<InvPurchaseDemandRow[]> {
+    if (orderItemIds.length === 0) return [];
+    return client
+      .select()
+      .from(invPurchaseDemands)
+      .where(
+        and(
+          eq(invPurchaseDemands.tenantId, tenantId),
+          inArray(invPurchaseDemands.expeditionOrderItemId, orderItemIds),
+        ),
+      );
+  }
+
+  /** Idempotent insert — the UNIQUE(order_item) makes replays a no-op (null). */
+  async insertProductionDemand(
+    input: NewProductionDemandInput,
+    client: ExpeditionDbClient = db,
+  ): Promise<InvProductionDemandRow | null> {
+    const [row] = await client
+      .insert(invProductionDemands)
+      .values({
+        tenantId: input.tenantId,
+        expeditionOrderItemId: input.expeditionOrderItemId,
+        expeditionOrderId: input.expeditionOrderId,
+        itemId: input.itemId,
+        quantity: input.quantity,
+      })
+      .onConflictDoNothing({ target: invProductionDemands.expeditionOrderItemId })
+      .returning();
+    return row ?? null;
+  }
+
+  /** Idempotent insert — claims the UNIQUE before the automatic PO exists. */
+  async insertPurchaseDemand(
+    input: NewPurchaseDemandInput,
+    client: ExpeditionDbClient = db,
+  ): Promise<InvPurchaseDemandRow | null> {
+    const [row] = await client
+      .insert(invPurchaseDemands)
+      .values({
+        tenantId: input.tenantId,
+        expeditionOrderItemId: input.expeditionOrderItemId,
+        expeditionOrderId: input.expeditionOrderId,
+        itemId: input.itemId,
+        quantity: input.quantity,
+        purchaseOrderId: input.purchaseOrderId ?? null,
+      })
+      .onConflictDoNothing({ target: invPurchaseDemands.expeditionOrderItemId })
+      .returning();
+    return row ?? null;
+  }
+
+  async setPurchaseDemandOrder(
+    tenantId: string,
+    demandId: string,
+    purchaseOrderId: string,
+    client: ExpeditionDbClient = db,
+  ): Promise<void> {
+    await client
+      .update(invPurchaseDemands)
+      .set({ purchaseOrderId })
+      .where(and(eq(invPurchaseDemands.tenantId, tenantId), eq(invPurchaseDemands.id, demandId)));
+  }
+}
+
+export const inventoryExpeditionRepository = new InventoryExpeditionRepository();

--- a/src/services/inventory/InventoryExpeditionService.ts
+++ b/src/services/inventory/InventoryExpeditionService.ts
@@ -1,0 +1,1502 @@
+// =============================================================================
+// RFC-0061 M6 — Expedição service (business rules) + §M4 demand resolution.
+//
+// Owns the §M6 rules on top of InventoryExpeditionRepository:
+//   - CRUD: project required (DEC-5 — items reference inv_items by FK),
+//     delivery date, is_replacement badge; PATCH edits the header anywhere but
+//     replaces items only while PENDENTE (deliveries CASCADE with items —
+//     INV_EDIT_LOCKED_STATE 409 otherwise); DELETE is destructive
+//     (confirmationToken guarded in the controller).
+//   - State machine: EXPEDITION_ORDER_TRANSITIONS enforced server-side (DEC-4)
+//     under a FOR UPDATE order lock — illegal → INV_ILLEGAL_TRANSITION 409
+//     (body carries current + allowedTransitions), repeat →
+//     INV_ALREADY_IN_STATE 409; reads expose allowedTransitions (S3). The
+//     generic /status endpoint redirects EM_TRANSITO to /ship and PERDIDO to
+//     /lost so their mandatory payloads can never be skipped.
+//   - Baixa (deliver): quantity ≤ remaining, photo required, manufactured item
+//     → EXACTLY one QR per unit, stockOnly (homologation registry + not
+//     already used; box QRs expand to their units — M5 repo reads, in-tx);
+//     writes inv_item_deliveries + inv_delivery_qrs + the SAIDA movement
+//     (reason "Baixa para pedido Myio") composing the M2 repository seam
+//     inside ONE transaction (same trade-off as M4: InventoryStockService.
+//     createMovement owns its own transaction, so this service drives
+//     inventoryStockRepository.lockItem/getBalance/insertMovement with the
+//     delivery transaction's executor and re-applies the negative-stock
+//     guard). Auto-status: all items delivered → PRONTO_ENTREGA, else
+//     PRODUZINDO; never regresses ENTREGUE_CLIENTE.
+//   - Ship: mandatory address/method/responsible/tracking/proof →
+//     inv_shipments + EM_TRANSITO.
+//   - ENTREGUE_CLIENTE: creates one inv_unit_products row per delivered unit
+//     (idempotent — existing labels are skipped), labels matched from the
+//     delivery QRs, "Projeto = Cliente" (client_name_snapshot = project name;
+//     customer_id from the project when set), status PARADO.
+//   - Return / lost / found: mandatory reason with the timestamped note stamps
+//     ("[Retornado para Expedição em …]", "[Mercadoria perdida em …]",
+//     "[Mercadoria encontrada em …]"); found maps the chosen sector to the
+//     target status (Cliente → ENTREGUE_CLIENTE + unit products).
+//   - Transit progress: per delivered QR against inv_external_states (no row =
+//     "em transporte" by default) → "X de Y em transporte" + per item.
+//   - External push (DEC-6): rows enqueued into inv_external_push_outbox in
+//     the SAME transaction (deliver → expedicao, ship → transporte,
+//     ENTREGUE_CLIENTE → cliente, return → expedicao, lost → perdido, found →
+//     sector). The HTTP client/drain worker is M8.
+//   - §M4 demand resolution (POST /production/resolve-demand, A4): expedition
+//     items short on ALMOXARIFADO stock → inv_production_demands
+//     (manufactured) or an automatic purchase order (recipient/delivery point
+//     "Estoque", CUSTOMIZADO deadline = delivery date, note "Demanda
+//     automática do pedido") + inv_purchase_demands (purchasable) — idempotent
+//     per expedition_order_item_id (UNIQUE, onConflictDoNothing).
+//
+// M6 DTOs live here (exported Zod schemas): the RFC finalizes later-phase DTOs
+// at implementation time and src/dto is frozen for this PR (module-boundary
+// rule) — follow-up: fold them into src/dto/request/InventoryDTO.ts in a
+// consolidating PR (same follow-up as M4/M5).
+// =============================================================================
+
+import { z } from 'zod';
+import {
+  InventoryExpeditionRepository,
+  inventoryExpeditionRepository,
+  ExpeditionTx,
+  InvExpeditionOrderRow,
+  InvShipmentRow,
+  OrderItemWithName,
+  DeliveredQrRow,
+  NewDeliveryQrInput,
+} from '../../repositories/inventory/InventoryExpeditionRepository';
+import {
+  InventoryStockRepository,
+  inventoryStockRepository,
+} from '../../repositories/inventory/InventoryStockRepository';
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+  InvHomologationRow,
+  InvHomologationUnitRow,
+  InvQrRegistryRow,
+  UnitWithHomologationRow,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import {
+  InventoryItemRepository,
+  inventoryItemRepository,
+} from '../../repositories/inventory/InventoryItemRepository';
+import {
+  InventoryPurchaseOrderService,
+  inventoryPurchaseOrderService,
+} from './InventoryPurchaseOrderService';
+import { normalizeQrInput } from './InventoryQrService';
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ValidationError,
+} from '../../shared/errors/AppError';
+import {
+  InventoryError,
+  alreadyInState,
+  editLockedState,
+  illegalTransition,
+  insufficientStock,
+  qrAlreadyUsed,
+  qrNotInRegistry,
+  qrWrongItem,
+} from '../../shared/errors/InventoryError';
+import {
+  EXPEDITION_ORDER_TRANSITIONS,
+  INV_SHIPPING_METHODS,
+  InvExpeditionStatus,
+} from '../../domain/entities/Inventory';
+import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+import type {
+  InvPaginatedResponse,
+  InvExpeditionOrderResponse,
+} from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Request DTOs (M6 — finalized at implementation time per the RFC)
+// -----------------------------------------------------------------------------
+
+const uuid = z.string().uuid();
+
+const EXPEDITION_STATUSES = [
+  'PENDENTE',
+  'PRODUZINDO',
+  'PRONTO_ENTREGA',
+  'EM_TRANSITO',
+  'ENTREGUE_CLIENTE',
+  'PERDIDO',
+] as const;
+
+const OrderItemsSchema = z
+  .array(z.object({ itemId: uuid, quantity: z.number().int().min(1).max(100000) }).strict())
+  .min(1)
+  .max(200);
+
+function assertUniqueItemIds(items: Array<{ itemId: string }>, ctx: z.RefinementCtx): void {
+  if (new Set(items.map((i) => i.itemId)).size !== items.length) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'duplicate itemId in items', path: ['items'] });
+  }
+}
+
+export const CreateExpeditionOrderSchema = z
+  .object({
+    title: z.string().max(255).optional(),
+    projectId: uuid,
+    customerId: uuid.optional(),
+    deliveryDate: z.string().datetime(),
+    isReplacement: z.boolean().optional(),
+    notes: z.string().max(4096).optional(),
+    items: OrderItemsSchema,
+  })
+  .strict()
+  .superRefine((v, ctx) => assertUniqueItemIds(v.items, ctx));
+export type CreateExpeditionOrderDTO = z.infer<typeof CreateExpeditionOrderSchema>;
+
+export const UpdateExpeditionOrderSchema = z
+  .object({
+    title: z.string().max(255).nullable().optional(),
+    projectId: uuid.optional(),
+    customerId: uuid.nullable().optional(),
+    deliveryDate: z.string().datetime().optional(),
+    isReplacement: z.boolean().optional(),
+    notes: z.string().max(4096).nullable().optional(),
+    /** Full item replace — allowed only while PENDENTE (INV_EDIT_LOCKED_STATE). */
+    items: OrderItemsSchema.optional(),
+  })
+  .strict()
+  .superRefine((v, ctx) => {
+    if (v.items) assertUniqueItemIds(v.items, ctx);
+  });
+export type UpdateExpeditionOrderDTO = z.infer<typeof UpdateExpeditionOrderSchema>;
+
+export const ExpeditionOrderListQuerySchema = PaginationQuerySchema.extend({
+  status: z.enum(EXPEDITION_STATUSES).optional(),
+  projectId: uuid.optional(),
+});
+export type ExpeditionOrderListQuery = z.infer<typeof ExpeditionOrderListQuerySchema>;
+
+export const ExpeditionStatusSchema = z
+  .object({
+    status: z.enum(['PRODUZINDO', 'PRONTO_ENTREGA', 'EM_TRANSITO', 'ENTREGUE_CLIENTE', 'PERDIDO']),
+  })
+  .strict();
+export type ExpeditionStatusDTO = z.infer<typeof ExpeditionStatusSchema>;
+
+export const DeliverItemSchema = z
+  .object({
+    quantity: z.number().int().min(1).max(100000),
+    photoFileId: uuid,
+    /** Bare codes or full produto.myio.com.br URLs; box QRs expand to units. */
+    qrs: z.array(z.string().min(1).max(512)).max(500).optional(),
+  })
+  .strict();
+export type DeliverItemDTO = z.infer<typeof DeliverItemSchema>;
+
+export const ShipExpeditionSchema = z
+  .object({
+    address: z.string().min(1).max(1024),
+    shippingMethod: z.enum(INV_SHIPPING_METHODS as unknown as [string, ...string[]]),
+    responsible: z.string().min(1).max(255),
+    trackingCode: z.string().min(1).max(255),
+    proofFileId: uuid,
+    notes: z.string().max(4096).optional(),
+  })
+  .strict();
+export type ShipExpeditionDTO = z.infer<typeof ShipExpeditionSchema>;
+
+export const ReturnExpeditionSchema = z.object({ reason: z.string().min(1).max(4096) }).strict();
+export type ReturnExpeditionDTO = z.infer<typeof ReturnExpeditionSchema>;
+
+export const LostExpeditionSchema = z.object({ reason: z.string().min(1).max(4096) }).strict();
+export type LostExpeditionDTO = z.infer<typeof LostExpeditionSchema>;
+
+export const FOUND_SECTORS = ['CLIENTE', 'EXPEDICAO', 'TRANSPORTE', 'ESTOQUE'] as const;
+export type InvFoundSector = (typeof FOUND_SECTORS)[number];
+
+export const FoundExpeditionSchema = z
+  .object({
+    sector: z.enum(FOUND_SECTORS),
+    notes: z.string().max(4096).optional(),
+  })
+  .strict();
+export type FoundExpeditionDTO = z.infer<typeof FoundExpeditionSchema>;
+
+export const ResolveDemandSchema = z.object({ expeditionOrderId: uuid }).strict();
+export type ResolveDemandDTO = z.infer<typeof ResolveDemandSchema>;
+
+// -----------------------------------------------------------------------------
+// Response read models
+// -----------------------------------------------------------------------------
+
+export interface InvExpeditionOrderItemResponse {
+  id: string;
+  itemId: string;
+  itemName: string;
+  isManufactured: boolean;
+  quantity: number;
+  delivered: number;
+  remaining: number;
+}
+
+export interface InvExpeditionOrderDetailResponse extends InvExpeditionOrderResponse {
+  notes: string | null;
+  items: InvExpeditionOrderItemResponse[];
+}
+
+export interface InvDeliverResponse {
+  order: InvExpeditionOrderDetailResponse;
+  delivery: {
+    id: string;
+    orderItemId: string;
+    quantity: number;
+    photoFileId: string;
+    createdAt: string;
+  };
+  movementId: string | null;
+  qrs: Array<{ qrValue: string; boxQr: string | null }>;
+  autoAdvanced: boolean;
+}
+
+export interface InvShipmentResponse {
+  id: string;
+  orderId: string;
+  address: string | null;
+  shippingMethod: string;
+  responsible: string | null;
+  trackingCode: string | null;
+  proofFileId: string;
+  notes: string | null;
+  createdAt: string;
+}
+
+export interface InvUnitProductsSummary {
+  created: number;
+  skipped: number;
+  labels: string[];
+}
+
+export interface InvStatusChangeResponse {
+  order: InvExpeditionOrderDetailResponse;
+  unitProducts?: InvUnitProductsSummary;
+}
+
+export interface InvShipResponse {
+  order: InvExpeditionOrderDetailResponse;
+  shipment: InvShipmentResponse;
+}
+
+export interface InvTransitUnit {
+  qrValue: string;
+  inTransit: boolean;
+  externalLocation: string | null;
+  externalStatus: string | null;
+}
+
+export interface InvTransitItemProgress {
+  orderItemId: string;
+  itemId: string;
+  itemName: string;
+  total: number;
+  inTransit: number;
+  units: InvTransitUnit[];
+}
+
+export interface InvTransitProgressResponse extends InvPaginatedResponse<InvTransitItemProgress> {
+  orderId: string;
+  status: InvExpeditionStatus;
+  totalUnits: number;
+  unitsInTransit: number;
+  /** Badge text — "X de Y em transporte". */
+  summary: string;
+}
+
+export type ResolveDemandAction = 'NONE' | 'PRODUCTION_DEMAND' | 'PURCHASE_ORDER' | 'ALREADY_RESOLVED';
+
+export interface InvResolveDemandItemResult {
+  orderItemId: string;
+  itemId: string;
+  itemName: string;
+  required: number;
+  balance: number;
+  shortage: number;
+  action: ResolveDemandAction;
+  productionDemandId?: string;
+  purchaseDemandId?: string;
+  purchaseOrderId?: string;
+}
+
+export interface InvResolveDemandResponse {
+  orderId: string;
+  items: InvResolveDemandItemResult[];
+}
+
+// -----------------------------------------------------------------------------
+// Seams (mocked in unit tests)
+// -----------------------------------------------------------------------------
+
+export type IInventoryExpeditionRepository = Pick<
+  InventoryExpeditionRepository,
+  | 'withTransaction'
+  | 'list'
+  | 'getById'
+  | 'lockById'
+  | 'insertOrder'
+  | 'updateOrder'
+  | 'deleteOrder'
+  | 'listItemsByOrders'
+  | 'getOrderItem'
+  | 'insertItems'
+  | 'deleteItemsByOrder'
+  | 'deliveredQuantities'
+  | 'insertDelivery'
+  | 'insertDeliveryQrs'
+  | 'deliveredQrsByOrder'
+  | 'insertShipment'
+  | 'existingUnitProductLabels'
+  | 'insertUnitProducts'
+  | 'getProject'
+  | 'externalStatesByCodes'
+  | 'enqueuePush'
+  | 'findProductionDemandsByOrderItemIds'
+  | 'findPurchaseDemandsByOrderItemIds'
+  | 'insertProductionDemand'
+  | 'insertPurchaseDemand'
+  | 'setPurchaseDemandOrder'
+>;
+
+/** The M2 seam composed inside the delivery transaction (same as M4). */
+export type IExpeditionStockRepository = Pick<
+  InventoryStockRepository,
+  'lockItem' | 'getBalance' | 'insertMovement' | 'insertMovementQrs' | 'latestQrEventTypes'
+>;
+
+/** The M5 seam — stockOnly QR validation + box expansion, in-tx reads. */
+export type IExpeditionHomologationRepository = Pick<
+  InventoryHomologationRepository,
+  'findRegistryByValues' | 'findUnitsByQrValues' | 'findBoxesByQrValues' | 'unitsByHomologationIds' | 'deliveryEventsByQrs'
+>;
+
+export type IExpeditionItemRepository = Pick<InventoryItemRepository, 'findByIds'>;
+
+/** The M3 seam — automatic purchase order on demand resolution. */
+export type IExpeditionPurchaseOrderService = Pick<InventoryPurchaseOrderService, 'create'>;
+
+export interface ExpeditionContext {
+  tenantId: string;
+  userId?: string;
+}
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/** Finished goods leave the warehouse (homologation entered them there — §M5). */
+export const DELIVERY_LOCATION = 'ALMOXARIFADO';
+export const REASON_EXPEDITION_DELIVERY = 'Baixa para pedido Myio';
+export const AUTO_PURCHASE_RECIPIENT = 'Estoque';
+export const AUTO_PURCHASE_DELIVERY_POINT = 'Estoque';
+export const AUTO_PURCHASE_NOTE = 'Demanda automática do pedido';
+
+/** States that still accept item deliveries (baixa). */
+const DELIVERABLE_STATES: ReadonlySet<string> = new Set(['PENDENTE', 'PRODUZINDO', 'PRONTO_ENTREGA']);
+
+const EXIT_TYPES = new Set(['SAIDA', 'TRANSFERENCIA_OUT']);
+
+const SECTOR_TO_STATUS: Record<InvFoundSector, InvExpeditionStatus> = {
+  CLIENTE: 'ENTREGUE_CLIENTE',
+  EXPEDICAO: 'PRONTO_ENTREGA',
+  TRANSPORTE: 'EM_TRANSITO',
+  ESTOQUE: 'PRODUZINDO',
+};
+
+const SECTOR_TO_PUSH: Record<InvFoundSector, string> = {
+  CLIENTE: 'cliente',
+  EXPEDICAO: 'expedicao',
+  TRANSPORTE: 'transporte',
+  ESTOQUE: 'estoque',
+};
+
+const SECTOR_LABEL: Record<InvFoundSector, string> = {
+  CLIENTE: 'Cliente',
+  EXPEDICAO: 'Expedição',
+  TRANSPORTE: 'Transporte',
+  ESTOQUE: 'Estoque',
+};
+
+// Idempotency cache tuning (best-effort, per-process — same M2/M4 pattern).
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const IDEMPOTENCY_MAX_ENTRIES = 5000;
+
+/** Append a timestamped stamp to the order notes (kept newline-separated). */
+function stampNotes(existing: string | null, stamp: string): string {
+  return existing && existing.trim() !== '' ? `${existing}\n${stamp}` : stamp;
+}
+
+export function returnStamp(isoDate: string, reason: string): string {
+  return `[Retornado para Expedição em ${isoDate}] ${reason}`;
+}
+
+export function lostStamp(isoDate: string, reason: string): string {
+  return `[Mercadoria perdida em ${isoDate}] ${reason}`;
+}
+
+export function foundStamp(isoDate: string, sector: InvFoundSector, notes?: string): string {
+  const base = `[Mercadoria encontrada em ${isoDate}] Setor: ${SECTOR_LABEL[sector]}`;
+  return notes && notes.trim() !== '' ? `${base} — ${notes}` : base;
+}
+
+export class InventoryExpeditionService {
+  private repository: IInventoryExpeditionRepository;
+
+  private stockRepository: IExpeditionStockRepository;
+
+  private homologationRepository: IExpeditionHomologationRepository;
+
+  private itemRepository: IExpeditionItemRepository;
+
+  private purchaseOrderService: IExpeditionPurchaseOrderService;
+
+  private idempotencyCache = new Map<string, { at: number; promise: Promise<unknown> }>();
+
+  constructor(
+    repository?: IInventoryExpeditionRepository,
+    stockRepository?: IExpeditionStockRepository,
+    homologationRepository?: IExpeditionHomologationRepository,
+    itemRepository?: IExpeditionItemRepository,
+    purchaseOrderService?: IExpeditionPurchaseOrderService,
+  ) {
+    this.repository = repository ?? inventoryExpeditionRepository;
+    this.stockRepository = stockRepository ?? inventoryStockRepository;
+    this.homologationRepository = homologationRepository ?? inventoryHomologationRepository;
+    this.itemRepository = itemRepository ?? inventoryItemRepository;
+    this.purchaseOrderService = purchaseOrderService ?? inventoryPurchaseOrderService;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
+
+  async list(
+    ctx: ExpeditionContext,
+    query: ExpeditionOrderListQuery,
+  ): Promise<InvPaginatedResponse<InvExpeditionOrderDetailResponse>> {
+    const { page, pageSize } = query;
+    const { rows, total } = await this.repository.list(ctx.tenantId, page, pageSize, {
+      status: query.status,
+      projectId: query.projectId,
+    });
+    const items = await this.repository.listItemsByOrders(ctx.tenantId, rows.map((r) => r.id));
+    const byOrder = new Map<string, OrderItemWithName[]>();
+    for (const item of items) {
+      const list = byOrder.get(item.orderId) ?? [];
+      list.push(item);
+      byOrder.set(item.orderId, list);
+    }
+    const detailed: InvExpeditionOrderDetailResponse[] = [];
+    for (const row of rows) {
+      const delivered = await this.repository.deliveredQuantities(ctx.tenantId, row.id);
+      detailed.push(this.toDetail(row, byOrder.get(row.id) ?? [], delivered));
+    }
+    return { items: detailed, page, pageSize, total, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  async getById(ctx: ExpeditionContext, id: string): Promise<InvExpeditionOrderDetailResponse> {
+    const order = await this.repository.getById(ctx.tenantId, id);
+    if (!order) throw new NotFoundError(`Expedition order ${id} not found`);
+    return this.loadDetail(ctx, order);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create / update / delete
+  // ---------------------------------------------------------------------------
+
+  async create(ctx: ExpeditionContext, dto: CreateExpeditionOrderDTO): Promise<InvExpeditionOrderDetailResponse> {
+    await this.assertItemsExist(ctx.tenantId, dto.items.map((i) => i.itemId));
+    const project = await this.repository.getProject(ctx.tenantId, dto.projectId);
+    if (!project) throw new ValidationError(`Project ${dto.projectId} not found in tenant`);
+
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.repository.insertOrder(
+          {
+            tenantId: ctx.tenantId,
+            title: dto.title ?? null,
+            projectId: dto.projectId,
+            customerId: dto.customerId ?? project.customerId ?? null,
+            deliveryDate: new Date(dto.deliveryDate),
+            isReplacement: dto.isReplacement ?? false,
+            notes: dto.notes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        await this.repository.insertItems(
+          dto.items.map((i) => ({
+            tenantId: ctx.tenantId,
+            orderId: order.id,
+            itemId: i.itemId,
+            quantity: i.quantity,
+          })),
+          tx,
+        );
+        return this.loadDetail(ctx, order, tx);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  async update(
+    ctx: ExpeditionContext,
+    id: string,
+    dto: UpdateExpeditionOrderDTO,
+  ): Promise<InvExpeditionOrderDetailResponse> {
+    if (dto.items) await this.assertItemsExist(ctx.tenantId, dto.items.map((i) => i.itemId));
+    if (dto.projectId) {
+      const project = await this.repository.getProject(ctx.tenantId, dto.projectId);
+      if (!project) throw new ValidationError(`Project ${dto.projectId} not found in tenant`);
+    }
+
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, id, tx);
+
+        // Item replace only while PENDENTE — the schema CASCADEs deliveries
+        // with the items, so replacing after a baixa would drop history.
+        if (dto.items && order.status !== 'PENDENTE') {
+          throw editLockedState(order.status);
+        }
+
+        const patch: Parameters<IInventoryExpeditionRepository['updateOrder']>[2] = {
+          updatedBy: ctx.userId ?? null,
+        };
+        if (dto.title !== undefined) patch.title = dto.title;
+        if (dto.projectId !== undefined) patch.projectId = dto.projectId;
+        if (dto.customerId !== undefined) patch.customerId = dto.customerId;
+        if (dto.deliveryDate !== undefined) patch.deliveryDate = new Date(dto.deliveryDate);
+        if (dto.isReplacement !== undefined) patch.isReplacement = dto.isReplacement;
+        if (dto.notes !== undefined) patch.notes = dto.notes;
+
+        const updated = (await this.repository.updateOrder(ctx.tenantId, id, patch, tx)) ?? order;
+
+        if (dto.items) {
+          await this.repository.deleteItemsByOrder(ctx.tenantId, id, tx);
+          await this.repository.insertItems(
+            dto.items.map((i) => ({
+              tenantId: ctx.tenantId,
+              orderId: id,
+              itemId: i.itemId,
+              quantity: i.quantity,
+            })),
+            tx,
+          );
+        }
+
+        return this.loadDetail(ctx, updated, tx);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /** Hard delete (destructive — confirmationToken guarded in the controller). */
+  async delete(ctx: ExpeditionContext, id: string): Promise<{ deleted: boolean }> {
+    try {
+      const deleted = await this.repository.deleteOrder(ctx.tenantId, id);
+      if (!deleted) throw new NotFoundError(`Expedition order ${id} not found`);
+      return { deleted: true };
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Generic status transition (DEC-4)
+  // ---------------------------------------------------------------------------
+
+  async changeStatus(
+    ctx: ExpeditionContext,
+    id: string,
+    dto: ExpeditionStatusDTO,
+  ): Promise<InvStatusChangeResponse> {
+    const target = dto.status as InvExpeditionStatus;
+    // Flows with mandatory payloads own their transitions — never skippable.
+    if (target === 'EM_TRANSITO') {
+      throw new ValidationError('Use POST /expedition-orders/:id/ship — dados de expedição são obrigatórios');
+    }
+    if (target === 'PERDIDO') {
+      throw new ValidationError('Use POST /expedition-orders/:id/lost — motivo é obrigatório');
+    }
+
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, id, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (current === target) throw alreadyInState(current);
+        if (current === 'PERDIDO') {
+          throw new ValidationError('Use POST /expedition-orders/:id/found — pedido está PERDIDO');
+        }
+        const allowed = EXPEDITION_ORDER_TRANSITIONS[current] ?? [];
+        if (!allowed.includes(target)) throw illegalTransition(current, allowed);
+
+        let unitProducts: InvUnitProductsSummary | undefined;
+        if (target === 'ENTREGUE_CLIENTE') {
+          unitProducts = await this.createUnitProductsForClient(ctx, order, tx);
+        }
+
+        const updated = await this.repository.updateOrder(
+          ctx.tenantId,
+          id,
+          { status: target, updatedBy: ctx.userId ?? null },
+          tx,
+        );
+        const detail = await this.loadDetail(ctx, updated ?? order, tx);
+        return unitProducts ? { order: detail, unitProducts } : { order: detail };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Baixa/separação (deliver)
+  // ---------------------------------------------------------------------------
+
+  async deliverItem(
+    ctx: ExpeditionContext,
+    orderId: string,
+    orderItemId: string,
+    dto: DeliverItemDTO,
+    idempotencyKey: string,
+  ): Promise<InvDeliverResponse> {
+    return this.idempotent(ctx.tenantId, `deliver:${idempotencyKey}`, () =>
+      this.doDeliverItem(ctx, orderId, orderItemId, dto),
+    );
+  }
+
+  private async doDeliverItem(
+    ctx: ExpeditionContext,
+    orderId: string,
+    orderItemId: string,
+    dto: DeliverItemDTO,
+  ): Promise<InvDeliverResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, orderId, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (!DELIVERABLE_STATES.has(current)) {
+          throw illegalTransition(current, EXPEDITION_ORDER_TRANSITIONS[current] ?? []);
+        }
+
+        const orderItem = await this.repository.getOrderItem(ctx.tenantId, orderItemId, tx);
+        if (!orderItem || orderItem.orderId !== orderId) {
+          throw new NotFoundError(`Order item ${orderItemId} not found in expedition order ${orderId}`);
+        }
+
+        // quantity ≤ disponível (remaining = ordered − already delivered).
+        const delivered = await this.repository.deliveredQuantities(ctx.tenantId, orderId, tx);
+        const alreadyDelivered = delivered.get(orderItemId) ?? 0;
+        const remaining = orderItem.quantity - alreadyDelivered;
+        if (dto.quantity > remaining) {
+          throw new ValidationError(
+            `Quantidade (${dto.quantity}) excede o disponível para baixa (${remaining}) do item ${orderItem.itemName}`,
+          );
+        }
+
+        // Lock the item (M2 seam) — serializes concurrent exits per item.
+        const item = await this.stockRepository.lockItem(ctx.tenantId, orderItem.itemId, tx);
+        if (!item) throw new NotFoundError(`Item ${orderItem.itemId} not found`);
+
+        // Manufactured → exactly one stockOnly QR per unit (boxes expand).
+        let qrLinks: NewDeliveryQrInput[] = [];
+        if (item.isManufactured) {
+          qrLinks = await this.resolveDeliveryQrs(ctx.tenantId, orderItem.itemId, dto.quantity, dto.qrs ?? [], tx);
+        } else if (dto.qrs && dto.qrs.length > 0) {
+          throw new ValidationError('QRs são aceitos apenas na baixa de itens manufaturados');
+        }
+
+        // Negative-stock guard on the derived balance (M2 sequence).
+        const totals = await this.stockRepository.getBalance(ctx.tenantId, orderItem.itemId, DELIVERY_LOCATION, tx);
+        const balance = Number(totals.balance);
+        if (Math.round(balance * 1000) < Math.round(dto.quantity * 1000)) {
+          throw insufficientStock(orderItem.itemId, DELIVERY_LOCATION, balance, dto.quantity);
+        }
+
+        // Delivery + QRs + the SAIDA movement — one transaction.
+        const delivery = await this.repository.insertDelivery(
+          {
+            tenantId: ctx.tenantId,
+            orderId,
+            orderItemId,
+            quantity: dto.quantity,
+            photoFileId: dto.photoFileId,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        await this.repository.insertDeliveryQrs(ctx.tenantId, delivery.id, orderItemId, qrLinks, tx);
+
+        const movement = await this.stockRepository.insertMovement(
+          {
+            tenantId: ctx.tenantId,
+            itemId: orderItem.itemId,
+            location: DELIVERY_LOCATION,
+            quantity: String(dto.quantity),
+            type: 'SAIDA',
+            reason: REASON_EXPEDITION_DELIVERY,
+            photoFileId: dto.photoFileId,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+        if (qrLinks.length > 0) {
+          await this.stockRepository.insertMovementQrs(
+            ctx.tenantId,
+            movement.id,
+            qrLinks.map((q) => ({
+              qrValue: q.qrValue,
+              boxQr: q.boxQr ?? undefined,
+              homologationUnitId: q.homologationUnitId ?? undefined,
+            })),
+            tx,
+          );
+        }
+
+        // Auto-status: all items delivered → PRONTO_ENTREGA, else PRODUZINDO.
+        // Never regresses ENTREGUE_CLIENTE (unreachable here by the state
+        // guard above — kept explicit for safety).
+        const allItems = await this.repository.listItemsByOrders(ctx.tenantId, [orderId], tx);
+        const afterDelivered = await this.repository.deliveredQuantities(ctx.tenantId, orderId, tx);
+        const allDelivered = allItems.every((i) => (afterDelivered.get(i.id) ?? 0) >= i.quantity);
+        const nextStatus: InvExpeditionStatus = allDelivered ? 'PRONTO_ENTREGA' : 'PRODUZINDO';
+        let updated = order;
+        let autoAdvanced = false;
+        if (current !== 'ENTREGUE_CLIENTE' && current !== nextStatus) {
+          updated =
+            (await this.repository.updateOrder(
+              ctx.tenantId,
+              orderId,
+              { status: nextStatus, updatedBy: ctx.userId ?? null },
+              tx,
+            )) ?? order;
+          autoAdvanced = true;
+        }
+
+        // DEC-6: push "expedicao" enqueued in the same transaction.
+        await this.repository.enqueuePush(
+          ctx.tenantId,
+          { qrCodes: qrLinks.map((q) => q.qrValue), location: 'expedicao' },
+          tx,
+        );
+
+        const detail = await this.loadDetail(ctx, updated, tx);
+        return {
+          order: detail,
+          delivery: {
+            id: delivery.id,
+            orderItemId,
+            quantity: delivery.quantity,
+            photoFileId: delivery.photoFileId,
+            createdAt: toIso(delivery.createdAt),
+          },
+          movementId: movement.id,
+          qrs: qrLinks.map((q) => ({ qrValue: q.qrValue, boxQr: q.boxQr ?? null })),
+          autoAdvanced,
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  /**
+   * stockOnly QR resolution (§M6): every code must exist in the homologation
+   * registry (unit row, box row — expanded to its units — or registry UNIT
+   * identity), belong to the expected item, and not be already used (latest
+   * ledger event an exit, or any expedition baixa). Exactly one QR per unit.
+   */
+  private async resolveDeliveryQrs(
+    tenantId: string,
+    expectedItemId: string,
+    quantity: number,
+    codes: string[],
+    tx: ExpeditionTx,
+  ): Promise<NewDeliveryQrInput[]> {
+    if (codes.length === 0) {
+      throw new ValidationError('Baixa de item manufaturado exige exatamente 1 QR por unidade');
+    }
+    const normalized = codes.map((c) => normalizeQrInput(c));
+    const seen = new Set<string>();
+    for (const n of normalized) {
+      if (seen.has(n.code)) throw new ValidationError(`QR duplicado na requisição: ${n.code}`);
+      seen.add(n.code);
+    }
+    const allCandidates = [...new Set(normalized.flatMap((n) => n.candidates))];
+
+    const [boxes, units, registry] = await Promise.all([
+      this.homologationRepository.findBoxesByQrValues(tenantId, allCandidates, tx),
+      this.homologationRepository.findUnitsByQrValues(tenantId, allCandidates, tx),
+      this.homologationRepository.findRegistryByValues(tenantId, allCandidates, tx),
+    ]);
+    const boxUnits = await this.homologationRepository.unitsByHomologationIds(
+      tenantId,
+      boxes.map((b) => b.id),
+      tx,
+    );
+
+    const resolved = normalized.flatMap((n) =>
+      resolveOneQr(n, expectedItemId, { boxes, units, registry, boxUnits }),
+    );
+
+    // Duplicates after box expansion (unit scanned alongside its own box).
+    const unitValues = resolved.map((r) => r.qrValue);
+    const dupCheck = new Set<string>();
+    for (const value of unitValues) {
+      if (dupCheck.has(value)) throw new ValidationError(`QR duplicado após expansão de caixa: ${value}`);
+      dupCheck.add(value);
+    }
+
+    // Exactly one QR per unit.
+    if (resolved.length !== quantity) {
+      throw new ValidationError(
+        `Baixa de item manufaturado: quantidade (${quantity}) deve igualar o número de QRs (${resolved.length})`,
+      );
+    }
+
+    await this.assertQrsUnused(tenantId, resolved, tx);
+    return resolved;
+  }
+
+  /** Not already used: any expedition baixa, or latest ledger event an exit. */
+  private async assertQrsUnused(
+    tenantId: string,
+    resolved: NewDeliveryQrInput[],
+    tx: ExpeditionTx,
+  ): Promise<void> {
+    const unitValues = resolved.map((r) => r.qrValue);
+    const boxValues = [...new Set(resolved.map((r) => r.boxQr).filter((v): v is string => !!v))];
+    const usageValues = [...new Set([...unitValues, ...boxValues])];
+    const [latestTypes, deliveryEvents] = await Promise.all([
+      this.stockRepository.latestQrEventTypes(tenantId, unitValues, tx),
+      this.homologationRepository.deliveryEventsByQrs(tenantId, usageValues, tx),
+    ]);
+    for (const r of resolved) {
+      const usedInDelivery = deliveryEvents.some(
+        (d) => d.qrValue === r.qrValue || (!!r.boxQr && d.boxQr === r.boxQr),
+      );
+      if (usedInDelivery) throw qrAlreadyUsed(r.qrValue);
+      const lastType = latestTypes.get(r.qrValue);
+      if (lastType && EXIT_TYPES.has(lastType)) throw qrAlreadyUsed(r.qrValue);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Expedir (ship)
+  // ---------------------------------------------------------------------------
+
+  async ship(ctx: ExpeditionContext, orderId: string, dto: ShipExpeditionDTO): Promise<InvShipResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, orderId, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (current === 'EM_TRANSITO') throw alreadyInState(current);
+        const allowed = EXPEDITION_ORDER_TRANSITIONS[current] ?? [];
+        if (!allowed.includes('EM_TRANSITO')) throw illegalTransition(current, allowed);
+
+        const shipment = await this.repository.insertShipment(
+          {
+            tenantId: ctx.tenantId,
+            orderId,
+            address: dto.address,
+            shippingMethod: dto.shippingMethod,
+            responsible: dto.responsible,
+            trackingCode: dto.trackingCode,
+            proofFileId: dto.proofFileId,
+            notes: dto.notes ?? null,
+            createdBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        const updated = await this.repository.updateOrder(
+          ctx.tenantId,
+          orderId,
+          { status: 'EM_TRANSITO', updatedBy: ctx.userId ?? null },
+          tx,
+        );
+
+        // DEC-6: push "transporte" with every delivered unit QR.
+        const qrRows = await this.repository.deliveredQrsByOrder(ctx.tenantId, orderId, tx);
+        await this.repository.enqueuePush(
+          ctx.tenantId,
+          { qrCodes: uniqueQrValues(qrRows), location: 'transporte', technician: dto.responsible },
+          tx,
+        );
+
+        return {
+          order: await this.loadDetail(ctx, updated ?? order, tx),
+          shipment: this.toShipmentResponse(shipment),
+        };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Return / lost / found
+  // ---------------------------------------------------------------------------
+
+  async returnToExpedition(
+    ctx: ExpeditionContext,
+    orderId: string,
+    dto: ReturnExpeditionDTO,
+  ): Promise<InvExpeditionOrderDetailResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, orderId, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (current === 'PRONTO_ENTREGA') throw alreadyInState(current);
+        if (current !== 'EM_TRANSITO') {
+          throw illegalTransition(current, EXPEDITION_ORDER_TRANSITIONS[current] ?? []);
+        }
+
+        const updated = await this.repository.updateOrder(
+          ctx.tenantId,
+          orderId,
+          {
+            status: 'PRONTO_ENTREGA',
+            notes: stampNotes(order.notes, returnStamp(new Date().toISOString(), dto.reason)),
+            updatedBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        const qrRows = await this.repository.deliveredQrsByOrder(ctx.tenantId, orderId, tx);
+        await this.repository.enqueuePush(
+          ctx.tenantId,
+          { qrCodes: uniqueQrValues(qrRows), location: 'expedicao' },
+          tx,
+        );
+
+        return this.loadDetail(ctx, updated ?? order, tx);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  async markLost(
+    ctx: ExpeditionContext,
+    orderId: string,
+    dto: LostExpeditionDTO,
+  ): Promise<InvExpeditionOrderDetailResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, orderId, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (current === 'PERDIDO') throw alreadyInState(current);
+        const allowed = EXPEDITION_ORDER_TRANSITIONS[current] ?? [];
+        if (!allowed.includes('PERDIDO')) throw illegalTransition(current, allowed);
+
+        const updated = await this.repository.updateOrder(
+          ctx.tenantId,
+          orderId,
+          {
+            status: 'PERDIDO',
+            notes: stampNotes(order.notes, lostStamp(new Date().toISOString(), dto.reason)),
+            updatedBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        const qrRows = await this.repository.deliveredQrsByOrder(ctx.tenantId, orderId, tx);
+        await this.repository.enqueuePush(
+          ctx.tenantId,
+          { qrCodes: uniqueQrValues(qrRows), location: 'perdido' },
+          tx,
+        );
+
+        return this.loadDetail(ctx, updated ?? order, tx);
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  async markFound(
+    ctx: ExpeditionContext,
+    orderId: string,
+    dto: FoundExpeditionDTO,
+  ): Promise<InvStatusChangeResponse> {
+    try {
+      return await this.repository.withTransaction(async (tx) => {
+        const order = await this.lockOr404(ctx.tenantId, orderId, tx);
+        const current = order.status as InvExpeditionStatus;
+        if (current !== 'PERDIDO') {
+          throw illegalTransition(current, EXPEDITION_ORDER_TRANSITIONS[current] ?? []);
+        }
+
+        const target = SECTOR_TO_STATUS[dto.sector];
+        let unitProducts: InvUnitProductsSummary | undefined;
+        if (dto.sector === 'CLIENTE') {
+          unitProducts = await this.createUnitProductsForClient(ctx, order, tx);
+        }
+
+        const updated = await this.repository.updateOrder(
+          ctx.tenantId,
+          orderId,
+          {
+            status: target,
+            notes: stampNotes(order.notes, foundStamp(new Date().toISOString(), dto.sector, dto.notes)),
+            updatedBy: ctx.userId ?? null,
+          },
+          tx,
+        );
+
+        if (dto.sector !== 'CLIENTE') {
+          // CLIENTE already pushed inside createUnitProductsForClient.
+          const qrRows = await this.repository.deliveredQrsByOrder(ctx.tenantId, orderId, tx);
+          await this.repository.enqueuePush(
+            ctx.tenantId,
+            { qrCodes: uniqueQrValues(qrRows), location: SECTOR_TO_PUSH[dto.sector] },
+            tx,
+          );
+        }
+
+        const detail = await this.loadDetail(ctx, updated ?? order, tx);
+        return unitProducts ? { order: detail, unitProducts } : { order: detail };
+      });
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transit progress
+  // ---------------------------------------------------------------------------
+
+  async transitProgress(
+    ctx: ExpeditionContext,
+    orderId: string,
+    page: number,
+    pageSize: number,
+  ): Promise<InvTransitProgressResponse> {
+    const order = await this.repository.getById(ctx.tenantId, orderId);
+    if (!order) throw new NotFoundError(`Expedition order ${orderId} not found`);
+
+    const [items, qrRows] = await Promise.all([
+      this.repository.listItemsByOrders(ctx.tenantId, [orderId]),
+      this.repository.deliveredQrsByOrder(ctx.tenantId, orderId),
+    ]);
+    const codes = uniqueQrValues(qrRows);
+    const states = await this.repository.externalStatesByCodes(ctx.tenantId, codes);
+    const stateByCode = new Map<string, (typeof states)[number]>();
+    for (const s of states) {
+      stateByCode.set(s.code, s);
+      if (s.qrValue) stateByCode.set(s.qrValue, s);
+    }
+
+    const byItem = new Map<string, InvTransitUnit[]>();
+    let totalUnits = 0;
+    let unitsInTransit = 0;
+    for (const row of qrRows) {
+      if (!row.qrValue) continue;
+      const state = stateByCode.get(row.qrValue) ?? stateByCode.get(normalizeQrInput(row.qrValue).code) ?? null;
+      // No mirror row = "em transporte" by default (§M6).
+      const inTransit = !state || state.location === 'transporte';
+      totalUnits += 1;
+      if (inTransit) unitsInTransit += 1;
+      const list = byItem.get(row.orderItemId) ?? [];
+      list.push({
+        qrValue: row.qrValue,
+        inTransit,
+        externalLocation: state?.location ?? null,
+        externalStatus: state?.status ?? null,
+      });
+      byItem.set(row.orderItemId, list);
+    }
+
+    const perItem: InvTransitItemProgress[] = items
+      .filter((i) => byItem.has(i.id))
+      .map((i) => {
+        const units = byItem.get(i.id) ?? [];
+        return {
+          orderItemId: i.id,
+          itemId: i.itemId,
+          itemName: i.itemName,
+          total: units.length,
+          inTransit: units.filter((u) => u.inTransit).length,
+          units,
+        };
+      });
+
+    const start = (page - 1) * pageSize;
+    return {
+      orderId,
+      status: order.status as InvExpeditionStatus,
+      totalUnits,
+      unitsInTransit,
+      summary: `${unitsInTransit} de ${totalUnits} em transporte`,
+      items: perItem.slice(start, start + pageSize),
+      page,
+      pageSize,
+      total: perItem.length,
+      totalPages: Math.ceil(perItem.length / pageSize),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // §M4 demand resolution (A4 — POST /production/resolve-demand)
+  // ---------------------------------------------------------------------------
+
+  async resolveDemand(ctx: ExpeditionContext, dto: ResolveDemandDTO): Promise<InvResolveDemandResponse> {
+    const order = await this.repository.getById(ctx.tenantId, dto.expeditionOrderId);
+    if (!order) throw new NotFoundError(`Expedition order ${dto.expeditionOrderId} not found`);
+    const items = await this.repository.listItemsByOrders(ctx.tenantId, [order.id]);
+    const orderItemIds = items.map((i) => i.id);
+
+    const [prodDemands, purchDemands] = await Promise.all([
+      this.repository.findProductionDemandsByOrderItemIds(ctx.tenantId, orderItemIds),
+      this.repository.findPurchaseDemandsByOrderItemIds(ctx.tenantId, orderItemIds),
+    ]);
+    const prodByItem = new Map(prodDemands.map((d) => [d.expeditionOrderItemId, d]));
+    const purchByItem = new Map(purchDemands.map((d) => [d.expeditionOrderItemId, d]));
+
+    const results: InvResolveDemandItemResult[] = [];
+    try {
+      for (const item of items) {
+        results.push(
+          await this.resolveDemandForItem(ctx, order, item, prodByItem.get(item.id), purchByItem.get(item.id)),
+        );
+      }
+    } catch (err) {
+      this.mapRepoError(err);
+    }
+
+    return { orderId: order.id, items: results };
+  }
+
+  private async resolveDemandForItem(
+    ctx: ExpeditionContext,
+    order: InvExpeditionOrderRow,
+    item: OrderItemWithName,
+    existingProd: { id: string } | undefined,
+    existingPurch: { id: string; purchaseOrderId: string | null } | undefined,
+  ): Promise<InvResolveDemandItemResult> {
+    const totals = await this.stockRepository.getBalance(ctx.tenantId, item.itemId, DELIVERY_LOCATION);
+    const balance = Number(totals.balance);
+    const shortage = Math.max(0, Math.ceil(item.quantity - balance));
+    const base = {
+      orderItemId: item.id,
+      itemId: item.itemId,
+      itemName: item.itemName,
+      required: item.quantity,
+      balance,
+      shortage,
+    };
+
+    if (shortage <= 0) return { ...base, action: 'NONE' };
+
+    if (existingProd || existingPurch) {
+      return {
+        ...base,
+        action: 'ALREADY_RESOLVED',
+        productionDemandId: existingProd?.id,
+        purchaseDemandId: existingPurch?.id,
+        purchaseOrderId: existingPurch?.purchaseOrderId ?? undefined,
+      };
+    }
+
+    if (item.isManufactured) {
+      const demand = await this.repository.insertProductionDemand({
+        tenantId: ctx.tenantId,
+        expeditionOrderItemId: item.id,
+        expeditionOrderId: order.id,
+        itemId: item.itemId,
+        quantity: shortage,
+      });
+      // null = a concurrent resolve claimed the UNIQUE first (idempotent).
+      return demand
+        ? { ...base, action: 'PRODUCTION_DEMAND', productionDemandId: demand.id }
+        : { ...base, action: 'ALREADY_RESOLVED' };
+    }
+
+    // Purchasable: claim the UNIQUE first, then create the automatic PO.
+    if (!order.projectId) {
+      throw new ValidationError(
+        'Pedido de expedição sem projeto — necessário para gerar o pedido de compra automático',
+      );
+    }
+    const demand = await this.repository.insertPurchaseDemand({
+      tenantId: ctx.tenantId,
+      expeditionOrderItemId: item.id,
+      expeditionOrderId: order.id,
+      itemId: item.itemId,
+      quantity: shortage,
+    });
+    if (!demand) return { ...base, action: 'ALREADY_RESOLVED' };
+
+    const purchaseOrder = await this.purchaseOrderService.create(ctx, {
+      projectId: order.projectId,
+      itemId: item.itemId,
+      quantity: shortage,
+      recipient: AUTO_PURCHASE_RECIPIENT,
+      deliveryPoint: AUTO_PURCHASE_DELIVERY_POINT,
+      deadlineType: 'CUSTOMIZADO',
+      deadlineDate: new Date(order.deliveryDate).toISOString(),
+      requesterNotes: AUTO_PURCHASE_NOTE,
+    });
+    await this.repository.setPurchaseDemandOrder(ctx.tenantId, demand.id, purchaseOrder.id);
+    return {
+      ...base,
+      action: 'PURCHASE_ORDER',
+      purchaseDemandId: demand.id,
+      purchaseOrderId: purchaseOrder.id,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private async lockOr404(tenantId: string, id: string, tx: ExpeditionTx): Promise<InvExpeditionOrderRow> {
+    const order = await this.repository.lockById(tenantId, id, tx);
+    if (!order) throw new NotFoundError(`Expedition order ${id} not found`);
+    return order;
+  }
+
+  private async assertItemsExist(tenantId: string, itemIds: string[]): Promise<void> {
+    const found = await this.itemRepository.findByIds(tenantId, itemIds);
+    const foundIds = new Set(found.map((i) => i.id));
+    const missing = itemIds.filter((id) => !foundIds.has(id));
+    if (missing.length > 0) {
+      throw new ValidationError(`Itens não encontrados no catálogo: ${missing.join(', ')}`);
+    }
+  }
+
+  /**
+   * ENTREGUE_CLIENTE: one inv_unit_products row per delivered unit, labels
+   * matched from the delivery QRs, "Projeto = Cliente" (client name = project
+   * name; customer from the project when set), status PARADO. Idempotent —
+   * labels already registered (this order or anywhere in the tenant) are
+   * skipped, never recreated. Also enqueues the "cliente" push (DEC-6).
+   */
+  private async createUnitProductsForClient(
+    ctx: ExpeditionContext,
+    order: InvExpeditionOrderRow,
+    tx: ExpeditionTx,
+  ): Promise<InvUnitProductsSummary> {
+    if (!order.projectId) {
+      throw new ValidationError('Pedido sem projeto — a regra "Projeto = Cliente" exige um projeto para a entrega');
+    }
+    const project = await this.repository.getProject(ctx.tenantId, order.projectId, tx);
+    if (!project) throw new ValidationError(`Project ${order.projectId} not found in tenant`);
+
+    const qrRows = await this.repository.deliveredQrsByOrder(ctx.tenantId, order.id, tx);
+    const byLabel = new Map<string, DeliveredQrRow>();
+    for (const row of qrRows) {
+      if (row.qrValue && !byLabel.has(row.qrValue)) byLabel.set(row.qrValue, row);
+    }
+    const labels = [...byLabel.keys()];
+    const existing = await this.repository.existingUnitProductLabels(ctx.tenantId, labels, tx);
+    const toCreate = labels.filter((l) => !existing.has(l));
+
+    await this.repository.insertUnitProducts(
+      toCreate.map((label) => ({
+        tenantId: ctx.tenantId,
+        itemId: byLabel.get(label)?.itemId ?? null,
+        label,
+        projectId: order.projectId,
+        customerId: project.customerId ?? order.customerId ?? null,
+        clientNameSnapshot: project.name,
+        expeditionOrderId: order.id,
+        createdBy: ctx.userId ?? null,
+      })),
+      tx,
+    );
+
+    await this.repository.enqueuePush(
+      ctx.tenantId,
+      { qrCodes: labels, location: 'cliente', clientName: project.name },
+      tx,
+    );
+
+    return { created: toCreate.length, skipped: labels.length - toCreate.length, labels };
+  }
+
+  private async loadDetail(
+    ctx: ExpeditionContext,
+    order: InvExpeditionOrderRow,
+    client?: ExpeditionTx,
+  ): Promise<InvExpeditionOrderDetailResponse> {
+    const items = await this.repository.listItemsByOrders(ctx.tenantId, [order.id], client);
+    const delivered = await this.repository.deliveredQuantities(ctx.tenantId, order.id, client);
+    return this.toDetail(order, items, delivered);
+  }
+
+  private toDetail(
+    order: InvExpeditionOrderRow,
+    items: OrderItemWithName[],
+    delivered: Map<string, number>,
+  ): InvExpeditionOrderDetailResponse {
+    const status = order.status as InvExpeditionStatus;
+    return {
+      id: order.id,
+      title: order.title ?? null,
+      projectId: order.projectId ?? null,
+      customerId: order.customerId ?? null,
+      deliveryDate: toIso(order.deliveryDate),
+      status,
+      isReplacement: order.isReplacement,
+      notes: order.notes ?? null,
+      allowedTransitions: EXPEDITION_ORDER_TRANSITIONS[status] ?? [],
+      createdAt: toIso(order.createdAt),
+      updatedAt: toIso(order.updatedAt),
+      items: items.map((i) => {
+        const done = delivered.get(i.id) ?? 0;
+        return {
+          id: i.id,
+          itemId: i.itemId,
+          itemName: i.itemName,
+          isManufactured: i.isManufactured,
+          quantity: i.quantity,
+          delivered: done,
+          remaining: Math.max(0, i.quantity - done),
+        };
+      }),
+    };
+  }
+
+  private toShipmentResponse(row: InvShipmentRow): InvShipmentResponse {
+    return {
+      id: row.id,
+      orderId: row.orderId,
+      address: row.address ?? null,
+      shippingMethod: row.shippingMethod,
+      responsible: row.responsible ?? null,
+      trackingCode: row.trackingCode ?? null,
+      proofFileId: row.proofFileId,
+      notes: row.notes ?? null,
+      createdAt: toIso(row.createdAt),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Idempotency (best-effort, per-process — same M2/M4 pattern; durable
+  // storage is the standing inv_idempotency_keys follow-up from the M2 PR).
+  // ---------------------------------------------------------------------------
+
+  private async idempotent<T>(tenantId: string, key: string, run: () => Promise<T>): Promise<T> {
+    const cacheKey = `${tenantId}:${key}`;
+    const now = Date.now();
+    const hit = this.idempotencyCache.get(cacheKey);
+    if (hit && now - hit.at < IDEMPOTENCY_TTL_MS) {
+      return hit.promise as Promise<T>;
+    }
+    const promise = run();
+    this.idempotencyCache.set(cacheKey, { at: now, promise });
+    // A failed attempt must NOT poison the key — retries reuse it on purpose.
+    promise.catch(() => this.idempotencyCache.delete(cacheKey));
+    this.evictStaleIdempotencyEntries(now);
+    return promise;
+  }
+
+  private evictStaleIdempotencyEntries(now: number): void {
+    if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    for (const [key, entry] of this.idempotencyCache) {
+      if (now - entry.at >= IDEMPOTENCY_TTL_MS) this.idempotencyCache.delete(key);
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+    }
+    for (const key of this.idempotencyCache.keys()) {
+      if (this.idempotencyCache.size <= IDEMPOTENCY_MAX_ENTRIES) return;
+      this.idempotencyCache.delete(key);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error mapping (Drizzle gotcha: the real SQLSTATE lives on `err.cause`)
+  // ---------------------------------------------------------------------------
+
+  private mapRepoError(err: unknown): never {
+    if (err instanceof AppError) throw err;
+    const top = err as { message?: string; code?: string; cause?: { message?: string; code?: string } };
+    const cause = top.cause ?? {};
+    const code = cause.code ?? top.code;
+    const message = `${top.message ?? String(err)}\n${cause.message ?? ''}`;
+
+    if (code === '23505' || /duplicate key/i.test(message)) {
+      throw new ConflictError('Registro duplicado (violação de unicidade)');
+    }
+    if (code === '23503' || /foreign key/i.test(message)) {
+      throw new ValidationError('Referência inexistente (item, projeto, foto ou comprovante)');
+    }
+    if (code === '23514' || /check constraint/i.test(message)) {
+      throw new ValidationError('Valor viola uma restrição do banco (quantidade/status/método)');
+    }
+    if (code === '40001' || code === '40P01') {
+      throw new ConflictError('Conflito de concorrência — tente novamente');
+    }
+    throw err;
+  }
+}
+
+/**
+ * Resolve one scanned code to its delivery-QR link(s): a box QR expands to its
+ * units; a homologation unit resolves directly; a registry-only UNIT identity
+ * is accepted (same stockOnly semantics as the M5 validate); anything else →
+ * INV_QR_NOT_IN_REGISTRY. Item mismatches → INV_QR_WRONG_ITEM.
+ */
+function resolveOneQr(
+  n: { code: string; candidates: string[] },
+  expectedItemId: string,
+  lookups: {
+    boxes: InvHomologationRow[];
+    units: UnitWithHomologationRow[];
+    registry: InvQrRegistryRow[];
+    boxUnits: InvHomologationUnitRow[];
+  },
+): NewDeliveryQrInput[] {
+  const inSet = (v: string | null | undefined): boolean => !!v && n.candidates.includes(v);
+
+  const box = lookups.boxes.find((b) => inSet(b.boxQr));
+  if (box) {
+    if (box.itemId !== expectedItemId) throw qrWrongItem(n.code, expectedItemId);
+    const contents = lookups.boxUnits.filter((u) => u.homologationId === box.id);
+    if (contents.length === 0) {
+      throw new InventoryError('INV_BOX_EMPTY', `Caixa ${n.code} não possui unidades`, 422, { boxQr: n.code });
+    }
+    return contents.map((u) => ({ qrValue: u.qrValue, boxQr: box.boxQr, homologationUnitId: u.id }));
+  }
+
+  const unit = lookups.units.find((u) => inSet(u.unit.qrValue));
+  if (unit) {
+    if (unit.homologation.itemId !== expectedItemId) throw qrWrongItem(n.code, expectedItemId);
+    return [
+      {
+        qrValue: unit.unit.qrValue,
+        boxQr: unit.homologation.boxQr ?? null,
+        homologationUnitId: unit.unit.id,
+      },
+    ];
+  }
+
+  const registryRow = lookups.registry.find((r) => inSet(r.qrValue));
+  if (registryRow && registryRow.kind === 'UNIT') {
+    if (registryRow.itemId && registryRow.itemId !== expectedItemId) {
+      throw qrWrongItem(n.code, expectedItemId);
+    }
+    return [{ qrValue: registryRow.qrValue, boxQr: null, homologationUnitId: null }];
+  }
+  throw qrNotInRegistry(n.code);
+}
+
+function toIso(value: Date | string | null | undefined): string {
+  return value ? new Date(value).toISOString() : new Date().toISOString();
+}
+
+function uniqueQrValues(rows: DeliveredQrRow[]): string[] {
+  return [...new Set(rows.map((r) => r.qrValue).filter((v): v is string => !!v))];
+}
+
+export const inventoryExpeditionService = new InventoryExpeditionService();

--- a/tests/unit/inventory/m4-contract.test.ts
+++ b/tests/unit/inventory/m4-contract.test.ts
@@ -127,7 +127,10 @@ describe('M4 production routes — real contract', () => {
     }
   });
 
-  it('POST /production/resolve-demand → STILL 501 (P3 with M6 — A4)', async () => {
+  // Was "STILL 501 (P3 with M6 — A4)": demand resolution shipped with M6 —
+  // the route is real now. The full route contract lives in m6-contract; here
+  // we keep the DTO gate (empty body → 400) so the M4 router stays covered.
+  it('POST /production/resolve-demand → 400 without expeditionOrderId (real route — was 501)', async () => {
     const srv = await listen(buildApp());
     try {
       const res = await fetch(U(srv.url, '/production/resolve-demand'), {
@@ -135,10 +138,7 @@ describe('M4 production routes — real contract', () => {
         headers: { 'x-api-key': 'gcdr_cust_x', 'content-type': 'application/json' },
         body: JSON.stringify({}),
       });
-      expect(res.status).toBe(501);
-      const body = (await res.json()) as ErrBody;
-      expect(body.error.code).toBe('INV_NOT_IMPLEMENTED');
-      expect(body.error.details).toMatchObject({ module: 'M4', phase: 'P3' });
+      expect(res.status).toBe(400);
     } finally {
       await srv.close();
     }

--- a/tests/unit/inventory/m6-contract.test.ts
+++ b/tests/unit/inventory/m6-contract.test.ts
@@ -1,0 +1,412 @@
+/**
+ * RFC-0061 M6 — wired-contract test for the REAL expedition routes (+ the
+ * resolve-demand route in the production router).
+ *
+ * Same harness as m1/m2/m5-contract: real router + real auth middleware, auth
+ * leaves mocked, M6 service mocked (no DB). Documents the standing guards
+ * (missing Idempotency-Key → 400, missing confirmationToken → 428, DTO
+ * validation → 400) and SUPERSEDES the deferred-501 case for
+ * GET /expedition-orders in tests/unit/controllers/inventory.contract.test.ts
+ * (that file is frozen for this PR — the retarget lands in the wave-2
+ * integration).
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryExpeditionService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryExpeditionService');
+  return {
+    ...actual,
+    inventoryExpeditionService: {
+      list: jest.fn(),
+      getById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      changeStatus: jest.fn(),
+      deliverItem: jest.fn(),
+      ship: jest.fn(),
+      returnToExpedition: jest.fn(),
+      markLost: jest.fn(),
+      markFound: jest.fn(),
+      transitProgress: jest.fn(),
+      resolveDemand: jest.fn(),
+    },
+  };
+});
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryExpeditionService } from '../../../src/services/inventory/InventoryExpeditionService';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+import { NotFoundError } from '../../../src/shared/errors/AppError';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const ORDER_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeee01';
+const ORDER_ITEM_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeee02';
+const PROJECT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01';
+const ITEM_ID = 'ffffffff-ffff-4fff-8fff-ffffffffff01';
+const PHOTO_ID = '44444444-4444-4444-4444-444444444444';
+const PROOF_ID = '44444444-4444-4444-4444-444444444445';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string; details?: Record<string, unknown> } };
+type OkBody<T> = { success: boolean; data: T };
+
+const svc = inventoryExpeditionService as jest.Mocked<typeof inventoryExpeditionService>;
+
+const emptyPage = { items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M6 expedition routes — real contract (supersedes the deferred 501 case)', () => {
+  it('GET /expedition-orders → 200 with the paginated listing (was 501 M6/P3)', async () => {
+    svc.list.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/expedition-orders?page=1&pageSize=20'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<typeof emptyPage>;
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual(emptyPage);
+      expect(svc.list).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        expect.objectContaining({ page: 1, pageSize: 20 }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /expedition-orders → 201 with a valid payload', async () => {
+    svc.create.mockResolvedValue({ id: ORDER_ID, status: 'PENDENTE' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/expedition-orders'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          projectId: PROJECT_ID,
+          deliveryDate: '2026-09-30T00:00:00.000Z',
+          items: [{ itemId: ITEM_ID, quantity: 2 }],
+        }),
+      });
+      expect(res.status).toBe(201);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /expedition-orders without projectId → 400 (Zod, project required)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/expedition-orders'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deliveryDate: '2026-09-30T00:00:00.000Z', items: [{ itemId: ITEM_ID, quantity: 2 }] }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.create).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /expedition-orders/:id with a malformed id → 400', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/expedition-orders/not-a-uuid'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(400);
+      expect(svc.getById).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET /expedition-orders/:id → 404 from the service NotFoundError', async () => {
+    svc.getById.mockRejectedValue(new NotFoundError(`Expedition order ${ORDER_ID} not found`));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}`), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /expedition-orders/:id without confirmationToken → 428 INV_CONFIRMATION_REQUIRED', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}`), {
+        method: 'DELETE',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(428);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_CONFIRMATION_REQUIRED');
+      expect(svc.delete).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('DELETE /expedition-orders/:id with the token → 200', async () => {
+    svc.delete.mockResolvedValue({ deleted: true });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}`), {
+        method: 'DELETE',
+        headers: {
+          'X-API-Key': 'gcdr_cust_test',
+          'Content-Type': 'application/json',
+          'X-Confirmation-Token': 'excluir',
+        },
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/deliver without Idempotency-Key → 400 INV_IDEMPOTENCY_KEY_MISSING', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/items/${ORDER_ITEM_ID}/deliver`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ quantity: 1, photoFileId: PHOTO_ID, qrs: ['100_1'] }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_IDEMPOTENCY_KEY_MISSING');
+      expect(svc.deliverItem).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/deliver with the key → 201, forwarding the key to the service', async () => {
+    svc.deliverItem.mockResolvedValue({ movementId: 'm-1' } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/items/${ORDER_ITEM_ID}/deliver`), {
+        method: 'POST',
+        headers: {
+          'X-API-Key': 'gcdr_cust_test',
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'baixa-abc-1',
+        },
+        body: JSON.stringify({ quantity: 1, photoFileId: PHOTO_ID, qrs: ['100_1'] }),
+      });
+      expect(res.status).toBe(201);
+      expect(svc.deliverItem).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        ORDER_ID,
+        ORDER_ITEM_ID,
+        expect.objectContaining({ quantity: 1, photoFileId: PHOTO_ID }),
+        'baixa-abc-1',
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/ship with an unknown method → 400 (enum)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/ship`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          address: 'Rua X',
+          shippingMethod: 'SEDEX',
+          responsible: 'João',
+          trackingCode: 'BR1',
+          proofFileId: PROOF_ID,
+        }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.ship).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/status → 200 via the mocked service', async () => {
+    svc.changeStatus.mockResolvedValue({ order: { id: ORDER_ID, status: 'PRODUZINDO' } } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/status`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'PRODUZINDO' }),
+      });
+      expect(res.status).toBe(200);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/return without reason → 400 (Zod)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/return`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.returnToExpedition).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST …/found → 200 with a valid sector', async () => {
+    svc.markFound.mockResolvedValue({ order: { id: ORDER_ID, status: 'PRONTO_ENTREGA' } } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/found`), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sector: 'EXPEDICAO' }),
+      });
+      expect(res.status).toBe(200);
+      expect(svc.markFound).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: TENANT }),
+        ORDER_ID,
+        { sector: 'EXPEDICAO' },
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('GET …/transit-progress → 200 with the badge summary', async () => {
+    svc.transitProgress.mockResolvedValue({
+      orderId: ORDER_ID,
+      status: 'EM_TRANSITO',
+      totalUnits: 3,
+      unitsInTransit: 2,
+      summary: '2 de 3 em transporte',
+      items: [],
+      page: 1,
+      pageSize: 20,
+      total: 0,
+      totalPages: 0,
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, `/expedition-orders/${ORDER_ID}/transit-progress`), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ summary: string }>;
+      expect(body.data.summary).toBe('2 de 3 em transporte');
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M4 resolve-demand route — real contract (was 501 M4/P3)', () => {
+  it('POST /production/resolve-demand → 200 via the expedition service', async () => {
+    svc.resolveDemand.mockResolvedValue({ orderId: ORDER_ID, items: [] });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/resolve-demand'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expeditionOrderId: ORDER_ID }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ orderId: string }>;
+      expect(body.data.orderId).toBe(ORDER_ID);
+      expect(svc.resolveDemand).toHaveBeenCalledWith(expect.objectContaining({ tenantId: TENANT }), {
+        expeditionOrderId: ORDER_ID,
+      });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('POST /production/resolve-demand with a malformed body → 400 (Zod)', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/production/resolve-demand'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expeditionOrderId: 'nope' }),
+      });
+      expect(res.status).toBe(400);
+      expect(svc.resolveDemand).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M6 — auth still guards the module', () => {
+  it('GET /expedition-orders without credentials → 401', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/expedition-orders'));
+      expect(res.status).toBe(401);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m6-deliver.test.ts
+++ b/tests/unit/inventory/m6-deliver.test.ts
@@ -1,0 +1,384 @@
+/**
+ * RFC-0061 M6 — baixa/separação (deliver) rules (service with mocked
+ * repositories — no DB).
+ *
+ * quantity ≤ disponível; photo mandatory (DTO); manufactured → exactly one
+ * stockOnly QR per unit (registry + not used; boxes expand); writes
+ * inv_item_deliveries + inv_delivery_qrs + the SAIDA movement (reason "Baixa
+ * para pedido Myio") in ONE transaction; auto-status (PRONTO_ENTREGA when all
+ * delivered, else PRODUZINDO, never regressing ENTREGUE_CLIENTE); push
+ * "expedicao" enqueued in the same transaction (DEC-6); Idempotency-Key
+ * replays the original result.
+ */
+
+import {
+  DeliverItemSchema,
+  REASON_EXPEDITION_DELIVERY,
+  DELIVERY_LOCATION,
+} from '../../../src/services/inventory/InventoryExpeditionService';
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  ORDER_ID,
+  ORDER_ITEM_ID,
+  ORDER_ITEM_ID_2,
+  ITEM_MANUFACTURED,
+  ITEM_PURCHASABLE,
+  PHOTO_ID,
+  makeOrder,
+  makeOrderItem,
+  makeBox,
+  makeHomologUnit,
+  makeRegistryRow,
+  makeExpeditionRepo,
+  makeStockRepo,
+  makeHomologRepo,
+  makeService,
+} from './m6-helpers';
+
+const DELIVER_2 = { quantity: 2, photoFileId: PHOTO_ID, qrs: ['100_1', '100_2'] };
+let keySeq = 0;
+const key = () => `idem-${++keySeq}`;
+
+describe('M6 deliver — DTO shape', () => {
+  it('photoFileId is mandatory (foto obrigatória)', () => {
+    expect(() => DeliverItemSchema.parse({ quantity: 1 })).toThrow();
+    expect(() => DeliverItemSchema.parse({ quantity: 1, photoFileId: PHOTO_ID })).not.toThrow();
+  });
+
+  it('quantity must be a positive integer', () => {
+    expect(() => DeliverItemSchema.parse({ quantity: 0, photoFileId: PHOTO_ID })).toThrow();
+    expect(() => DeliverItemSchema.parse({ quantity: 1.5, photoFileId: PHOTO_ID })).toThrow();
+  });
+});
+
+describe('M6 deliver — guards', () => {
+  it('rejects deliver when the order is EM_TRANSITO (state conflict 409)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('404 when the order item belongs to another order', async () => {
+    const repo = makeExpeditionRepo({
+      getOrderItem: jest.fn(async () => makeOrderItem({ orderId: 'ffffffff-0000-4000-8000-000000000000' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('quantity > disponível (ordered − delivered) → ValidationError', async () => {
+    const repo = makeExpeditionRepo({
+      deliveredQuantities: jest.fn(async () => new Map([[ORDER_ITEM_ID, 1]])), // 1 of 2 delivered
+    });
+    const { service } = makeService({ repo });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('excede o disponível');
+  });
+
+  it('manufactured item without QRs → ValidationError (1 QR por unidade)', async () => {
+    const { service } = makeService();
+    const err = await service
+      .deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, { quantity: 2, photoFileId: PHOTO_ID }, key())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('1 QR por unidade');
+  });
+
+  it('QR count ≠ quantity → ValidationError', async () => {
+    const { service } = makeService();
+    const err = await service
+      .deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, { quantity: 2, photoFileId: PHOTO_ID, qrs: ['100_1'] }, key())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('deve igualar o número de QRs');
+  });
+
+  it('QR not homologated/registered → INV_QR_NOT_IN_REGISTRY 422 (stockOnly)', async () => {
+    const homolog = makeHomologRepo({ findUnitsByQrValues: jest.fn(async () => []) });
+    const { service } = makeService({ homolog });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_QR_NOT_IN_REGISTRY');
+    expect(err.statusCode).toBe(422);
+  });
+
+  it('QR of another item → INV_QR_WRONG_ITEM 422', async () => {
+    const homolog = makeHomologRepo({
+      findUnitsByQrValues: jest.fn(async (_t: string, values: string[]) =>
+        values
+          .filter((v) => !v.startsWith('http'))
+          .map((v) => ({
+            unit: makeHomologUnit(v),
+            homologation: makeBox({ boxSize: 1, boxQr: null, itemId: ITEM_PURCHASABLE }),
+          })),
+      ),
+    });
+    const { service } = makeService({ homolog });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_QR_WRONG_ITEM');
+    expect(err.statusCode).toBe(422);
+  });
+
+  it('QR already delivered (expedition baixa) → INV_QR_ALREADY_USED 409', async () => {
+    const homolog = makeHomologRepo({
+      deliveryEventsByQrs: jest.fn(async () => [{ qrValue: '100_1', boxQr: null }]),
+    });
+    const { service } = makeService({ homolog });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_QR_ALREADY_USED');
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('QR whose latest ledger event is an exit → INV_QR_ALREADY_USED 409', async () => {
+    const stock = makeStockRepo({
+      latestQrEventTypes: jest.fn(async () => new Map([['100_2', 'SAIDA']])),
+    });
+    const { service } = makeService({ stock });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_QR_ALREADY_USED');
+  });
+
+  it('duplicate QR in the request → ValidationError', async () => {
+    const { service } = makeService();
+    const err = await service
+      .deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, { quantity: 2, photoFileId: PHOTO_ID, qrs: ['100_1', '100_1'] }, key())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('duplicado');
+  });
+
+  it('non-manufactured item rejects QRs', async () => {
+    const repo = makeExpeditionRepo({
+      getOrderItem: jest.fn(async () =>
+        makeOrderItem({ id: ORDER_ITEM_ID_2, itemId: ITEM_PURCHASABLE, isManufactured: false, domain: 'COMPONENT' }),
+      ),
+    });
+    const { service } = makeService({ repo });
+    const err = await service
+      .deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID_2, { quantity: 1, photoFileId: PHOTO_ID, qrs: ['100_1'] }, key())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('manufaturados');
+  });
+
+  it('insufficient ALMOXARIFADO balance → INV_INSUFFICIENT_STOCK 409', async () => {
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '1', totalIn: '1', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service } = makeService({ stock });
+    const err = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key()).catch((e) => e);
+    expect(err.code).toBe('INV_INSUFFICIENT_STOCK');
+    expect(err.statusCode).toBe(409);
+    expect(err.details).toMatchObject({ itemId: ITEM_MANUFACTURED, location: DELIVERY_LOCATION });
+  });
+});
+
+describe('M6 deliver — box expansion', () => {
+  it('a box QR expands to its units (1 QR per unit satisfied by the box)', async () => {
+    const box = makeBox({ boxQr: 'caixa-10/7', boxSize: 10 });
+    const units = [makeHomologUnit('200_1'), makeHomologUnit('200_2')];
+    const homolog = makeHomologRepo({
+      findBoxesByQrValues: jest.fn(async () => [box]),
+      unitsByHomologationIds: jest.fn(async () => units),
+    });
+    const repo = makeExpeditionRepo();
+    const { service, stock } = makeService({ repo, homolog });
+    const result = await service.deliverItem(
+      CTX,
+      ORDER_ID,
+      ORDER_ITEM_ID,
+      { quantity: 2, photoFileId: PHOTO_ID, qrs: ['caixa-10/7'] },
+      key(),
+    );
+    expect(result.qrs).toEqual([
+      { qrValue: '200_1', boxQr: 'caixa-10/7' },
+      { qrValue: '200_2', boxQr: 'caixa-10/7' },
+    ]);
+    expect(stock.insertMovementQrs).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.any(String),
+      [
+        expect.objectContaining({ qrValue: '200_1', boxQr: 'caixa-10/7' }),
+        expect.objectContaining({ qrValue: '200_2', boxQr: 'caixa-10/7' }),
+      ],
+      expect.anything(),
+    );
+  });
+
+  it('empty box → INV_BOX_EMPTY 422', async () => {
+    const homolog = makeHomologRepo({
+      findBoxesByQrValues: jest.fn(async () => [makeBox({ boxQr: 'caixa-10/7' })]),
+      unitsByHomologationIds: jest.fn(async () => []),
+    });
+    const { service } = makeService({ homolog });
+    const err = await service
+      .deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, { quantity: 2, photoFileId: PHOTO_ID, qrs: ['caixa-10/7'] }, key())
+      .catch((e) => e);
+    expect(err.code).toBe('INV_BOX_EMPTY');
+    expect(err.statusCode).toBe(422);
+  });
+
+  it('registry-only UNIT identity is accepted (same stockOnly semantics as M5)', async () => {
+    const homolog = makeHomologRepo({
+      findUnitsByQrValues: jest.fn(async () => []),
+      findRegistryByValues: jest.fn(async (_t: string, values: string[]) =>
+        values.filter((v) => !v.startsWith('http')).map((v) => makeRegistryRow(v)),
+      ),
+    });
+    const { service } = makeService({ homolog });
+    const result = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key());
+    expect(result.qrs.map((q) => q.qrValue)).toEqual(['100_1', '100_2']);
+  });
+});
+
+describe('M6 deliver — happy path, auto-status and push', () => {
+  it('writes delivery + delivery QRs + the SAIDA movement in one transaction', async () => {
+    const repo = makeExpeditionRepo();
+    const { service, stock } = makeService({ repo });
+    const result = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key());
+
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+    expect(repo.insertDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({ orderId: ORDER_ID, orderItemId: ORDER_ITEM_ID, quantity: 2, photoFileId: PHOTO_ID }),
+      expect.anything(),
+    );
+    expect(repo.insertDeliveryQrs).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.any(String),
+      ORDER_ITEM_ID,
+      [
+        expect.objectContaining({ qrValue: '100_1' }),
+        expect.objectContaining({ qrValue: '100_2' }),
+      ],
+      expect.anything(),
+    );
+    expect(stock.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: ITEM_MANUFACTURED,
+        location: DELIVERY_LOCATION,
+        quantity: '2',
+        type: 'SAIDA',
+        reason: REASON_EXPEDITION_DELIVERY,
+        photoFileId: PHOTO_ID,
+      }),
+      expect.anything(),
+    );
+    expect(result.movementId).toBeTruthy();
+  });
+
+  it('all items delivered → auto-advance to PRONTO_ENTREGA', async () => {
+    const repo = makeExpeditionRepo({
+      // Second read (post-insert) reports the full quantity delivered.
+      deliveredQuantities: jest
+        .fn()
+        .mockResolvedValueOnce(new Map()) // pre-insert: nothing delivered
+        .mockResolvedValue(new Map([[ORDER_ITEM_ID, 2]])), // post-insert
+    });
+    const { service } = makeService({ repo });
+    const result = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key());
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      CTX.tenantId,
+      ORDER_ID,
+      expect.objectContaining({ status: 'PRONTO_ENTREGA' }),
+      expect.anything(),
+    );
+    expect(result.autoAdvanced).toBe(true);
+  });
+
+  it('partial delivery → auto-advance to PRODUZINDO', async () => {
+    const repo = makeExpeditionRepo({
+      deliveredQuantities: jest
+        .fn()
+        .mockResolvedValueOnce(new Map())
+        .mockResolvedValue(new Map([[ORDER_ITEM_ID, 1]])),
+    });
+    const { service } = makeService({ repo });
+    await service.deliverItem(
+      CTX,
+      ORDER_ID,
+      ORDER_ITEM_ID,
+      { quantity: 1, photoFileId: PHOTO_ID, qrs: ['100_1'] },
+      key(),
+    );
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      CTX.tenantId,
+      ORDER_ID,
+      expect.objectContaining({ status: 'PRODUZINDO' }),
+      expect.anything(),
+    );
+  });
+
+  it('no auto-update when the status is already the computed one', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRODUZINDO' })),
+      deliveredQuantities: jest
+        .fn()
+        .mockResolvedValueOnce(new Map())
+        .mockResolvedValue(new Map([[ORDER_ITEM_ID, 1]])),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.deliverItem(
+      CTX,
+      ORDER_ID,
+      ORDER_ITEM_ID,
+      { quantity: 1, photoFileId: PHOTO_ID, qrs: ['100_1'] },
+      key(),
+    );
+    expect(repo.updateOrder).not.toHaveBeenCalled();
+    expect(result.autoAdvanced).toBe(false);
+  });
+
+  it('enqueues the "expedicao" push with the delivered unit QRs (DEC-6)', async () => {
+    const repo = makeExpeditionRepo();
+    const { service } = makeService({ repo });
+    await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, key());
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      { qrCodes: ['100_1', '100_2'], location: 'expedicao' },
+      expect.anything(),
+    );
+  });
+});
+
+describe('M6 deliver — idempotency (S1)', () => {
+  it('same Idempotency-Key executes once and replays the original result', async () => {
+    const repo = makeExpeditionRepo();
+    const { service } = makeService({ repo });
+    const idemKey = key();
+    const first = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, idemKey);
+    const second = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, idemKey);
+    expect(second).toBe(first);
+    expect(repo.insertDelivery).toHaveBeenCalledTimes(1);
+    expect(repo.withTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed attempt does not poison the key (retry re-executes)', async () => {
+    const repo = makeExpeditionRepo({
+      insertDelivery: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('connection reset'))
+        .mockImplementation(async (input: { quantity: number; photoFileId: string }) => ({
+          id: 'dddddddd-0000-0000-0000-000000000099',
+          tenantId: CTX.tenantId,
+          orderId: ORDER_ID,
+          orderItemId: ORDER_ITEM_ID,
+          quantity: input.quantity,
+          photoFileId: input.photoFileId,
+          createdAt: new Date(),
+          createdBy: null,
+        })),
+    });
+    const { service } = makeService({ repo });
+    const idemKey = key();
+    await expect(service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, idemKey)).rejects.toThrow();
+    const retry = await service.deliverItem(CTX, ORDER_ID, ORDER_ITEM_ID, DELIVER_2, idemKey);
+    expect(retry.delivery.quantity).toBe(2);
+    expect(repo.insertDelivery).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/inventory/m6-helpers.ts
+++ b/tests/unit/inventory/m6-helpers.ts
@@ -1,0 +1,374 @@
+// Shared fixtures/mocks for the RFC-0061 M6 unit suites (expedition service
+// with mocked expedition/stock/homologation repositories — no DB). Reuses the
+// M2 item/movement factories.
+
+import {
+  InventoryExpeditionService,
+  IInventoryExpeditionRepository,
+  IExpeditionStockRepository,
+  IExpeditionHomologationRepository,
+  IExpeditionItemRepository,
+  IExpeditionPurchaseOrderService,
+} from '../../../src/services/inventory/InventoryExpeditionService';
+import type {
+  InvExpeditionOrderRow,
+  InvItemDeliveryRow,
+  InvShipmentRow,
+  InvProjectRow,
+  InvProductionDemandRow,
+  InvPurchaseDemandRow,
+  NewDeliveryInput,
+  NewShipmentInput,
+  NewExpeditionOrderInput,
+  NewOrderItemInput,
+  NewProductionDemandInput,
+  NewPurchaseDemandInput,
+  NewUnitProductInput,
+  OrderItemWithName,
+  DeliveredQrRow,
+} from '../../../src/repositories/inventory/InventoryExpeditionRepository';
+import type {
+  InvHomologationRow,
+  InvHomologationUnitRow,
+  InvQrRegistryRow,
+} from '../../../src/repositories/inventory/InventoryHomologationRepository';
+import type { NewMovementInput } from '../../../src/repositories/inventory/InventoryStockRepository';
+import { makeItem, movementRowFrom, TENANT, USER, PHOTO_ID } from './m2-helpers';
+
+export { TENANT, USER, PHOTO_ID };
+export const CTX = { tenantId: TENANT, userId: USER };
+
+export const PROJECT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa01';
+export const CUSTOMER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaa02';
+export const ORDER_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeee01';
+export const ORDER_ITEM_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeee02';
+export const ORDER_ITEM_ID_2 = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeee03';
+export const ITEM_MANUFACTURED = 'ffffffff-ffff-4fff-8fff-ffffffffff01';
+export const ITEM_PURCHASABLE = 'ffffffff-ffff-4fff-8fff-ffffffffff02';
+export const PROOF_ID = '44444444-4444-4444-4444-444444444445';
+export const HOMOLOG_ID = '66666666-6666-6666-6666-666666666666';
+
+let seq = 0;
+export function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-0000-0000-0000-${String(seq).padStart(12, '0')}`;
+}
+
+export function makeOrder(overrides: Partial<InvExpeditionOrderRow> = {}): InvExpeditionOrderRow {
+  return {
+    id: ORDER_ID,
+    tenantId: TENANT,
+    title: 'Pedido Myio de teste',
+    projectId: PROJECT_ID,
+    customerId: null,
+    deliveryDate: new Date('2026-09-30T00:00:00Z'),
+    status: 'PENDENTE',
+    isReplacement: false,
+    notes: null,
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    createdBy: USER,
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+    updatedBy: USER,
+    ...overrides,
+  } as InvExpeditionOrderRow;
+}
+
+export function makeOrderItem(overrides: Partial<OrderItemWithName> = {}): OrderItemWithName {
+  return {
+    id: ORDER_ITEM_ID,
+    orderId: ORDER_ID,
+    itemId: ITEM_MANUFACTURED,
+    itemName: 'Produto manufaturado',
+    isManufactured: true,
+    domain: 'PRODUCT',
+    quantity: 2,
+    ...overrides,
+  };
+}
+
+export function makeProject(overrides: Partial<InvProjectRow> = {}): InvProjectRow {
+  return {
+    id: PROJECT_ID,
+    tenantId: TENANT,
+    name: 'Projeto Moxuara',
+    description: null,
+    customerId: CUSTOMER_ID,
+    legacyClientName: null,
+    legacyClientCnpj: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    createdBy: null,
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    updatedBy: null,
+    ...overrides,
+  } as InvProjectRow;
+}
+
+export function makeDeliveredQr(overrides: Partial<DeliveredQrRow> = {}): DeliveredQrRow {
+  return {
+    orderItemId: ORDER_ITEM_ID,
+    itemId: ITEM_MANUFACTURED,
+    qrValue: '100_1',
+    boxQr: null,
+    homologationUnitId: null,
+    ...overrides,
+  };
+}
+
+export function makeBox(overrides: Partial<InvHomologationRow> = {}): InvHomologationRow {
+  return {
+    id: HOMOLOG_ID,
+    tenantId: TENANT,
+    releaseId: null,
+    itemId: ITEM_MANUFACTURED,
+    boxSize: 10,
+    boxQr: 'caixa-10/1',
+    responsibleId: null,
+    notes: null,
+    createdAt: new Date('2026-07-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvHomologationRow;
+}
+
+export function makeHomologUnit(
+  qrValue: string,
+  overrides: Partial<InvHomologationUnitRow> = {},
+): InvHomologationUnitRow {
+  return {
+    id: nextId('88888888'),
+    tenantId: TENANT,
+    homologationId: HOMOLOG_ID,
+    position: 1,
+    qrValue,
+    createdAt: new Date('2026-07-01T00:00:00Z'),
+    ...overrides,
+  } as InvHomologationUnitRow;
+}
+
+export function makeRegistryRow(qrValue: string, overrides: Partial<InvQrRegistryRow> = {}): InvQrRegistryRow {
+  return {
+    id: nextId('99999999'),
+    tenantId: TENANT,
+    qrValue,
+    kind: 'UNIT',
+    itemId: ITEM_MANUFACTURED,
+    createdAt: new Date('2026-07-01T00:00:00Z'),
+    createdBy: USER,
+    ...overrides,
+  } as InvQrRegistryRow;
+}
+
+export function makeProductionDemand(overrides: Partial<InvProductionDemandRow> = {}): InvProductionDemandRow {
+  return {
+    id: nextId('11111111'),
+    tenantId: TENANT,
+    expeditionOrderItemId: ORDER_ITEM_ID,
+    expeditionOrderId: ORDER_ID,
+    itemId: ITEM_MANUFACTURED,
+    quantity: 1,
+    status: 'PENDENTE',
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as InvProductionDemandRow;
+}
+
+export function makePurchaseDemand(overrides: Partial<InvPurchaseDemandRow> = {}): InvPurchaseDemandRow {
+  return {
+    id: nextId('22222222'),
+    tenantId: TENANT,
+    expeditionOrderItemId: ORDER_ITEM_ID_2,
+    expeditionOrderId: ORDER_ID,
+    purchaseOrderId: null,
+    itemId: ITEM_PURCHASABLE,
+    quantity: 1,
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as InvPurchaseDemandRow;
+}
+
+export type MockExpeditionRepo = jest.Mocked<IInventoryExpeditionRepository>;
+export type MockStockRepo = jest.Mocked<IExpeditionStockRepository>;
+export type MockHomologRepo = jest.Mocked<IExpeditionHomologationRepository>;
+export type MockItemRepo = jest.Mocked<IExpeditionItemRepository>;
+export type MockPoService = jest.Mocked<IExpeditionPurchaseOrderService>;
+
+/** Expedition repo mock: withTransaction just runs the callback. */
+export function makeExpeditionRepo(overrides: Record<string, jest.Mock> = {}): MockExpeditionRepo {
+  const repo = {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    list: jest.fn(async () => ({ rows: [], total: 0 })),
+    getById: jest.fn(async () => makeOrder()),
+    lockById: jest.fn(async () => makeOrder()),
+    insertOrder: jest.fn(async (input: NewExpeditionOrderInput) =>
+      makeOrder({
+        id: ORDER_ID,
+        title: input.title ?? null,
+        projectId: input.projectId,
+        customerId: input.customerId ?? null,
+        deliveryDate: input.deliveryDate,
+        isReplacement: input.isReplacement ?? false,
+        notes: input.notes ?? null,
+      }),
+    ),
+    updateOrder: jest.fn(
+      async (_tenant: string, _id: string, patch: Record<string, unknown>) =>
+        makeOrder(patch as Partial<InvExpeditionOrderRow>),
+    ),
+    deleteOrder: jest.fn(async () => true),
+    listItemsByOrders: jest.fn(async () => [makeOrderItem()]),
+    getOrderItem: jest.fn(async () => makeOrderItem()),
+    insertItems: jest.fn(async (rows: NewOrderItemInput[]) =>
+      rows.map((r) => ({
+        id: nextId('eeeeeeee'),
+        tenantId: r.tenantId,
+        orderId: r.orderId,
+        itemId: r.itemId,
+        quantity: r.quantity,
+      })),
+    ),
+    deleteItemsByOrder: jest.fn(async () => 0),
+    deliveredQuantities: jest.fn(async () => new Map<string, number>()),
+    insertDelivery: jest.fn(async (input: NewDeliveryInput) =>
+      ({
+        id: nextId('dddddddd'),
+        tenantId: input.tenantId,
+        orderId: input.orderId,
+        orderItemId: input.orderItemId,
+        quantity: input.quantity,
+        photoFileId: input.photoFileId,
+        createdAt: new Date(),
+        createdBy: input.createdBy ?? null,
+      }) as InvItemDeliveryRow,
+    ),
+    insertDeliveryQrs: jest.fn(async () => []),
+    deliveredQrsByOrder: jest.fn(async () => [] as DeliveredQrRow[]),
+    insertShipment: jest.fn(async (input: NewShipmentInput) =>
+      ({
+        id: nextId('cccccccc'),
+        tenantId: input.tenantId,
+        orderId: input.orderId,
+        address: input.address,
+        shippingMethod: input.shippingMethod,
+        responsible: input.responsible,
+        trackingCode: input.trackingCode,
+        proofFileId: input.proofFileId,
+        notes: input.notes ?? null,
+        createdAt: new Date(),
+        createdBy: input.createdBy ?? null,
+      }) as InvShipmentRow,
+    ),
+    existingUnitProductLabels: jest.fn(async () => new Set<string>()),
+    insertUnitProducts: jest.fn(async (rows: NewUnitProductInput[]) =>
+      rows.map((r) => ({ id: nextId('bbbbbbbb'), ...r, status: 'PARADO' }) as never),
+    ),
+    getProject: jest.fn(async () => makeProject()),
+    externalStatesByCodes: jest.fn(async () => []),
+    enqueuePush: jest.fn(async () => undefined),
+    findProductionDemandsByOrderItemIds: jest.fn(async () => [] as InvProductionDemandRow[]),
+    findPurchaseDemandsByOrderItemIds: jest.fn(async () => [] as InvPurchaseDemandRow[]),
+    insertProductionDemand: jest.fn(async (input: NewProductionDemandInput) =>
+      makeProductionDemand({
+        expeditionOrderItemId: input.expeditionOrderItemId,
+        expeditionOrderId: input.expeditionOrderId,
+        itemId: input.itemId,
+        quantity: input.quantity,
+      }),
+    ),
+    insertPurchaseDemand: jest.fn(async (input: NewPurchaseDemandInput) =>
+      makePurchaseDemand({
+        expeditionOrderItemId: input.expeditionOrderItemId,
+        expeditionOrderId: input.expeditionOrderId,
+        itemId: input.itemId,
+        quantity: input.quantity,
+      }),
+    ),
+    setPurchaseDemandOrder: jest.fn(async () => undefined),
+  } as unknown as MockExpeditionRepo;
+  return Object.assign(repo, overrides);
+}
+
+/** Stock repo mock (the M2 seam): manufactured PRODUCT by default, deep stock. */
+export function makeStockRepo(overrides: Record<string, jest.Mock> = {}): MockStockRepo {
+  const repo = {
+    lockItem: jest.fn(async (_tenant: string, itemId: string) =>
+      itemId === ITEM_PURCHASABLE
+        ? makeItem({ id: itemId, name: 'Item comprável', domain: 'COMPONENT', isManufactured: false })
+        : makeItem({ id: itemId, name: 'Produto manufaturado', domain: 'PRODUCT', isManufactured: true }),
+    ),
+    getBalance: jest.fn(async () => ({ balance: '100', totalIn: '100', totalOut: '0', lastMovementAt: null })),
+    insertMovement: jest.fn(async (input: NewMovementInput) => movementRowFrom(input)),
+    insertMovementQrs: jest.fn(async () => []),
+    latestQrEventTypes: jest.fn(async () => new Map<string, string>()),
+  } as unknown as MockStockRepo;
+  return Object.assign(repo, overrides);
+}
+
+/** Homologation repo mock (the M5 seam): every QR resolves to a unit row. */
+export function makeHomologRepo(overrides: Record<string, jest.Mock> = {}): MockHomologRepo {
+  const repo = {
+    findRegistryByValues: jest.fn(async () => [] as InvQrRegistryRow[]),
+    // Every BARE code resolves to a size-1 homologation unit by default
+    // (candidates include the full URL spelling — only the bare one matches).
+    findUnitsByQrValues: jest.fn(async (_tenant: string, values: string[]) =>
+      [...new Set(values)]
+        .filter((v) => !v.startsWith('http'))
+        .map((v) => ({
+          unit: makeHomologUnit(v),
+          homologation: makeBox({ boxSize: 1, boxQr: null }),
+        })),
+    ),
+    findBoxesByQrValues: jest.fn(async () => [] as InvHomologationRow[]),
+    unitsByHomologationIds: jest.fn(async () => [] as InvHomologationUnitRow[]),
+    deliveryEventsByQrs: jest.fn(async () => []),
+  } as unknown as MockHomologRepo;
+  return Object.assign(repo, overrides);
+}
+
+export function makeItemRepo(overrides: Record<string, jest.Mock> = {}): MockItemRepo {
+  const repo = {
+    findByIds: jest.fn(async (_tenant: string, ids: string[]) =>
+      ids.map((id) =>
+        makeItem({
+          id,
+          name: `Item ${id.slice(-2)}`,
+          domain: id === ITEM_PURCHASABLE ? 'COMPONENT' : 'PRODUCT',
+          isManufactured: id !== ITEM_PURCHASABLE,
+        }),
+      ),
+    ),
+  } as unknown as MockItemRepo;
+  return Object.assign(repo, overrides);
+}
+
+export function makePoService(overrides: Record<string, jest.Mock> = {}): MockPoService {
+  const svc = {
+    create: jest.fn(async () => ({ id: nextId('33333333'), status: 'PENDENTE' }) as never),
+  } as unknown as MockPoService;
+  return Object.assign(svc, overrides);
+}
+
+export interface ServiceBundle {
+  service: InventoryExpeditionService;
+  repo: MockExpeditionRepo;
+  stock: MockStockRepo;
+  homolog: MockHomologRepo;
+  items: MockItemRepo;
+  po: MockPoService;
+}
+
+export function makeService(
+  parts: {
+    repo?: MockExpeditionRepo;
+    stock?: MockStockRepo;
+    homolog?: MockHomologRepo;
+    items?: MockItemRepo;
+    po?: MockPoService;
+  } = {},
+): ServiceBundle {
+  const repo = parts.repo ?? makeExpeditionRepo();
+  const stock = parts.stock ?? makeStockRepo();
+  const homolog = parts.homolog ?? makeHomologRepo();
+  const items = parts.items ?? makeItemRepo();
+  const po = parts.po ?? makePoService();
+  return { service: new InventoryExpeditionService(repo, stock, homolog, items, po), repo, stock, homolog, items, po };
+}

--- a/tests/unit/inventory/m6-resolve-demand.test.ts
+++ b/tests/unit/inventory/m6-resolve-demand.test.ts
@@ -1,0 +1,230 @@
+/**
+ * RFC-0061 §M4 — demand resolution (P3, A4 — ships with M6; service with
+ * mocked repositories — no DB).
+ *
+ * For expedition-order items short on ALMOXARIFADO stock: manufactured →
+ * inv_production_demands; purchasable → automatic purchase order (recipient/
+ * delivery point "Estoque", CUSTOMIZADO deadline = delivery date, note
+ * "Demanda automática do pedido") + inv_purchase_demands. Idempotent per
+ * expedition_order_item_id (UNIQUE).
+ */
+
+import {
+  AUTO_PURCHASE_RECIPIENT,
+  AUTO_PURCHASE_DELIVERY_POINT,
+  AUTO_PURCHASE_NOTE,
+} from '../../../src/services/inventory/InventoryExpeditionService';
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  ORDER_ID,
+  ORDER_ITEM_ID,
+  ORDER_ITEM_ID_2,
+  ITEM_MANUFACTURED,
+  ITEM_PURCHASABLE,
+  PROJECT_ID,
+  makeOrder,
+  makeOrderItem,
+  makeProductionDemand,
+  makePurchaseDemand,
+  makeExpeditionRepo,
+  makeStockRepo,
+  makePoService,
+  makeService,
+} from './m6-helpers';
+
+const DTO = { expeditionOrderId: ORDER_ID };
+
+function manufacturedItem(qty = 10) {
+  return makeOrderItem({ id: ORDER_ITEM_ID, itemId: ITEM_MANUFACTURED, isManufactured: true, quantity: qty });
+}
+
+function purchasableItem(qty = 10) {
+  return makeOrderItem({
+    id: ORDER_ITEM_ID_2,
+    itemId: ITEM_PURCHASABLE,
+    itemName: 'Item comprável',
+    isManufactured: false,
+    domain: 'COMPONENT',
+    quantity: qty,
+  });
+}
+
+describe('M4 resolve-demand — shortage detection (saldo ALMOXARIFADO)', () => {
+  it('no shortage → action NONE, nothing written', async () => {
+    const repo = makeExpeditionRepo({ listItemsByOrders: jest.fn(async () => [manufacturedItem(5)]) });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '5', totalIn: '5', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items).toEqual([
+      expect.objectContaining({ orderItemId: ORDER_ITEM_ID, required: 5, balance: 5, shortage: 0, action: 'NONE' }),
+    ]);
+    expect(repo.insertProductionDemand).not.toHaveBeenCalled();
+    expect(repo.insertPurchaseDemand).not.toHaveBeenCalled();
+  });
+
+  it('manufactured shortage → inv_production_demands with the missing quantity', async () => {
+    const repo = makeExpeditionRepo({ listItemsByOrders: jest.fn(async () => [manufacturedItem(10)]) });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '3', totalIn: '3', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service, po } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+
+    expect(repo.insertProductionDemand).toHaveBeenCalledWith({
+      tenantId: CTX.tenantId,
+      expeditionOrderItemId: ORDER_ITEM_ID,
+      expeditionOrderId: ORDER_ID,
+      itemId: ITEM_MANUFACTURED,
+      quantity: 7,
+    });
+    expect(po.create).not.toHaveBeenCalled();
+    expect(result.items[0]).toMatchObject({ action: 'PRODUCTION_DEMAND', shortage: 7 });
+    expect(result.items[0].productionDemandId).toBeTruthy();
+  });
+
+  it('purchasable shortage → automatic purchase order + inv_purchase_demands', async () => {
+    const repo = makeExpeditionRepo({ listItemsByOrders: jest.fn(async () => [purchasableItem(10)]) });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '4', totalIn: '4', totalOut: '0', lastMovementAt: null })),
+    });
+    const po = makePoService({
+      create: jest.fn(async () => ({ id: '33333333-0000-4000-8000-000000000001', status: 'PENDENTE' }) as never),
+    });
+    const { service } = makeService({ repo, stock, po });
+    const result = await service.resolveDemand(CTX, DTO);
+
+    expect(po.create).toHaveBeenCalledWith(CTX, {
+      projectId: PROJECT_ID,
+      itemId: ITEM_PURCHASABLE,
+      quantity: 6,
+      recipient: AUTO_PURCHASE_RECIPIENT,
+      deliveryPoint: AUTO_PURCHASE_DELIVERY_POINT,
+      deadlineType: 'CUSTOMIZADO',
+      deadlineDate: new Date('2026-09-30T00:00:00Z').toISOString(), // order delivery date
+      requesterNotes: AUTO_PURCHASE_NOTE,
+    });
+    expect(repo.insertPurchaseDemand).toHaveBeenCalledWith({
+      tenantId: CTX.tenantId,
+      expeditionOrderItemId: ORDER_ITEM_ID_2,
+      expeditionOrderId: ORDER_ID,
+      itemId: ITEM_PURCHASABLE,
+      quantity: 6,
+    });
+    expect(repo.setPurchaseDemandOrder).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.any(String),
+      '33333333-0000-4000-8000-000000000001',
+    );
+    expect(result.items[0]).toMatchObject({
+      action: 'PURCHASE_ORDER',
+      shortage: 6,
+      purchaseOrderId: '33333333-0000-4000-8000-000000000001',
+    });
+  });
+
+  it('fractional balance rounds the shortage UP (never under-provisions)', async () => {
+    const repo = makeExpeditionRepo({ listItemsByOrders: jest.fn(async () => [manufacturedItem(10)]) });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '3.4', totalIn: '3.4', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items[0].shortage).toBe(7); // ceil(10 − 3.4)
+  });
+
+  it('mixed order resolves each item by its own kind', async () => {
+    const repo = makeExpeditionRepo({
+      listItemsByOrders: jest.fn(async () => [manufacturedItem(10), purchasableItem(10)]),
+    });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service, po } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items.map((i) => i.action)).toEqual(['PRODUCTION_DEMAND', 'PURCHASE_ORDER']);
+    expect(repo.insertProductionDemand).toHaveBeenCalledTimes(1);
+    expect(repo.insertPurchaseDemand).toHaveBeenCalledTimes(1);
+    expect(po.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('M4 resolve-demand — idempotency (UNIQUE per expedition_order_item_id)', () => {
+  it('an existing production demand short-circuits to ALREADY_RESOLVED', async () => {
+    const existing = makeProductionDemand({ expeditionOrderItemId: ORDER_ITEM_ID });
+    const repo = makeExpeditionRepo({
+      listItemsByOrders: jest.fn(async () => [manufacturedItem(10)]),
+      findProductionDemandsByOrderItemIds: jest.fn(async () => [existing]),
+    });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items[0]).toMatchObject({ action: 'ALREADY_RESOLVED', productionDemandId: existing.id });
+    expect(repo.insertProductionDemand).not.toHaveBeenCalled();
+  });
+
+  it('an existing purchase demand short-circuits and never re-creates the PO', async () => {
+    const existing = makePurchaseDemand({
+      expeditionOrderItemId: ORDER_ITEM_ID_2,
+      purchaseOrderId: '33333333-0000-4000-8000-000000000009',
+    });
+    const repo = makeExpeditionRepo({
+      listItemsByOrders: jest.fn(async () => [purchasableItem(10)]),
+      findPurchaseDemandsByOrderItemIds: jest.fn(async () => [existing]),
+    });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service, po } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items[0]).toMatchObject({
+      action: 'ALREADY_RESOLVED',
+      purchaseOrderId: '33333333-0000-4000-8000-000000000009',
+    });
+    expect(po.create).not.toHaveBeenCalled();
+    expect(repo.insertPurchaseDemand).not.toHaveBeenCalled();
+  });
+
+  it('a concurrent claim (insert returns null on conflict) reports ALREADY_RESOLVED', async () => {
+    const repo = makeExpeditionRepo({
+      listItemsByOrders: jest.fn(async () => [manufacturedItem(10), purchasableItem(10)]),
+      insertProductionDemand: jest.fn(async () => null),
+      insertPurchaseDemand: jest.fn(async () => null),
+    });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service, po } = makeService({ repo, stock });
+    const result = await service.resolveDemand(CTX, DTO);
+    expect(result.items.map((i) => i.action)).toEqual(['ALREADY_RESOLVED', 'ALREADY_RESOLVED']);
+    // The UNIQUE claim lost → the automatic PO must NOT be created.
+    expect(po.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('M4 resolve-demand — guards', () => {
+  it('404 for an unknown expedition order', async () => {
+    const repo = makeExpeditionRepo({ getById: jest.fn(async () => null) });
+    const { service } = makeService({ repo });
+    const err = await service.resolveDemand(CTX, DTO).catch((e) => e);
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('purchasable shortage on an order without project → ValidationError', async () => {
+    const repo = makeExpeditionRepo({
+      getById: jest.fn(async () => makeOrder({ projectId: null })),
+      listItemsByOrders: jest.fn(async () => [purchasableItem(10)]),
+    });
+    const stock = makeStockRepo({
+      getBalance: jest.fn(async () => ({ balance: '0', totalIn: '0', totalOut: '0', lastMovementAt: null })),
+    });
+    const { service } = makeService({ repo, stock });
+    const err = await service.resolveDemand(CTX, DTO).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('projeto');
+  });
+});

--- a/tests/unit/inventory/m6-ship-return-lost-found.test.ts
+++ b/tests/unit/inventory/m6-ship-return-lost-found.test.ts
@@ -1,0 +1,288 @@
+/**
+ * RFC-0061 M6 — ship / return / lost / found flows (service with mocked
+ * repositories — no DB).
+ *
+ * Ship: mandatory address/method/responsible/tracking/proof → inv_shipments +
+ * EM_TRANSITO + push "transporte". Return (EM_TRANSITO → PRONTO_ENTREGA) and
+ * lost (→ PERDIDO) demand a reason and stamp the notes with the timestamped
+ * markers; found maps the chosen sector to the target status and stamps too.
+ */
+
+import {
+  ShipExpeditionSchema,
+  ReturnExpeditionSchema,
+  LostExpeditionSchema,
+  FoundExpeditionSchema,
+  returnStamp,
+  lostStamp,
+  foundStamp,
+} from '../../../src/services/inventory/InventoryExpeditionService';
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  ORDER_ID,
+  PROOF_ID,
+  makeOrder,
+  makeDeliveredQr,
+  makeExpeditionRepo,
+  makeService,
+} from './m6-helpers';
+
+const SHIP_DTO = {
+  address: 'Rua das Amoreiras, 100 — Vitória/ES',
+  shippingMethod: 'AZUL_CARGO',
+  responsible: 'João Transportes',
+  trackingCode: 'AZ123456789BR',
+  proofFileId: PROOF_ID,
+};
+
+describe('M6 ship — DTO shape (campos obrigatórios)', () => {
+  it.each(['address', 'shippingMethod', 'responsible', 'trackingCode', 'proofFileId'])(
+    'rejects a payload missing %s',
+    (field) => {
+      const dto: Record<string, unknown> = { ...SHIP_DTO };
+      delete dto[field];
+      expect(() => ShipExpeditionSchema.parse(dto)).toThrow();
+    },
+  );
+
+  it('rejects an unknown shipping method (enum AZUL_CARGO/CORREIOS/CARRO_MYIO/UBER)', () => {
+    expect(() => ShipExpeditionSchema.parse({ ...SHIP_DTO, shippingMethod: 'SEDEX' })).toThrow();
+    for (const method of ['AZUL_CARGO', 'CORREIOS', 'CARRO_MYIO', 'UBER']) {
+      expect(() => ShipExpeditionSchema.parse({ ...SHIP_DTO, shippingMethod: method })).not.toThrow();
+    }
+  });
+});
+
+describe('M6 ship — flow', () => {
+  it('PRONTO_ENTREGA → EM_TRANSITO: creates the shipment and pushes "transporte"', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRONTO_ENTREGA' })),
+      deliveredQrsByOrder: jest.fn(async () => [
+        makeDeliveredQr({ qrValue: '100_1' }),
+        makeDeliveredQr({ qrValue: '100_2' }),
+      ]),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.ship(CTX, ORDER_ID, SHIP_DTO);
+
+    expect(repo.insertShipment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: ORDER_ID,
+        address: SHIP_DTO.address,
+        shippingMethod: 'AZUL_CARGO',
+        responsible: SHIP_DTO.responsible,
+        trackingCode: SHIP_DTO.trackingCode,
+        proofFileId: PROOF_ID,
+      }),
+      expect.anything(),
+    );
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      CTX.tenantId,
+      ORDER_ID,
+      expect.objectContaining({ status: 'EM_TRANSITO' }),
+      expect.anything(),
+    );
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.objectContaining({ qrCodes: ['100_1', '100_2'], location: 'transporte' }),
+      expect.anything(),
+    );
+    expect(result.order.status).toBe('EM_TRANSITO');
+    expect(result.shipment.trackingCode).toBe(SHIP_DTO.trackingCode);
+  });
+
+  it('already EM_TRANSITO → INV_ALREADY_IN_STATE 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.ship(CTX, ORDER_ID, SHIP_DTO).catch((e) => e);
+    expect(err.code).toBe('INV_ALREADY_IN_STATE');
+    expect(repo.insertShipment).not.toHaveBeenCalled();
+  });
+
+  it('ship from PENDENTE → INV_ILLEGAL_TRANSITION 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PENDENTE' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.ship(CTX, ORDER_ID, SHIP_DTO).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+    expect(err.details).toEqual({ current: 'PENDENTE', allowedTransitions: ['PRODUZINDO'] });
+  });
+});
+
+describe('M6 return — EM_TRANSITO → PRONTO_ENTREGA with the note stamp', () => {
+  it('reason is mandatory (DTO)', () => {
+    expect(() => ReturnExpeditionSchema.parse({})).toThrow();
+    expect(() => ReturnExpeditionSchema.parse({ reason: '' })).toThrow();
+  });
+
+  it('stamps "[Retornado para Expedição em <ISO>] motivo" and pushes "expedicao"', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO', notes: 'nota antiga' })),
+      deliveredQrsByOrder: jest.fn(async () => [makeDeliveredQr({ qrValue: '100_1' })]),
+    });
+    const { service } = makeService({ repo });
+    await service.returnToExpedition(CTX, ORDER_ID, { reason: 'cliente ausente' });
+
+    const patch = repo.updateOrder.mock.calls[0][2] as { status: string; notes: string };
+    expect(patch.status).toBe('PRONTO_ENTREGA');
+    expect(patch.notes).toMatch(
+      /^nota antiga\n\[Retornado para Expedição em \d{4}-\d{2}-\d{2}T[\d:.]+Z\] cliente ausente$/,
+    );
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.objectContaining({ location: 'expedicao', qrCodes: ['100_1'] }),
+      expect.anything(),
+    );
+  });
+
+  it('return outside EM_TRANSITO → INV_ILLEGAL_TRANSITION 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRODUZINDO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.returnToExpedition(CTX, ORDER_ID, { reason: 'x' }).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+  });
+
+  it('already PRONTO_ENTREGA → INV_ALREADY_IN_STATE 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRONTO_ENTREGA' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.returnToExpedition(CTX, ORDER_ID, { reason: 'x' }).catch((e) => e);
+    expect(err.code).toBe('INV_ALREADY_IN_STATE');
+  });
+});
+
+describe('M6 lost — EM_TRANSITO → PERDIDO with the note stamp', () => {
+  it('reason is mandatory (DTO)', () => {
+    expect(() => LostExpeditionSchema.parse({})).toThrow();
+  });
+
+  it('stamps "[Mercadoria perdida em <ISO>] motivo" and pushes "perdido"', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO', notes: null })),
+      deliveredQrsByOrder: jest.fn(async () => [makeDeliveredQr({ qrValue: '100_1' })]),
+    });
+    const { service } = makeService({ repo });
+    await service.markLost(CTX, ORDER_ID, { reason: 'extraviado pela transportadora' });
+
+    const patch = repo.updateOrder.mock.calls[0][2] as { status: string; notes: string };
+    expect(patch.status).toBe('PERDIDO');
+    expect(patch.notes).toMatch(
+      /^\[Mercadoria perdida em \d{4}-\d{2}-\d{2}T[\d:.]+Z\] extraviado pela transportadora$/,
+    );
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.objectContaining({ location: 'perdido' }),
+      expect.anything(),
+    );
+  });
+
+  it('lost outside EM_TRANSITO → INV_ILLEGAL_TRANSITION 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRONTO_ENTREGA' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.markLost(CTX, ORDER_ID, { reason: 'x' }).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+  });
+
+  it('already PERDIDO → INV_ALREADY_IN_STATE 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PERDIDO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.markLost(CTX, ORDER_ID, { reason: 'x' }).catch((e) => e);
+    expect(err.code).toBe('INV_ALREADY_IN_STATE');
+  });
+});
+
+describe('M6 found — PERDIDO → sector-mapped status with the note stamp', () => {
+  it('sector enum is enforced (DTO)', () => {
+    expect(() => FoundExpeditionSchema.parse({ sector: 'FABRICA' })).toThrow();
+    expect(() => FoundExpeditionSchema.parse({ sector: 'EXPEDICAO' })).not.toThrow();
+  });
+
+  const sectorCases: Array<[string, string, string]> = [
+    ['EXPEDICAO', 'PRONTO_ENTREGA', 'expedicao'],
+    ['TRANSPORTE', 'EM_TRANSITO', 'transporte'],
+    ['ESTOQUE', 'PRODUZINDO', 'estoque'],
+  ];
+
+  it.each(sectorCases)('sector %s → status %s + push %s', async (sector, status, push) => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PERDIDO' })),
+      deliveredQrsByOrder: jest.fn(async () => [makeDeliveredQr({ qrValue: '100_1' })]),
+    });
+    const { service } = makeService({ repo });
+    await service.markFound(CTX, ORDER_ID, { sector: sector as never });
+
+    const patch = repo.updateOrder.mock.calls[0][2] as { status: string; notes: string };
+    expect(patch.status).toBe(status);
+    expect(patch.notes).toMatch(/^\[Mercadoria encontrada em \d{4}-\d{2}-\d{2}T[\d:.]+Z\] Setor: /);
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.objectContaining({ location: push }),
+      expect.anything(),
+    );
+    expect(repo.insertUnitProducts).not.toHaveBeenCalled();
+  });
+
+  it('sector CLIENTE → ENTREGUE_CLIENTE + unit products + push "cliente"', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PERDIDO' })),
+      deliveredQrsByOrder: jest.fn(async () => [makeDeliveredQr({ qrValue: '100_1' })]),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.markFound(CTX, ORDER_ID, { sector: 'CLIENTE', notes: 'achado no cliente' });
+
+    const patch = repo.updateOrder.mock.calls[0][2] as { status: string; notes: string };
+    expect(patch.status).toBe('ENTREGUE_CLIENTE');
+    expect(patch.notes).toContain('Setor: Cliente — achado no cliente');
+    expect(repo.insertUnitProducts).toHaveBeenCalled();
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      expect.objectContaining({ location: 'cliente', qrCodes: ['100_1'] }),
+      expect.anything(),
+    );
+    expect(result.unitProducts).toMatchObject({ created: 1, skipped: 0 });
+  });
+
+  it('sector CLIENTE without a project → ValidationError (Projeto = Cliente)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PERDIDO', projectId: null })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.markFound(CTX, ORDER_ID, { sector: 'CLIENTE' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('projeto');
+  });
+
+  it('found outside PERDIDO → INV_ILLEGAL_TRANSITION 409', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.markFound(CTX, ORDER_ID, { sector: 'EXPEDICAO' }).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+  });
+});
+
+describe('M6 — stamp formats (documented)', () => {
+  it('keeps the exact source markers', () => {
+    expect(returnStamp('2026-08-27T12:00:00.000Z', 'motivo x')).toBe(
+      '[Retornado para Expedição em 2026-08-27T12:00:00.000Z] motivo x',
+    );
+    expect(lostStamp('2026-08-27T12:00:00.000Z', 'motivo y')).toBe(
+      '[Mercadoria perdida em 2026-08-27T12:00:00.000Z] motivo y',
+    );
+    expect(foundStamp('2026-08-27T12:00:00.000Z', 'ESTOQUE')).toBe(
+      '[Mercadoria encontrada em 2026-08-27T12:00:00.000Z] Setor: Estoque',
+    );
+  });
+});

--- a/tests/unit/inventory/m6-state-machine.test.ts
+++ b/tests/unit/inventory/m6-state-machine.test.ts
@@ -1,0 +1,154 @@
+/**
+ * RFC-0061 M6 — expedition-order state machine (DEC-4, service with mocked
+ * repositories — no DB).
+ *
+ * Covers the whole EXPEDITION_ORDER_TRANSITIONS map through the generic
+ * /status service call plus the dedicated flows' transition guards:
+ * legal transitions, INV_ALREADY_IN_STATE, INV_ILLEGAL_TRANSITION (body with
+ * current + allowedTransitions), the mandatory-payload redirects (EM_TRANSITO
+ * → ship, PERDIDO → lost, from-PERDIDO → found) and allowedTransitions on
+ * reads (S3).
+ */
+
+import {
+  EXPEDITION_ORDER_TRANSITIONS,
+  InvExpeditionStatus,
+} from '../../../src/domain/entities/Inventory';
+import { InventoryError } from '../../../src/shared/errors/InventoryError';
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import { CTX, ORDER_ID, makeOrder, makeExpeditionRepo, makeService } from './m6-helpers';
+
+describe('M6 — EXPEDITION_ORDER_TRANSITIONS map (documented)', () => {
+  it('matches the RFC §M6 diagram', () => {
+    expect(EXPEDITION_ORDER_TRANSITIONS).toEqual({
+      PENDENTE: ['PRODUZINDO'],
+      PRODUZINDO: ['PRONTO_ENTREGA'],
+      PRONTO_ENTREGA: ['EM_TRANSITO'],
+      EM_TRANSITO: ['ENTREGUE_CLIENTE', 'PERDIDO'],
+      ENTREGUE_CLIENTE: [],
+      PERDIDO: ['PRODUZINDO', 'PRONTO_ENTREGA', 'EM_TRANSITO'],
+    });
+  });
+});
+
+describe('M6 — changeStatus (generic manual transitions)', () => {
+  it('PENDENTE → PRODUZINDO succeeds and persists the new status', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PENDENTE' })),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'PRODUZINDO' });
+    expect(repo.updateOrder).toHaveBeenCalledWith(
+      CTX.tenantId,
+      ORDER_ID,
+      expect.objectContaining({ status: 'PRODUZINDO' }),
+      expect.anything(),
+    );
+    expect(result.order.status).toBe('PRODUZINDO');
+    expect(result.order.allowedTransitions).toEqual(['PRONTO_ENTREGA']);
+  });
+
+  it('PRODUZINDO → PRONTO_ENTREGA succeeds', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRODUZINDO' })),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'PRONTO_ENTREGA' });
+    expect(result.order.status).toBe('PRONTO_ENTREGA');
+  });
+
+  it('transition to the CURRENT state → INV_ALREADY_IN_STATE 409 (A1)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PRODUZINDO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'PRODUZINDO' }).catch((e) => e);
+    expect(err).toBeInstanceOf(InventoryError);
+    expect(err.code).toBe('INV_ALREADY_IN_STATE');
+    expect(err.statusCode).toBe(409);
+    expect(err.details).toEqual({ current: 'PRODUZINDO' });
+    expect(repo.updateOrder).not.toHaveBeenCalled();
+  });
+
+  it('illegal transition → INV_ILLEGAL_TRANSITION 409 with allowedTransitions', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PENDENTE' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' }).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+    expect(err.statusCode).toBe(409);
+    expect(err.details).toEqual({ current: 'PENDENTE', allowedTransitions: ['PRODUZINDO'] });
+  });
+
+  it('ENTREGUE_CLIENTE is terminal — any transition out is illegal', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'ENTREGUE_CLIENTE' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'PRODUZINDO' }).catch((e) => e);
+    expect(err.code).toBe('INV_ILLEGAL_TRANSITION');
+    expect(err.details.allowedTransitions).toEqual([]);
+  });
+
+  it('target EM_TRANSITO is redirected to /ship (mandatory payload)', async () => {
+    const { service, repo } = makeService();
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'EM_TRANSITO' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('/ship');
+    expect(repo.lockById).not.toHaveBeenCalled();
+  });
+
+  it('target PERDIDO is redirected to /lost (motivo obrigatório)', async () => {
+    const { service } = makeService();
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'PERDIDO' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('/lost');
+  });
+
+  it('current PERDIDO is redirected to /found (sector mapping)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'PERDIDO' })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'PRODUZINDO' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toContain('/found');
+  });
+
+  it('EM_TRANSITO → ENTREGUE_CLIENTE creates the unit products (idempotent path tested in m6-unit-products)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+    expect(result.order.status).toBe('ENTREGUE_CLIENTE');
+    expect(result.unitProducts).toBeDefined();
+    expect(repo.insertUnitProducts).toHaveBeenCalled();
+  });
+
+  it('404 when the order does not exist', async () => {
+    const repo = makeExpeditionRepo({ lockById: jest.fn(async () => null) });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'PRODUZINDO' }).catch((e) => e);
+    expect(err.statusCode).toBe(404);
+  });
+});
+
+describe('M6 — allowedTransitions on reads (S3)', () => {
+  const cases: Array<[InvExpeditionStatus, InvExpeditionStatus[]]> = [
+    ['PENDENTE', ['PRODUZINDO']],
+    ['PRODUZINDO', ['PRONTO_ENTREGA']],
+    ['PRONTO_ENTREGA', ['EM_TRANSITO']],
+    ['EM_TRANSITO', ['ENTREGUE_CLIENTE', 'PERDIDO']],
+    ['ENTREGUE_CLIENTE', []],
+    ['PERDIDO', ['PRODUZINDO', 'PRONTO_ENTREGA', 'EM_TRANSITO']],
+  ];
+
+  it.each(cases)('getById exposes allowedTransitions for %s', async (status, allowed) => {
+    const repo = makeExpeditionRepo({ getById: jest.fn(async () => makeOrder({ status })) });
+    const { service } = makeService({ repo });
+    const detail = await service.getById(CTX, ORDER_ID);
+    expect(detail.allowedTransitions).toEqual(allowed);
+  });
+});

--- a/tests/unit/inventory/m6-unit-products.test.ts
+++ b/tests/unit/inventory/m6-unit-products.test.ts
@@ -1,0 +1,203 @@
+/**
+ * RFC-0061 M6 — inv_unit_products creation on ENTREGUE_CLIENTE (service with
+ * mocked repositories — no DB).
+ *
+ * One row per delivered unit, labels matched from the delivery QRs, "Projeto =
+ * Cliente" (client_name_snapshot = project name; customer from the project
+ * when set), status PARADO, idempotent (existing labels are never recreated).
+ * Also covers the transit-progress read ("X de Y em transporte").
+ */
+
+import { ValidationError } from '../../../src/shared/errors/AppError';
+import {
+  CTX,
+  ORDER_ID,
+  ORDER_ITEM_ID,
+  ORDER_ITEM_ID_2,
+  ITEM_MANUFACTURED,
+  ITEM_PURCHASABLE,
+  PROJECT_ID,
+  CUSTOMER_ID,
+  makeOrder,
+  makeProject,
+  makeDeliveredQr,
+  makeExpeditionRepo,
+  makeService,
+} from './m6-helpers';
+
+function deliveredThree() {
+  return [
+    makeDeliveredQr({ qrValue: '100_1' }),
+    makeDeliveredQr({ qrValue: '100_2', boxQr: 'caixa-10/1' }),
+    makeDeliveredQr({ qrValue: '100_3', orderItemId: ORDER_ITEM_ID_2, itemId: ITEM_PURCHASABLE }),
+  ];
+}
+
+describe('M6 — unit products on ENTREGUE_CLIENTE', () => {
+  it('creates one PARADO row per delivered unit with the Projeto = Cliente rule', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => deliveredThree()),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+
+    expect(repo.getProject).toHaveBeenCalledWith(CTX.tenantId, PROJECT_ID, expect.anything());
+    const rows = repo.insertUnitProducts.mock.calls[0][0];
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      tenantId: CTX.tenantId,
+      itemId: ITEM_MANUFACTURED,
+      label: '100_1',
+      projectId: PROJECT_ID,
+      customerId: CUSTOMER_ID, // from the project
+      clientNameSnapshot: 'Projeto Moxuara', // Projeto = Cliente
+      expeditionOrderId: ORDER_ID,
+    });
+    expect(rows[2]).toMatchObject({ label: '100_3', itemId: ITEM_PURCHASABLE });
+    expect(result.unitProducts).toMatchObject({ created: 3, skipped: 0 });
+    expect(repo.enqueuePush).toHaveBeenCalledWith(
+      CTX.tenantId,
+      { qrCodes: ['100_1', '100_2', '100_3'], location: 'cliente', clientName: 'Projeto Moxuara' },
+      expect.anything(),
+    );
+  });
+
+  it('is idempotent — labels already registered are skipped, never recreated', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => deliveredThree()),
+      existingUnitProductLabels: jest.fn(async () => new Set(['100_1', '100_2'])),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+
+    const rows = repo.insertUnitProducts.mock.calls[0][0];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ label: '100_3' });
+    expect(result.unitProducts).toMatchObject({ created: 1, skipped: 2 });
+  });
+
+  it('fully replayed order creates nothing (created 0, skipped all)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => deliveredThree()),
+      existingUnitProductLabels: jest.fn(async () => new Set(['100_1', '100_2', '100_3'])),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+    expect(repo.insertUnitProducts.mock.calls[0][0]).toHaveLength(0);
+    expect(result.unitProducts).toMatchObject({ created: 0, skipped: 3 });
+  });
+
+  it('duplicate delivered labels collapse to one unit product', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => [
+        makeDeliveredQr({ qrValue: '100_1' }),
+        makeDeliveredQr({ qrValue: '100_1' }),
+      ]),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+    expect(repo.insertUnitProducts.mock.calls[0][0]).toHaveLength(1);
+    expect(result.unitProducts).toMatchObject({ created: 1, skipped: 0 });
+  });
+
+  it('customer falls back to the order when the project has none', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () =>
+        makeOrder({ status: 'EM_TRANSITO', customerId: '99999999-9999-4999-8999-999999999999' }),
+      ),
+      getProject: jest.fn(async () => makeProject({ customerId: null })),
+      deliveredQrsByOrder: jest.fn(async () => [makeDeliveredQr()]),
+    });
+    const { service } = makeService({ repo });
+    await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' });
+    expect(repo.insertUnitProducts.mock.calls[0][0][0]).toMatchObject({
+      customerId: '99999999-9999-4999-8999-999999999999',
+    });
+  });
+
+  it('order without a project → ValidationError (regra Projeto = Cliente)', async () => {
+    const repo = makeExpeditionRepo({
+      lockById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO', projectId: null })),
+    });
+    const { service } = makeService({ repo });
+    const err = await service.changeStatus(CTX, ORDER_ID, { status: 'ENTREGUE_CLIENTE' }).catch((e) => e);
+    expect(err).toBeInstanceOf(ValidationError);
+  });
+});
+
+describe('M6 — transit progress ("X de Y em transporte")', () => {
+  it('no external-state rows → every QR counts as in transit (default)', async () => {
+    const repo = makeExpeditionRepo({
+      getById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => [
+        makeDeliveredQr({ qrValue: '100_1' }),
+        makeDeliveredQr({ qrValue: '100_2' }),
+      ]),
+      externalStatesByCodes: jest.fn(async () => []),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.transitProgress(CTX, ORDER_ID, 1, 20);
+    expect(result.summary).toBe('2 de 2 em transporte');
+    expect(result.totalUnits).toBe(2);
+    expect(result.unitsInTransit).toBe(2);
+    expect(result.items[0].units.every((u) => u.inTransit)).toBe(true);
+  });
+
+  it('a QR mirrored elsewhere (e.g. cliente) leaves the in-transit count', async () => {
+    const repo = makeExpeditionRepo({
+      getById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      deliveredQrsByOrder: jest.fn(async () => [
+        makeDeliveredQr({ qrValue: '100_1' }),
+        makeDeliveredQr({ qrValue: '100_2' }),
+        makeDeliveredQr({ qrValue: '100_3' }),
+      ]),
+      externalStatesByCodes: jest.fn(async () => [
+        { code: '100_2', qrValue: null, location: 'cliente', status: 'instalado' },
+        { code: '100_3', qrValue: null, location: 'transporte', status: null },
+      ]),
+    });
+    const { service } = makeService({ repo });
+    const result = await service.transitProgress(CTX, ORDER_ID, 1, 20);
+    expect(result.summary).toBe('2 de 3 em transporte');
+    const units = result.items[0].units;
+    expect(units.find((u) => u.qrValue === '100_2')).toMatchObject({
+      inTransit: false,
+      externalLocation: 'cliente',
+    });
+    expect(units.find((u) => u.qrValue === '100_3')).toMatchObject({ inTransit: true });
+  });
+
+  it('groups per order item and paginates the item breakdown', async () => {
+    const repo = makeExpeditionRepo({
+      getById: jest.fn(async () => makeOrder({ status: 'EM_TRANSITO' })),
+      listItemsByOrders: jest.fn(async () => [
+        { id: ORDER_ITEM_ID, orderId: ORDER_ID, itemId: ITEM_MANUFACTURED, itemName: 'Produto A', isManufactured: true, domain: 'PRODUCT', quantity: 1 },
+        { id: ORDER_ITEM_ID_2, orderId: ORDER_ID, itemId: ITEM_PURCHASABLE, itemName: 'Produto B', isManufactured: true, domain: 'PRODUCT', quantity: 1 },
+      ]),
+      deliveredQrsByOrder: jest.fn(async () => [
+        makeDeliveredQr({ qrValue: '100_1', orderItemId: ORDER_ITEM_ID }),
+        makeDeliveredQr({ qrValue: '100_2', orderItemId: ORDER_ITEM_ID_2 }),
+      ]),
+    });
+    const { service } = makeService({ repo });
+    const page1 = await service.transitProgress(CTX, ORDER_ID, 1, 1);
+    expect(page1.items).toHaveLength(1);
+    expect(page1.total).toBe(2);
+    expect(page1.totalPages).toBe(2);
+    expect(page1.summary).toBe('2 de 2 em transporte');
+    const page2 = await service.transitProgress(CTX, ORDER_ID, 2, 1);
+    expect(page2.items).toHaveLength(1);
+    expect(page2.items[0].orderItemId).toBe(ORDER_ITEM_ID_2);
+  });
+
+  it('404 for an unknown order', async () => {
+    const repo = makeExpeditionRepo({ getById: jest.fn(async () => null) });
+    const { service } = makeService({ repo });
+    const err = await service.transitProgress(CTX, ORDER_ID, 1, 20).catch((e) => e);
+    expect(err.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## RFC-0061 — M6 Expedição (Pedidos Myio) + §M4 demand resolution (P3, A4)

### What's in
- **`InventoryExpeditionRepository`** — `inv_expedition_orders/_order_items`, `inv_item_deliveries`, `inv_delivery_qrs`, `inv_shipments`, `inv_unit_products`, the two demand tables (idempotent `onConflictDoNothing` on the `expedition_order_item_id` UNIQUE), `inv_external_states` reads and the `inv_external_push_outbox` enqueue (DEC-6 — rows land in the SAME transaction as the domain write; the drain worker/HTTP client is M8).
- **`InventoryExpeditionService`** (M6 DTOs live here — `src/dto` frozen, same consolidation follow-up as M4/M5):
  - **CRUD**: project required, `delivery_date`, `is_replacement`, items by `inv_items` FK (DEC-5); PATCH edits the header anywhere but replaces items only while `PENDENTE` (`INV_EDIT_LOCKED_STATE` 409 — deliveries CASCADE with items); DELETE requires `confirmationToken` (428 without).
  - **State machine (DEC-4)**: `EXPEDITION_ORDER_TRANSITIONS` server-side — `INV_ILLEGAL_TRANSITION` / `INV_ALREADY_IN_STATE` 409 with `current` + `allowedTransitions`; reads expose `allowedTransitions` (S3). `/status` redirects `EM_TRANSITO` → `/ship` and `PERDIDO` → `/lost` so their mandatory payloads can never be skipped.
  - **Deliver (baixa)**: `Idempotency-Key` required (replayed per-process, M2/M4 pattern); quantity ≤ remaining; photo mandatory; manufactured item → **exactly 1 stockOnly QR per unit** (homologation registry + not already used, via the M5 repo reads in-tx; **box QRs expand to their units**, `INV_BOX_EMPTY` 422); writes delivery + delivery QRs + the `SAIDA` movement (reason **"Baixa para pedido Myio"**, `ALMOXARIFADO`) composing the **M2 repository seam** inside ONE transaction with the negative-stock guard (`INV_INSUFFICIENT_STOCK`); auto-status → `PRONTO_ENTREGA` when all items delivered, else `PRODUZINDO`, never regressing `ENTREGUE_CLIENTE`; push `expedicao`.
  - **Ship**: mandatory `address`/`shippingMethod` enum/`responsible`/`trackingCode`/`proofFileId` → `inv_shipments` + `EM_TRANSITO` + push `transporte`.
  - **ENTREGUE_CLIENTE** (via `/status` or found→Cliente): idempotent `inv_unit_products` — 1 per delivered unit, labels matched from delivery QRs, **"Projeto = Cliente"** (`client_name_snapshot` = project name; `customer_id` from the project, falling back to the order), status `PARADO`; existing labels skipped, never recreated; push `cliente`.
  - **Return / lost / found**: reason mandatory; note stamps `[Retornado para Expedição em <ISO>] motivo`, `[Mercadoria perdida em <ISO>] motivo`, `[Mercadoria encontrada em <ISO>] Setor: X`; found maps Cliente→`ENTREGUE_CLIENTE` (+unit products, requires project), Expedição→`PRONTO_ENTREGA`, Transporte→`EM_TRANSITO`, Estoque→`PRODUZINDO`; pushes `expedicao`/`perdido`/sector.
  - **Transit progress**: per delivered QR against `inv_external_states` (no mirror row = "em transporte" by default) → `"X de Y em transporte"` + per-item breakdown, paginated.
  - **Resolve-demand (§M4, A4)**: for expedition items with `ALMOXARIFADO` balance < qty — manufactured → `inv_production_demands`; purchasable → **automatic purchase order** via `InventoryPurchaseOrderService.create` (recipient/delivery point **"Estoque"**, deadline **CUSTOMIZADO = delivery_date**, note **"Demanda automática do pedido"**) + `inv_purchase_demands`. Idempotent per `expedition_order_item_id`: existing demands short-circuit to `ALREADY_RESOLVED`, and the UNIQUE is claimed **before** the PO is created so a lost race never duplicates the PO.
- **Controllers**: `expedition.controller.ts` — all §M6 routes real (were 501). `production.controller.ts` — ONLY the `POST /production/resolve-demand` defer swapped for the real handler (authorized exception); rest untouched.

### Tests (all local, no DB)
`jest tests/unit/inventory` → **29 suites, 424 tests, all passing**; `tsc --noEmit` clean; `eslint --max-warnings 0` clean on the touched files.
- `m6-state-machine.test.ts` — full transition map, 409s, redirects, `allowedTransitions` per status.
- `m6-deliver.test.ts` — QR/photo/qty validations, stockOnly (`INV_QR_NOT_IN_REGISTRY`/`WRONG_ITEM`/`ALREADY_USED`), box expansion + `INV_BOX_EMPTY`, insufficient stock, auto-status, push, idempotency (replay + no key-poisoning).
- `m6-ship-return-lost-found.test.ts` — mandatory ship fields + method enum, note-stamp formats, sector mapping, pushes.
- `m6-unit-products.test.ts` — Projeto=Cliente rule, idempotent labels (skip/created counts), customer fallback, transit-progress badge + pagination.
- `m6-resolve-demand.test.ts` — manufactured × purchasable × mixed, shortage ceil, automatic-PO payload, idempotency (existing + concurrent-claim), project guard.
- `m6-contract.test.ts` — real router + real auth, service mocked: 200/201 paths, `Idempotency-Key` 400, `confirmationToken` 428, Zod 400s, resolve-demand route, 401 unauthenticated.

### Superseded deferred-501 cases (for the wave-2 integration)
- **`tests/unit/controllers/inventory.contract.test.ts`** (frozen for this PR, NOT edited): the case **"GET /expedition-orders → 501"** now fails as expected (7/8 cases in that file still pass) — the route is real and covered by `m6-contract.test.ts`. **Retarget it at integration.**
- `tests/unit/inventory/m4-contract.test.ts`: the "resolve-demand → STILL 501" case covered exactly the route this PR was authorized to deliver — retargeted in place to the real route's DTO gate (400).

### Follow-ups
- Consolidate the M6 Zod DTOs from the service module into `src/dto/request/InventoryDTO.ts` (same standing follow-up as M4/M5).
- Durable idempotency storage (`inv_idempotency_keys`) — standing M2 follow-up; deliver uses the per-process replay cache meanwhile.
- RBAC role gating for manual transitions ("gated by role", §M6) — M10 wiring, same hook-style deferral as M3.
- M8 will drain the `inv_external_push_outbox` rows this module enqueues (deliver→expedicao, ship→transporte, entrega→cliente, return→expedicao, lost→perdido, found→setor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
