### PR TITLE
feat(inventory): M8 external sync — shadow pull + outbox drain (P2/P4)

### DIFF
--- a/src/controllers/inventory/external.controller.ts
+++ b/src/controllers/inventory/external.controller.ts
@@ -1,12 +1,60 @@
-import { Router } from 'express';
-import { defer } from './shared';
-import { PaginationQuerySchema } from '../../dto/request/InventoryDTO';
+import { Router, Request, Response, NextFunction } from 'express';
+import {
+  inventoryExternalSyncService,
+  ExternalStatesQuerySchema,
+  SyncRunQuerySchema,
+} from '../../services/inventory/InventoryExternalSyncService';
+import { sendSuccess } from '../../middleware/response';
 
-// M8 — Sync externo (P2 shadow → P4 live)
+// M8 — Sync externo (P2 shadow → P4 live). Real routes (RFC-0061 §M8):
+// the mirror listing, the sync status (lease + run report + outbox counters)
+// and the manual pull trigger. The trigger respects the persisted
+// single-flight lease (held lease → 409 CONFLICT) and the J4 shadow gate:
+// ?live=true is only accepted when env INV_SYNC_LIVE=true; without it the run
+// computes and logs the corrections it would make. Auth is the standing
+// inventory:read/inventory:write hybrid gate mounted in app.ts (DEC-7 — no
+// public anon endpoint; finer admin/M2M role gating arrives with M10, same as
+// the sibling modules).
 const router = Router();
 
-router.get('/external/states', defer('M8', 'P2', (req) => { PaginationQuerySchema.parse(req.query); }));
-router.get('/external/sync/status', defer('M8', 'P2'));
-router.post('/external/sync/run', defer('M8', 'P4'));
+// GET /external/states — paginated platform mirror (filters: location, status,
+// q = substring on code).
+router.get('/external/states', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = ExternalStatesQuerySchema.parse(req.query);
+    const data = await inventoryExternalSyncService.listStates(tenantId, query);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /external/sync/status — inv_external_sync_state (lease, last run report)
+// + outbox counters + shadow/live mode.
+router.get('/external/sync/status', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const data = await inventoryExternalSyncService.getStatus(tenantId);
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /external/sync/run — one pull execution, respecting the lease (409 when
+// held). 503 when the external client is not configured; 400 on ?live=true
+// without INV_SYNC_LIVE=true.
+router.post('/external/sync/run', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { tenantId, requestId } = req.context;
+    const query = SyncRunQuerySchema.parse(req.query);
+    const live = query.live === undefined ? undefined : query.live === 'true';
+    const data = await inventoryExternalSyncService.runPull(tenantId, { live });
+    sendSuccess(res, data, 200, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/src/controllers/inventory/homologation.controller.ts
+++ b/src/controllers/inventory/homologation.controller.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { defer, requireUuid, requireIdempotencyKey } from './shared';
+import { requireUuid, requireIdempotencyKey } from './shared';
 import { QrValidateSchema } from '../../dto/request/InventoryDTO';
 import {
   inventoryHomologationService,
@@ -8,6 +8,10 @@ import {
   HomologationListQuerySchema,
 } from '../../services/inventory/InventoryHomologationService';
 import { inventoryQrService } from '../../services/inventory/InventoryQrService';
+import {
+  inventoryExternalSyncService,
+  GenerateQrSchema,
+} from '../../services/inventory/InventoryExternalSyncService';
 import { sendSuccess, sendCreated } from '../../middleware/response';
 
 // M5 — Homologação & QR (P2). Real routes (RFC-0061 §M5):
@@ -15,9 +19,9 @@ import { sendSuccess, sendCreated } from '../../middleware/response';
 // box×unit uniqueness) and finish with an ENTRADA into ALMOXARIFADO; box ops
 // re-shuffle units between boxes; /qr/validate (S2) gives per-code verdicts
 // for handheld scanners; /qr/trace/:code (S5) returns the current-state
-// header + normalized timeline. POST /qr/generate stays deferred: it
-// delegates QR generation to the external platform, whose client ships with
-// M8 (P4) — v1 keeps external-only generation (source parity).
+// header + normalized timeline; /qr/generate delegates QR generation to the
+// external platform through the M8 client — v1 keeps external-only
+// generation (source parity).
 const router = Router();
 
 // GET /homologations — paginated listing (optional itemId/releaseId filters).
@@ -85,9 +89,20 @@ router.post('/homologations/units/:id/remove-from-box', async (req: Request, res
   }
 });
 
-// POST /qr/generate — delegates to the external platform (M8 client, P4).
-// v1 keeps generation external-only (source parity — RFC Unresolved q. 3).
-router.post('/qr/generate', defer('M5 /qr/generate (external platform client — M8)', 'P4'));
+// POST /qr/generate — delegates to the external platform (M8 client): POST
+// /api/public/products {product_type, location:'estoque', status:'parado'} →
+// {code, qrUrl}. v1 keeps generation external-only (source parity — RFC
+// Unresolved q. 3); 503 INV_EXTERNAL_NOT_CONFIGURED without the client env.
+router.post('/qr/generate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { requestId } = req.context;
+    const dto = GenerateQrSchema.parse(req.body ?? {});
+    const data = await inventoryExternalSyncService.generateQr(dto);
+    sendCreated(res, data, requestId);
+  } catch (err) {
+    next(err);
+  }
+});
 
 // GET /qr/trace/:code — S5 traceability. `:code` accepts the bare code or the
 // URL-encoded full https://produto.myio.com.br/<code> URL.

--- a/src/repositories/inventory/InventoryExternalRepository.ts
+++ b/src/repositories/inventory/InventoryExternalRepository.ts
@@ -1,0 +1,473 @@
+// =============================================================================
+// RFC-0061 M8 — External sync repository (data access only).
+//
+// Owns `inv_external_states` (platform mirror), `inv_external_sync_state`
+// (per-tenant single-flight lease + run report) and `inv_external_push_outbox`
+// (DEC-6 transactional outbox), plus the M8-specific batch reads over sibling
+// tables (unit products by label, projects by name, technician dispatches by
+// QR, open damaged reports, in-transit orders). All writes accept an optional
+// executor so the sync/outbox services compose them inside one transaction
+// (same seam as InventoryStockRepository).
+//
+// Outbox drain (DEC-6/W3): `claimOutboxBatchQuery` is the raw claim —
+// `FOR UPDATE SKIP LOCKED` (deploy-safe under side-by-side instances) with
+// per-QR FIFO: a row is eligible only if NO older live row shares any of its
+// `qr_codes` (array overlap `&&`). "Live" = status PENDING/FAILED with
+// attempts < max; a dead-lettered row (attempts exhausted) neither drains nor
+// blocks — the pull-sync reconciliation is the safety net for its QRs, and a
+// younger push for the same QR carries newer state anyway.
+// =============================================================================
+
+import { and, asc, desc, eq, ilike, inArray, notInArray, or, sql, SQL } from 'drizzle-orm';
+import { db, schema } from '../../infrastructure/database/drizzle/db';
+
+const {
+  invExternalStates,
+  invExternalSyncState,
+  invExternalPushOutbox,
+  invUnitProducts,
+  invProjects,
+  invStockMovements,
+  invMovementQrs,
+  invDamagedItems,
+  invExpeditionOrders,
+} = schema;
+
+// -----------------------------------------------------------------------------
+// Transaction typing (same derivation as InventoryStockRepository)
+// -----------------------------------------------------------------------------
+
+/** The Drizzle transaction client passed to `db.transaction(async (tx) => …)`. */
+export type ExternalTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/** Either the root `db` client or an in-flight transaction. */
+export type ExternalDbClient = typeof db | ExternalTx;
+
+// -----------------------------------------------------------------------------
+// Row & input types
+// -----------------------------------------------------------------------------
+
+export type InvExternalStateRow = typeof invExternalStates.$inferSelect;
+export type InvExternalSyncStateRow = typeof invExternalSyncState.$inferSelect;
+export type InvExternalPushOutboxRow = typeof invExternalPushOutbox.$inferSelect;
+export type InvUnitProductRow = typeof invUnitProducts.$inferSelect;
+export type InvProjectRow = typeof invProjects.$inferSelect;
+export type InvDamagedItemRow = typeof invDamagedItems.$inferSelect;
+export type InvExpeditionOrderRow = typeof invExpeditionOrders.$inferSelect;
+
+export interface ExternalStateUpsertInput {
+  tenantId: string;
+  code: string;
+  productType?: string | null;
+  location?: string | null;
+  status?: string | null;
+  technician?: string | null;
+  clientName?: string | null;
+  qrValue?: string | null;
+  itemId?: string | null;
+  homologationUnitId?: string | null;
+  /** Computed by the service: kept when nothing changed, bumped when it did. */
+  lastChangeAt?: Date | null;
+  payload?: unknown;
+}
+
+export interface ExternalStateListFilters {
+  page: number;
+  pageSize: number;
+  location?: string;
+  status?: string;
+  /** Substring match on code (ILIKE). */
+  q?: string;
+}
+
+export interface SyncRunReportInput {
+  status: 'OK' | 'PARCIAL' | 'ERRO';
+  /** JSON run report (shadow corrections land here too — see the service). */
+  message: string;
+  totalItems: number;
+}
+
+export interface OutboxCounters {
+  pending: number;
+  retryable: number;
+  dead: number;
+  done: number;
+}
+
+/** One technician dispatch linked to a QR (reconciliation input). */
+export interface DispatchByQrRow {
+  movementId: string;
+  itemId: string;
+  technician: string;
+  quantity: string;
+  movedQuantity: number;
+  qrValue: string;
+  createdAt: Date;
+}
+
+/** Default ceiling before a row is dead-lettered (INV_OUTBOX_MAX_ATTEMPTS). */
+export const OUTBOX_MAX_ATTEMPTS = 6;
+
+export class InventoryExternalRepository {
+  // ---------------------------------------------------------------------------
+  // Transaction boundary
+  // ---------------------------------------------------------------------------
+
+  async withTransaction<T>(fn: (tx: ExternalTx) => Promise<T>): Promise<T> {
+    return db.transaction(fn);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mirror — inv_external_states
+  // ---------------------------------------------------------------------------
+
+  async listStates(
+    tenantId: string,
+    filters: ExternalStateListFilters,
+    client: ExternalDbClient = db,
+  ): Promise<{ rows: InvExternalStateRow[]; total: number }> {
+    const conditions: (SQL | undefined)[] = [eq(invExternalStates.tenantId, tenantId)];
+    if (filters.location) conditions.push(eq(invExternalStates.location, filters.location));
+    if (filters.status) conditions.push(eq(invExternalStates.status, filters.status));
+    if (filters.q) conditions.push(ilike(invExternalStates.code, `%${filters.q}%`));
+    const where = and(...conditions);
+
+    const rows = await client
+      .select()
+      .from(invExternalStates)
+      .where(where)
+      .orderBy(asc(invExternalStates.code))
+      .limit(filters.pageSize)
+      .offset((filters.page - 1) * filters.pageSize);
+    const [count] = await client
+      .select({ total: sql<number>`count(*)::int` })
+      .from(invExternalStates)
+      .where(where);
+    return { rows, total: count?.total ?? 0 };
+  }
+
+  /** Full mirror for one tenant (diff base for the pull worker; ≤ item cap). */
+  async allStates(tenantId: string, client: ExternalDbClient = db): Promise<InvExternalStateRow[]> {
+    return client.select().from(invExternalStates).where(eq(invExternalStates.tenantId, tenantId));
+  }
+
+  /** Upsert one mirror row (onConflict tenant+code; raw payload kept). */
+  async upsertState(input: ExternalStateUpsertInput, client: ExternalDbClient = db): Promise<InvExternalStateRow> {
+    const values = {
+      tenantId: input.tenantId,
+      code: input.code,
+      productType: input.productType ?? null,
+      location: input.location ?? null,
+      status: input.status ?? null,
+      technician: input.technician ?? null,
+      clientName: input.clientName ?? null,
+      qrValue: input.qrValue ?? null,
+      itemId: input.itemId ?? null,
+      homologationUnitId: input.homologationUnitId ?? null,
+      lastChangeAt: input.lastChangeAt ?? null,
+      payload: input.payload ?? null,
+      updatedAt: new Date(),
+    };
+    const [row] = await client
+      .insert(invExternalStates)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [invExternalStates.tenantId, invExternalStates.code],
+        set: {
+          productType: values.productType,
+          location: values.location,
+          status: values.status,
+          technician: values.technician,
+          clientName: values.clientName,
+          qrValue: values.qrValue,
+          itemId: values.itemId,
+          homologationUnitId: values.homologationUnitId,
+          lastChangeAt: values.lastChangeAt,
+          payload: values.payload,
+          updatedAt: values.updatedAt,
+        },
+      })
+      .returning();
+    return row;
+  }
+
+  /** Golden rule cleanup: drop mirror rows whose code is no longer eligible. */
+  async deleteStatesNotIn(tenantId: string, keepCodes: string[], client: ExternalDbClient = db): Promise<number> {
+    const conditions: (SQL | undefined)[] = [eq(invExternalStates.tenantId, tenantId)];
+    if (keepCodes.length > 0) conditions.push(notInArray(invExternalStates.code, keepCodes));
+    const rows = await client
+      .delete(invExternalStates)
+      .where(and(...conditions))
+      .returning({ id: invExternalStates.id });
+    return rows.length;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sync state — inv_external_sync_state (single-flight lease, §M8)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Atomic lease claim: one UPSERT that only takes the lease when it is free
+   * or expired (`setWhere`). Returns the row when claimed, null when another
+   * runner holds it — the persisted single-flight the RFC requires.
+   */
+  async claimLease(
+    tenantId: string,
+    leaseMs: number,
+    client: ExternalDbClient = db,
+  ): Promise<InvExternalSyncStateRow | null> {
+    const leaseUntil = new Date(Date.now() + leaseMs);
+    const [row] = await client
+      .insert(invExternalSyncState)
+      .values({ tenantId, leaseUntil })
+      .onConflictDoUpdate({
+        target: invExternalSyncState.tenantId,
+        set: { leaseUntil },
+        setWhere: sql`${invExternalSyncState.leaseUntil} IS NULL OR ${invExternalSyncState.leaseUntil} < now()`,
+      })
+      .returning();
+    return row ?? null;
+  }
+
+  /** Release the lease and persist the run report (`ok|parcial|erro`). */
+  async releaseLease(
+    tenantId: string,
+    report: SyncRunReportInput,
+    client: ExternalDbClient = db,
+  ): Promise<void> {
+    await client
+      .update(invExternalSyncState)
+      .set({
+        leaseUntil: null,
+        lastRunAt: new Date(),
+        lastStatus: report.status,
+        lastMessage: report.message,
+        totalItems: report.totalItems,
+      })
+      .where(eq(invExternalSyncState.tenantId, tenantId));
+  }
+
+  async getSyncState(tenantId: string, client: ExternalDbClient = db): Promise<InvExternalSyncStateRow | null> {
+    const [row] = await client
+      .select()
+      .from(invExternalSyncState)
+      .where(eq(invExternalSyncState.tenantId, tenantId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Outbox — inv_external_push_outbox (DEC-6 drain)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Raw claim query (public for SQL-shape tests): oldest-first batch of live
+   * rows due now, skipping any row that shares a QR with an OLDER live row
+   * (per-QR FIFO — W3), locked with FOR UPDATE SKIP LOCKED so overlapping
+   * instances never double-dispatch. Must run inside the drain transaction.
+   */
+  claimOutboxBatchQuery(limit: number, maxAttempts: number = OUTBOX_MAX_ATTEMPTS): SQL {
+    return sql`
+      SELECT o.*
+      FROM inv_external_push_outbox o
+      WHERE o.status IN ('PENDING','FAILED')
+        AND o.attempts < ${maxAttempts}
+        AND (o.next_attempt_at IS NULL OR o.next_attempt_at <= now())
+        AND NOT EXISTS (
+          SELECT 1 FROM inv_external_push_outbox older
+          WHERE older.tenant_id = o.tenant_id
+            AND older.status IN ('PENDING','FAILED')
+            AND older.attempts < ${maxAttempts}
+            AND older.qr_codes && o.qr_codes
+            AND (older.created_at < o.created_at
+                 OR (older.created_at = o.created_at AND older.id < o.id))
+        )
+      ORDER BY o.created_at ASC, o.id ASC
+      LIMIT ${limit}
+      FOR UPDATE OF o SKIP LOCKED
+    `;
+  }
+
+  /** Claim a drain batch (see claimOutboxBatchQuery). Call inside a tx. */
+  async claimOutboxBatch(
+    limit: number,
+    tx: ExternalTx,
+    maxAttempts: number = OUTBOX_MAX_ATTEMPTS,
+  ): Promise<InvExternalPushOutboxRow[]> {
+    const result = await tx.execute(this.claimOutboxBatchQuery(limit, maxAttempts));
+    const rows = result as unknown as Array<Record<string, unknown>>;
+    return rows.map((r) => ({
+      id: String(r.id),
+      tenantId: String(r.tenant_id),
+      qrCodes: (r.qr_codes ?? []) as string[],
+      location: (r.location ?? null) as string | null,
+      status: String(r.status),
+      technician: (r.technician ?? null) as string | null,
+      clientName: (r.client_name ?? null) as string | null,
+      attempts: Number(r.attempts ?? 0),
+      nextAttemptAt: (r.next_attempt_at ?? null) as Date | null,
+      lastError: (r.last_error ?? null) as string | null,
+      dispatchedAt: (r.dispatched_at ?? null) as Date | null,
+      createdAt: r.created_at as Date,
+    }));
+  }
+
+  async markOutboxDispatched(ids: string[], client: ExternalDbClient = db): Promise<void> {
+    if (ids.length === 0) return;
+    await client
+      .update(invExternalPushOutbox)
+      .set({ status: 'DONE', dispatchedAt: new Date(), lastError: null })
+      .where(inArray(invExternalPushOutbox.id, ids));
+  }
+
+  /**
+   * Record one failed dispatch: attempts+1 and exponential backoff. When the
+   * attempts ceiling is reached the row keeps status FAILED with
+   * next_attempt_at NULL — dead-lettered: it stops draining AND stops blocking
+   * (see the header note), keeping only last_error for operators.
+   */
+  async markOutboxFailed(
+    id: string,
+    attempts: number,
+    nextAttemptAt: Date | null,
+    lastError: string,
+    client: ExternalDbClient = db,
+  ): Promise<void> {
+    await client
+      .update(invExternalPushOutbox)
+      .set({ status: 'FAILED', attempts, nextAttemptAt, lastError: lastError.slice(0, 2000) })
+      .where(eq(invExternalPushOutbox.id, id));
+  }
+
+  async outboxCounters(
+    tenantId: string,
+    maxAttempts: number = OUTBOX_MAX_ATTEMPTS,
+    client: ExternalDbClient = db,
+  ): Promise<OutboxCounters> {
+    const [row] = await client
+      .select({
+        pending: sql<number>`count(*) FILTER (WHERE ${invExternalPushOutbox.status} = 'PENDING')::int`,
+        retryable: sql<number>`count(*) FILTER (WHERE ${invExternalPushOutbox.status} = 'FAILED' AND ${invExternalPushOutbox.attempts} < ${maxAttempts})::int`,
+        dead: sql<number>`count(*) FILTER (WHERE ${invExternalPushOutbox.status} = 'FAILED' AND ${invExternalPushOutbox.attempts} >= ${maxAttempts})::int`,
+        done: sql<number>`count(*) FILTER (WHERE ${invExternalPushOutbox.status} = 'DONE')::int`,
+      })
+      .from(invExternalPushOutbox)
+      .where(eq(invExternalPushOutbox.tenantId, tenantId));
+    return row ?? { pending: 0, retryable: 0, dead: 0, done: 0 };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Batch reads over sibling tables (M8-only; writes stay in the owner repos)
+  // ---------------------------------------------------------------------------
+
+  /** Unit products holding any of the labels (QR spellings — bare or URL). */
+  async unitProductsByLabels(
+    tenantId: string,
+    labels: string[],
+    client: ExternalDbClient = db,
+  ): Promise<InvUnitProductRow[]> {
+    if (labels.length === 0) return [];
+    return client
+      .select()
+      .from(invUnitProducts)
+      .where(and(eq(invUnitProducts.tenantId, tenantId), inArray(invUnitProducts.label, labels)));
+  }
+
+  /** Projects matched case-insensitively by name ("Projeto = Cliente" rule). */
+  async projectsByNamesInsensitive(
+    tenantId: string,
+    names: string[],
+    client: ExternalDbClient = db,
+  ): Promise<InvProjectRow[]> {
+    if (names.length === 0) return [];
+    const lowered = names.map((n) => n.toLowerCase());
+    return client
+      .select()
+      .from(invProjects)
+      .where(
+        and(
+          eq(invProjects.tenantId, tenantId),
+          inArray(sql`lower(${invProjects.name})`, lowered),
+        ),
+      );
+  }
+
+  /**
+   * Technician dispatches (SAIDA with a responsible) linked to any of the QR
+   * spellings, with the Σ already consumed — newest first so the service can
+   * take the latest dispatch per QR ("zera a lista do técnico" input).
+   */
+  async dispatchesByQrValues(
+    tenantId: string,
+    qrValues: string[],
+    client: ExternalDbClient = db,
+  ): Promise<DispatchByQrRow[]> {
+    if (qrValues.length === 0) return [];
+    const movedQuantityExpr = sql<number>`coalesce((
+      select sum(tm.quantity)::int
+      from inv_technician_moves tm
+      where tm.movement_id = ${invStockMovements.id}
+    ), 0)`;
+    const rows = await client
+      .select({
+        movementId: invStockMovements.id,
+        itemId: invStockMovements.itemId,
+        technician: invStockMovements.responsible,
+        quantity: invStockMovements.quantity,
+        movedQuantity: movedQuantityExpr,
+        qrValue: invMovementQrs.qrValue,
+        createdAt: invStockMovements.createdAt,
+      })
+      .from(invMovementQrs)
+      .innerJoin(invStockMovements, eq(invStockMovements.id, invMovementQrs.movementId))
+      .where(
+        and(
+          eq(invMovementQrs.tenantId, tenantId),
+          inArray(invMovementQrs.qrValue, qrValues),
+          eq(invStockMovements.type, 'SAIDA'),
+          sql`${invStockMovements.responsible} IS NOT NULL AND btrim(${invStockMovements.responsible}) <> ''`,
+        ),
+      )
+      .orderBy(desc(invStockMovements.createdAt), desc(invStockMovements.id));
+    return rows
+      .filter((r) => r.qrValue !== null)
+      .map((r) => ({ ...r, technician: r.technician as string, qrValue: r.qrValue as string }));
+  }
+
+  /** Open damage reports (status AVARIADO) — the service matches codes in
+   *  source_detail to enforce "one open row per code". */
+  async listOpenDamaged(tenantId: string, client: ExternalDbClient = db): Promise<InvDamagedItemRow[]> {
+    return client
+      .select()
+      .from(invDamagedItems)
+      .where(and(eq(invDamagedItems.tenantId, tenantId), eq(invDamagedItems.status, 'AVARIADO')));
+  }
+
+  /** Expedition orders currently EM_TRANSITO (auto-transition candidates). */
+  async ordersInTransit(tenantId: string, client: ExternalDbClient = db): Promise<InvExpeditionOrderRow[]> {
+    return client
+      .select()
+      .from(invExpeditionOrders)
+      .where(and(eq(invExpeditionOrders.tenantId, tenantId), eq(invExpeditionOrders.status, 'EM_TRANSITO')));
+  }
+
+  /** Mirror rows matching any spelling (code or qr_value) — transit checks. */
+  async statesByCodesOrQrs(
+    tenantId: string,
+    values: string[],
+    client: ExternalDbClient = db,
+  ): Promise<InvExternalStateRow[]> {
+    if (values.length === 0) return [];
+    return client
+      .select()
+      .from(invExternalStates)
+      .where(
+        and(
+          eq(invExternalStates.tenantId, tenantId),
+          or(inArray(invExternalStates.code, values), inArray(invExternalStates.qrValue, values)),
+        ),
+      );
+  }
+}
+
+export const inventoryExternalRepository = new InventoryExternalRepository();

--- a/src/services/inventory/ExternalPlatformClient.ts
+++ b/src/services/inventory/ExternalPlatformClient.ts
@@ -1,0 +1,247 @@
+// =============================================================================
+// RFC-0061 M8 — External platform HTTP client (produto.myio.com.br).
+//
+// The 3-endpoint public contract (Appendix A, kept as-is):
+//   GET   /api/public/products            → full product list
+//   POST  /api/public/products            → create product (QR generation)
+//   PATCH /api/public/products/:code      → update location/status/technician
+// Auth: `x-api-key` header.
+//
+// v1 configuration is process-wide via env (single Myio tenant):
+//   MYIO_PRODUCTS_API_BASE  (default: the Lovable project URL below)
+//   MYIO_PRODUCTS_API_KEY   (no default — client is "not configured" without it)
+//   MYIO_PRODUCTS_API_TIMEOUT_MS (default 15000)
+//
+// FOLLOW-UP (DEC-7): per-tenant configuration with the API key stored via the
+// RFC-0056 `secretEnvelope` pattern (customer-config), resolved per tenant at
+// worker start. The class already takes its config through the constructor so
+// the per-tenant resolver only needs to build one instance per enabled tenant;
+// the env-based `externalPlatformClientFromEnv()` then becomes the single
+// default-tenant fallback.
+//
+// NEVER call the real platform from tests — inject `fetchImpl` (or mock the
+// whole module) instead.
+// =============================================================================
+
+import { AppError } from '../../shared/errors/AppError';
+
+export const DEFAULT_PRODUCTS_API_BASE =
+  'https://project--efd53831-b793-40e3-a8ef-13627f3457db.lovable.app';
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** External product locations (source contract — Appendix A). */
+export const EXTERNAL_LOCATIONS = [
+  'estoque',
+  'expedicao',
+  'transporte',
+  'cliente',
+  'tecnico',
+  'perdido',
+  'avariado',
+] as const;
+export type ExternalLocation = (typeof EXTERNAL_LOCATIONS)[number];
+
+/** External product statuses (source contract). */
+export const EXTERNAL_STATUSES = ['instalado', 'parado'] as const;
+export type ExternalStatus = (typeof EXTERNAL_STATUSES)[number];
+
+/** One product as reported by the platform (tolerant shape — `raw` keeps all). */
+export interface ExternalProduct {
+  code: string;
+  productType: string | null;
+  location: string | null;
+  status: string | null;
+  technician: string | null;
+  clientName: string | null;
+  /** Platform-side change timestamp when provided (updated_at / last_change_at). */
+  changedAt: string | null;
+  /** The untouched platform payload (mirrored into inv_external_states.payload). */
+  raw: Record<string, unknown>;
+}
+
+export interface CreateExternalProductInput {
+  product_type: string;
+  location: ExternalLocation;
+  status: ExternalStatus;
+}
+
+export interface PatchExternalProductInput {
+  location?: string;
+  status?: string;
+  technician?: string | null;
+  client_name?: string | null;
+}
+
+export interface ExternalPlatformClientConfig {
+  baseUrl: string;
+  apiKey: string;
+  timeoutMs?: number;
+  /** Test seam — never let a test reach the real platform. */
+  fetchImpl?: typeof fetch;
+}
+
+/** 502 wrapper for any platform-side failure (HTTP error, timeout, bad JSON). */
+export class ExternalPlatformError extends AppError {
+  public readonly details?: Record<string, unknown>;
+
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('INV_EXTERNAL_PLATFORM_ERROR', message, 502);
+    this.details = details;
+  }
+}
+
+/** 503 — the external client has no API key configured (env or tenant config). */
+export function externalNotConfigured(): AppError {
+  return new AppError(
+    'INV_EXTERNAL_NOT_CONFIGURED',
+    'Plataforma externa não configurada: defina MYIO_PRODUCTS_API_KEY (e opcionalmente MYIO_PRODUCTS_API_BASE)',
+    503,
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Tolerant payload normalization
+// -----------------------------------------------------------------------------
+
+function asStringOrNull(v: unknown): string | null {
+  if (typeof v === 'string' && v.trim() !== '') return v;
+  if (typeof v === 'number') return String(v);
+  return null;
+}
+
+/** Normalize one raw platform record; null when it carries no usable code. */
+export function normalizeExternalProduct(raw: unknown): ExternalProduct | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const code = asStringOrNull(r.code ?? r.codigo);
+  if (!code) return null;
+  return {
+    code,
+    productType: asStringOrNull(r.product_type ?? r.productType ?? r.tipo),
+    location: asStringOrNull(r.location ?? r.localizacao)?.toLowerCase() ?? null,
+    status: asStringOrNull(r.status)?.toLowerCase() ?? null,
+    technician: asStringOrNull(r.technician ?? r.tecnico),
+    clientName: asStringOrNull(r.client_name ?? r.clientName ?? r.cliente),
+    changedAt: asStringOrNull(r.updated_at ?? r.last_change_at ?? r.updatedAt),
+    raw: r,
+  };
+}
+
+/** The list endpoint may answer a bare array or {data|products|items: [...]}. */
+export function extractProductArray(body: unknown): unknown[] {
+  if (Array.isArray(body)) return body;
+  if (body && typeof body === 'object') {
+    const b = body as Record<string, unknown>;
+    for (const key of ['data', 'products', 'items']) {
+      if (Array.isArray(b[key])) return b[key] as unknown[];
+    }
+  }
+  throw new ExternalPlatformError('Resposta inesperada da plataforma externa (lista de produtos)');
+}
+
+// -----------------------------------------------------------------------------
+// Client
+// -----------------------------------------------------------------------------
+
+export class ExternalPlatformClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: ExternalPlatformClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.apiKey = config.apiKey;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  /** GET /api/public/products — the full platform state (pull worker input). */
+  async listProducts(): Promise<ExternalProduct[]> {
+    const body = await this.request('GET', '/api/public/products');
+    return extractProductArray(body)
+      .map(normalizeExternalProduct)
+      .filter((p): p is ExternalProduct => p !== null);
+  }
+
+  /** POST /api/public/products — QR generation (source parity: external-only). */
+  async createProduct(input: CreateExternalProductInput): Promise<ExternalProduct> {
+    const body = await this.request('POST', '/api/public/products', input);
+    // Tolerate {data: {...}} envelopes on the create response too.
+    const record =
+      body && typeof body === 'object' && 'data' in (body as Record<string, unknown>)
+        ? (body as Record<string, unknown>).data
+        : body;
+    const product = normalizeExternalProduct(record);
+    if (!product) {
+      throw new ExternalPlatformError('Plataforma externa não retornou um code na criação do produto');
+    }
+    return product;
+  }
+
+  /** PATCH /api/public/products/:code — outbox drain target. */
+  async patchProduct(code: string, patch: PatchExternalProductInput): Promise<void> {
+    await this.request('PATCH', `/api/public/products/${encodeURIComponent(code)}`, patch);
+  }
+
+  private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers: {
+          'x-api-key': this.apiKey,
+          'content-type': 'application/json',
+          accept: 'application/json',
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new ExternalPlatformError(`Plataforma externa respondeu ${res.status} em ${method} ${path}`, {
+          status: res.status,
+          body: text.slice(0, 500),
+        });
+      }
+      if (res.status === 204) return undefined;
+      const text = await res.text();
+      if (text.trim() === '') return undefined;
+      try {
+        return JSON.parse(text) as unknown;
+      } catch {
+        throw new ExternalPlatformError(`Plataforma externa retornou JSON inválido em ${method} ${path}`);
+      }
+    } catch (err) {
+      if (err instanceof ExternalPlatformError) throw err;
+      if ((err as Error)?.name === 'AbortError') {
+        throw new ExternalPlatformError(`Timeout (${this.timeoutMs}ms) em ${method} ${path}`);
+      }
+      throw new ExternalPlatformError(
+        `Falha de rede em ${method} ${path}: ${(err as Error)?.message ?? String(err)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Env-based factory (v1 single-tenant; see DEC-7 follow-up in the header)
+// -----------------------------------------------------------------------------
+
+/** Whether the env carries enough config to talk to the platform. */
+export function isExternalPlatformConfigured(): boolean {
+  return !!(process.env.MYIO_PRODUCTS_API_KEY && process.env.MYIO_PRODUCTS_API_KEY.trim() !== '');
+}
+
+/** Build the client from env, or null when not configured (callers 503 / skip). */
+export function externalPlatformClientFromEnv(): ExternalPlatformClient | null {
+  if (!isExternalPlatformConfigured()) return null;
+  return new ExternalPlatformClient({
+    baseUrl: process.env.MYIO_PRODUCTS_API_BASE?.trim() || DEFAULT_PRODUCTS_API_BASE,
+    apiKey: process.env.MYIO_PRODUCTS_API_KEY as string,
+    timeoutMs: Number(process.env.MYIO_PRODUCTS_API_TIMEOUT_MS ?? DEFAULT_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS,
+  });
+}

--- a/src/services/inventory/InventoryExternalSyncService.ts
+++ b/src/services/inventory/InventoryExternalSyncService.ts
@@ -1,0 +1,1190 @@
+// =============================================================================
+// RFC-0061 M8 — External pull sync (source semantics preserved, §M8).
+//
+// One run =
+//   1. single-flight LEASE (3 min) persisted in inv_external_sync_state —
+//      an atomic upsert claim; a held lease → ConflictError (409 on the manual
+//      trigger, silent skip on the cron). 1000-item cap per execution.
+//   2. GET the full platform list. GOLDEN RULE: only codes whose QR exists in
+//      inv_qr_registry / inv_homologation_units are considered; everything
+//      else is ignored (counted). Mirror rows whose code is no longer eligible
+//      are deleted (orphans).
+//   3. BOX-IS-MASTER (2 passes): pass 1 — a state reported for a BOX QR
+//      propagates to every unit inside the box; pass 2 — a unit reported at
+//      the client (location `cliente` or status `instalado`) "leaves the box":
+//      it becomes its own box_size=1 homologation (M5 repos), an emptied box
+//      is deleted and its box-QR identity released.
+//   4. Mirror upsert into inv_external_states (raw payload kept;
+//      last_change_at only bumped when the observable state changed).
+//   5. LEDGER RECONCILIATION — auto-corrections with an app-level guard:
+//      product in the field but its QR still "in stock" (latest ledger event
+//      is an entry) ⇒ SAIDA of 1un (responsible = technician when the platform
+//      says `tecnico`; skipped with a problem when the balance would go
+//      negative); back to `estoque` while the ledger says exited ⇒ compensating
+//      ENTRADA with the QR re-linked to the new movement (so the next run
+//      doesn't undo it). A QR that left a technician's custody also consumes
+//      the open dispatch via inv_technician_moves ("zera a lista do técnico").
+//   6. Order auto-transition: EM_TRANSITO orders whose delivered QRs ALL read
+//      `cliente` ⇒ ENTREGUE_CLIENTE + unit-product vínculo (runs BEFORE the
+//      generic client upsert so those units keep the expedition link).
+//   7. `cliente` ⇒ upsert inv_unit_products (INSTALADO/PARADO; client matched
+//      to inv_projects case-insensitively — "Projeto = Cliente"); a unit that
+//      left the client ⇒ moved_to per the location map.
+//   8. `avariado` ⇒ inv_damaged_items (at most ONE open report per code).
+//   9. Run report {ok, total, ignored, changed, corrections, problems[]}
+//      persisted in inv_external_sync_state (status OK|PARCIAL|ERRO).
+//
+// SHADOW MODE (J4 — the default): steps 1–4 and 9 always run for real (the
+// mirror is observability, not state); steps 5–8 are COMPUTED AND LOGGED ONLY
+// — each would-be correction lands in the run report (persisted as JSON in
+// inv_external_sync_state.last_message — the "simple choice": no extra log
+// table; weeks of shadow diffs live in the report history + stdout) and is
+// NOT applied. Real writes require env INV_SYNC_LIVE=true; the manual trigger
+// additionally accepts ?live=true only when that env is set.
+//
+// Drizzle gotcha: DrizzleQueryError wraps the real SQLSTATE/message in
+// `err.cause` — `errMessage()` unwraps it before recording problems.
+// =============================================================================
+
+import { z } from 'zod';
+import {
+  InventoryExternalRepository,
+  inventoryExternalRepository,
+  InvExternalStateRow,
+  InvExternalSyncStateRow,
+  OutboxCounters,
+  ExternalStateListFilters,
+  DispatchByQrRow,
+  InvProjectRow,
+  InvUnitProductRow,
+} from '../../repositories/inventory/InventoryExternalRepository';
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+  InvQrRegistryRow,
+  UnitWithHomologationRow,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import {
+  InventoryStockRepository,
+  inventoryStockRepository,
+} from '../../repositories/inventory/InventoryStockRepository';
+import {
+  InventoryFieldRepository,
+  inventoryFieldRepository,
+} from '../../repositories/inventory/InventoryFieldRepository';
+import {
+  InventoryExpeditionRepository,
+  inventoryExpeditionRepository,
+} from '../../repositories/inventory/InventoryExpeditionRepository';
+import {
+  ExternalPlatformClient,
+  ExternalProduct,
+  externalPlatformClientFromEnv,
+  externalNotConfigured,
+} from './ExternalPlatformClient';
+import { normalizeQrInput } from './InventoryQrService';
+import { QR_BASE_URL } from './InventoryHomologationService';
+import { ConflictError, ValidationError } from '../../shared/errors/AppError';
+import type { InvPaginatedResponse } from '../../dto/response/InventoryResponseDTO';
+
+// -----------------------------------------------------------------------------
+// Tuning
+// -----------------------------------------------------------------------------
+
+export const SYNC_LEASE_MS = 3 * 60_000; // single-flight lease (§M8)
+export const SYNC_ITEM_CAP = 1000; // per-execution cap (§M8)
+/** Ledger corrections act on the warehouse (homologation entry location). */
+export const SYNC_STOCK_LOCATION = 'ALMOXARIFADO';
+/** Corrections kept verbatim in the persisted report (the rest is counted). */
+const REPORT_CORRECTIONS_CAP = 200;
+
+const EXIT_TYPES = new Set(['SAIDA', 'TRANSFERENCIA_OUT']);
+
+/** external location → inv_unit_products.moved_to / technician destination. */
+const LOCATION_TO_MOVED_TO: Record<string, string> = {
+  tecnico: 'TECNICO',
+  estoque: 'ALMOXARIFADO',
+  perdido: 'PERDIDO',
+  avariado: 'AVARIADO',
+};
+const LOCATION_TO_TECH_DESTINATION: Record<string, string> = {
+  cliente: 'UNIDADE',
+  estoque: 'ALMOXARIFADO',
+  perdido: 'PERDIDO',
+  avariado: 'AVARIADO',
+};
+
+/** A QR code embedded in free text (damage dedup — same regex as M7). */
+const EMBEDDED_QR_REGEX = /\d+(?:_\d+)+/;
+
+export function isSyncLiveEnabled(): boolean {
+  return process.env.INV_SYNC_LIVE === 'true';
+}
+
+// -----------------------------------------------------------------------------
+// Request DTOs (M8 — finalized at implementation time; src/dto frozen for this
+// PR, same module-boundary note as M5/M7)
+// -----------------------------------------------------------------------------
+
+export const ExternalStatesQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).default(20),
+  location: z.string().min(1).max(50).optional(),
+  status: z.string().min(1).max(50).optional(),
+  q: z.string().min(1).max(100).optional(),
+});
+export type ExternalStatesQuery = z.infer<typeof ExternalStatesQuerySchema>;
+
+export const SyncRunQuerySchema = z.object({
+  live: z.enum(['true', 'false']).optional(),
+});
+export type SyncRunQuery = z.infer<typeof SyncRunQuerySchema>;
+
+export const GenerateQrSchema = z
+  .object({ productType: z.string().min(1).max(200) })
+  .strict();
+export type GenerateQrDTO = z.infer<typeof GenerateQrSchema>;
+
+// -----------------------------------------------------------------------------
+// Report shapes
+// -----------------------------------------------------------------------------
+
+export type SyncCorrectionKind =
+  | 'BOX_UNIT_LEFT_BOX'
+  | 'LEDGER_SAIDA'
+  | 'LEDGER_ENTRADA'
+  | 'TECHNICIAN_MOVE'
+  | 'UNIT_CREATED'
+  | 'UNIT_STATUS'
+  | 'UNIT_MOVED_OUT'
+  | 'DAMAGED_REPORT'
+  | 'ORDER_DELIVERED';
+
+export interface SyncCorrection {
+  kind: SyncCorrectionKind;
+  code: string;
+  detail: string;
+  /** false in shadow mode — the correction was only computed and logged. */
+  applied: boolean;
+}
+
+export interface SyncRunReport {
+  ok: boolean;
+  live: boolean;
+  total: number;
+  ignored: number;
+  changed: number;
+  orphansDeleted: number;
+  corrections: SyncCorrection[];
+  problems: string[];
+}
+
+export interface ExternalSyncStatusResponse {
+  syncState: {
+    tenantId: string;
+    leaseUntil: string | null;
+    leaseActive: boolean;
+    lastRunAt: string | null;
+    lastStatus: string | null;
+    lastMessage: string | null;
+    totalItems: number | null;
+  } | null;
+  outbox: OutboxCounters;
+  mode: { live: boolean; shadow: boolean };
+}
+
+export interface InvExternalStateResponse {
+  id: string;
+  code: string;
+  productType: string | null;
+  location: string | null;
+  status: string | null;
+  technician: string | null;
+  clientName: string | null;
+  qrValue: string | null;
+  itemId: string | null;
+  homologationUnitId: string | null;
+  lastChangeAt: string | null;
+  updatedAt: string;
+}
+
+// -----------------------------------------------------------------------------
+// Repository seams (Pick — tests inject jest mocks)
+// -----------------------------------------------------------------------------
+
+export type IExternalSyncRepository = Pick<
+  InventoryExternalRepository,
+  | 'listStates'
+  | 'allStates'
+  | 'upsertState'
+  | 'deleteStatesNotIn'
+  | 'claimLease'
+  | 'releaseLease'
+  | 'getSyncState'
+  | 'outboxCounters'
+  | 'unitProductsByLabels'
+  | 'projectsByNamesInsensitive'
+  | 'dispatchesByQrValues'
+  | 'listOpenDamaged'
+  | 'ordersInTransit'
+>;
+
+export type IExternalHomologRepository = Pick<
+  InventoryHomologationRepository,
+  | 'withTransaction'
+  | 'findRegistryByValues'
+  | 'findUnitsByQrValues'
+  | 'findBoxesByQrValues'
+  | 'unitsByHomologationIds'
+  | 'insertHomologation'
+  | 'moveUnit'
+  | 'countUnits'
+  | 'deleteHomologation'
+  | 'deleteRegistryByValues'
+>;
+
+export type IExternalStockRepository = Pick<
+  InventoryStockRepository,
+  'withTransaction' | 'lockItem' | 'getBalance' | 'insertMovement' | 'insertMovementQrs' | 'latestQrEventTypes'
+>;
+
+export type IExternalFieldRepository = Pick<
+  InventoryFieldRepository,
+  'insertUnitProducts' | 'updateUnitStatus' | 'markUnitMoved' | 'insertTechnicianMove' | 'insertDamagedItem'
+>;
+
+export type IExternalExpeditionRepository = Pick<
+  InventoryExpeditionRepository,
+  'withTransaction' | 'deliveredQrsByOrder' | 'updateOrder' | 'existingUnitProductLabels' | 'insertUnitProducts' | 'getProject'
+>;
+
+export interface InventoryExternalSyncDeps {
+  repository?: IExternalSyncRepository;
+  homologRepository?: IExternalHomologRepository;
+  stockRepository?: IExternalStockRepository;
+  fieldRepository?: IExternalFieldRepository;
+  expeditionRepository?: IExternalExpeditionRepository;
+  /** Client provider — null means "not configured" (503 / cron skip). */
+  clientProvider?: () => ExternalPlatformClient | null;
+  now?: () => Date;
+}
+
+// -----------------------------------------------------------------------------
+// Internal working shape — one per eligible code after box propagation
+// -----------------------------------------------------------------------------
+
+interface EffectiveState {
+  /** Bare code (`\d+(_\d+)+` for units; box QRs keep their scanned value). */
+  code: string;
+  candidates: string[];
+  location: string | null;
+  status: string | null;
+  technician: string | null;
+  clientName: string | null;
+  productType: string | null;
+  changedAt: string | null;
+  payload: unknown;
+  registry: InvQrRegistryRow | null;
+  unit: UnitWithHomologationRow | null;
+  isBox: boolean;
+}
+
+/** Unwrap DrizzleQueryError — real SQLSTATE/message live in err.cause. */
+function errMessage(err: unknown): string {
+  const cause = (err as { cause?: unknown })?.cause;
+  if (cause instanceof Error && cause.message) return cause.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+function toIso(d: Date | null | undefined): string | null {
+  return d ? d.toISOString() : null;
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+export class InventoryExternalSyncService {
+  private repository: IExternalSyncRepository;
+  private homologRepository: IExternalHomologRepository;
+  private stockRepository: IExternalStockRepository;
+  private fieldRepository: IExternalFieldRepository;
+  private expeditionRepository: IExternalExpeditionRepository;
+  private clientProvider: () => ExternalPlatformClient | null;
+  private now: () => Date;
+
+  constructor(deps: InventoryExternalSyncDeps = {}) {
+    this.repository = deps.repository ?? inventoryExternalRepository;
+    this.homologRepository = deps.homologRepository ?? inventoryHomologationRepository;
+    this.stockRepository = deps.stockRepository ?? inventoryStockRepository;
+    this.fieldRepository = deps.fieldRepository ?? inventoryFieldRepository;
+    this.expeditionRepository = deps.expeditionRepository ?? inventoryExpeditionRepository;
+    this.clientProvider = deps.clientProvider ?? externalPlatformClientFromEnv;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read endpoints
+  // ---------------------------------------------------------------------------
+
+  async listStates(tenantId: string, query: ExternalStatesQuery): Promise<InvPaginatedResponse<InvExternalStateResponse>> {
+    const filters: ExternalStateListFilters = {
+      page: query.page,
+      pageSize: query.pageSize,
+      location: query.location,
+      status: query.status,
+      q: query.q,
+    };
+    const { rows, total } = await this.repository.listStates(tenantId, filters);
+    return {
+      items: rows.map((r) => this.toStateResponse(r)),
+      page: query.page,
+      pageSize: query.pageSize,
+      total,
+      totalPages: Math.ceil(total / query.pageSize),
+    };
+  }
+
+  async getStatus(tenantId: string): Promise<ExternalSyncStatusResponse> {
+    const [state, outbox] = await Promise.all([
+      this.repository.getSyncState(tenantId),
+      this.repository.outboxCounters(tenantId),
+    ]);
+    const live = isSyncLiveEnabled();
+    return {
+      syncState: state ? this.toSyncStateResponse(state) : null,
+      outbox,
+      mode: { live, shadow: !live },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // QR generation (POST /qr/generate — delegates to the platform, DEC-7)
+  // ---------------------------------------------------------------------------
+
+  async generateQr(dto: GenerateQrDTO): Promise<{ code: string; qrUrl: string }> {
+    const client = this.clientProvider();
+    if (!client) throw externalNotConfigured();
+    const product = await client.createProduct({
+      product_type: dto.productType,
+      location: 'estoque',
+      status: 'parado',
+    });
+    return { code: product.code, qrUrl: `${QR_BASE_URL}${product.code}` };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pull run
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One pull execution. `opts.live` (manual ?live=true) requires
+   * INV_SYNC_LIVE=true; without opts the mode follows the env (cron path).
+   * Throws ConflictError (409) when another runner holds the lease.
+   */
+  async runPull(tenantId: string, opts: { live?: boolean } = {}): Promise<SyncRunReport> {
+    const client = this.clientProvider();
+    if (!client) throw externalNotConfigured();
+
+    const liveEnv = isSyncLiveEnabled();
+    if (opts.live === true && !liveEnv) {
+      throw new ValidationError('live=true requer INV_SYNC_LIVE=true no ambiente (J4 — shadow first)');
+    }
+    const live = opts.live ?? liveEnv;
+
+    const lease = await this.repository.claimLease(tenantId, SYNC_LEASE_MS);
+    if (!lease) {
+      throw new ConflictError('Sincronização externa já em execução (lease ativo)');
+    }
+
+    const report: SyncRunReport = {
+      ok: true,
+      live,
+      total: 0,
+      ignored: 0,
+      changed: 0,
+      orphansDeleted: 0,
+      corrections: [],
+      problems: [],
+    };
+
+    try {
+      let products: ExternalProduct[];
+      try {
+        products = await client.listProducts();
+      } catch (err) {
+        report.ok = false;
+        report.problems.push(`Falha ao consultar a plataforma externa: ${errMessage(err)}`);
+        return report;
+      }
+
+      report.total = products.length;
+      if (products.length > SYNC_ITEM_CAP) {
+        report.problems.push(
+          `Plataforma retornou ${products.length} itens; processando apenas ${SYNC_ITEM_CAP} (cap por execução)`,
+        );
+        products = products.slice(0, SYNC_ITEM_CAP);
+      }
+
+      // Golden rule + box-is-master → the effective per-code state map.
+      const effective = await this.buildEffectiveStates(tenantId, products, report);
+
+      // Pass 2 of box-is-master: a unit at the client leaves its box.
+      await this.applyBoxExits(tenantId, effective, live, report);
+
+      // Mirror upsert (always applied — shadow included) + orphan cleanup.
+      await this.upsertMirror(tenantId, effective, report);
+
+      // Ledger reconciliation + technician zeroing (shadow-gated).
+      await this.reconcileLedger(tenantId, effective, live, report);
+
+      // Order auto-transition BEFORE the generic client upsert (keeps vínculo).
+      await this.autoDeliverOrders(tenantId, effective, live, report);
+
+      // Client unit products (upsert + moved-out) — shadow-gated.
+      await this.reconcileClientUnits(tenantId, effective, live, report);
+
+      // Damaged auto-report — shadow-gated.
+      await this.reportDamaged(tenantId, effective, live, report);
+
+      return report;
+    } catch (err) {
+      report.ok = false;
+      report.problems.push(`Erro inesperado no sync: ${errMessage(err)}`);
+      return report;
+    } finally {
+      await this.persistReport(tenantId, report);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 2/3a — golden rule + box propagation (pass 1)
+  // ---------------------------------------------------------------------------
+
+  private async buildEffectiveStates(
+    tenantId: string,
+    products: ExternalProduct[],
+    report: SyncRunReport,
+  ): Promise<Map<string, EffectiveState>> {
+    const allCandidates = new Set<string>();
+    const normalized = products.map((p) => {
+      const n = normalizeQrInput(p.code);
+      n.candidates.forEach((c) => allCandidates.add(c));
+      return { product: p, code: n.code, candidates: n.candidates };
+    });
+
+    const registryRows = await this.homologRepository.findRegistryByValues(tenantId, [...allCandidates]);
+    const registryByValue = new Map(registryRows.map((r) => [r.qrValue, r]));
+
+    const unitRows = await this.homologRepository.findUnitsByQrValues(tenantId, [...allCandidates]);
+    const unitByValue = new Map(unitRows.map((u) => [u.unit.qrValue, u]));
+
+    const effective = new Map<string, EffectiveState>();
+
+    for (const { product, code, candidates } of normalized) {
+      const registry = candidates.map((c) => registryByValue.get(c)).find((r) => r) ?? null;
+      const unit = candidates.map((c) => unitByValue.get(c)).find((u) => u) ?? null;
+      if (!registry && !unit) {
+        // GOLDEN RULE: not homologated in GCDR — ignored.
+        report.ignored += 1;
+        continue;
+      }
+      effective.set(code, {
+        code,
+        candidates,
+        location: product.location,
+        status: product.status,
+        technician: product.technician,
+        clientName: product.clientName,
+        productType: product.productType,
+        changedAt: product.changedAt,
+        payload: product.raw,
+        registry,
+        unit,
+        isBox: registry?.kind === 'BOX',
+      });
+    }
+
+    // BOX-IS-MASTER pass 1: box state overwrites its units' state.
+    const boxStates = [...effective.values()].filter((s) => s.isBox);
+    if (boxStates.length > 0) {
+      const boxCandidates = boxStates.flatMap((s) => s.candidates);
+      const boxes = await this.homologRepository.findBoxesByQrValues(tenantId, boxCandidates);
+      const boxByValue = new Map(boxes.filter((b) => b.boxQr).map((b) => [b.boxQr as string, b]));
+      const boxIds = boxes.map((b) => b.id);
+      const units = await this.homologRepository.unitsByHomologationIds(tenantId, boxIds);
+      const unitsByHomologation = new Map<string, typeof units>();
+      for (const u of units) {
+        const list = unitsByHomologation.get(u.homologationId) ?? [];
+        list.push(u);
+        unitsByHomologation.set(u.homologationId, list);
+      }
+
+      for (const boxState of boxStates) {
+        const box = boxState.candidates.map((c) => boxByValue.get(c)).find((b) => b);
+        if (!box) continue;
+        for (const u of unitsByHomologation.get(box.id) ?? []) {
+          const n = normalizeQrInput(u.qrValue);
+          const existing = effective.get(n.code);
+          const propagated: EffectiveState = {
+            code: n.code,
+            candidates: existing?.candidates ?? n.candidates,
+            location: boxState.location,
+            status: boxState.status,
+            technician: boxState.technician,
+            clientName: boxState.clientName,
+            productType: existing?.productType ?? boxState.productType,
+            changedAt: boxState.changedAt,
+            payload: existing?.payload ?? boxState.payload,
+            registry: existing?.registry ?? null,
+            unit: existing?.unit ?? { unit: u, homologation: box },
+            isBox: false,
+          };
+          effective.set(n.code, propagated);
+        }
+      }
+    }
+
+    return effective;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 3b — box-is-master pass 2: unit at the client leaves its box
+  // ---------------------------------------------------------------------------
+
+  private async applyBoxExits(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    for (const state of effective.values()) {
+      if (state.isBox || !state.unit) continue;
+      const { homologation } = state.unit;
+      if (homologation.boxSize <= 1) continue;
+      const atClient = state.location === 'cliente' || state.status === 'instalado';
+      if (!atClient) continue;
+
+      const correction: SyncCorrection = {
+        kind: 'BOX_UNIT_LEFT_BOX',
+        code: state.code,
+        detail: `Unidade em cliente/instalado sai da caixa ${homologation.boxQr ?? homologation.id} (avulsa box_size=1)`,
+        applied: false,
+      };
+      if (live) {
+        try {
+          await this.homologRepository.withTransaction(async (tx) => {
+            const solo = await this.homologRepository.insertHomologation(
+              {
+                tenantId,
+                itemId: homologation.itemId,
+                releaseId: homologation.releaseId,
+                boxSize: 1,
+                boxQr: null,
+                responsibleId: homologation.responsibleId,
+                notes: homologation.notes,
+                createdBy: null,
+              },
+              tx,
+            );
+            await this.homologRepository.moveUnit(tenantId, state.unit!.unit.id, solo.id, 1, tx);
+            const left = await this.homologRepository.countUnits(homologation.id, tx);
+            if (left === 0) {
+              await this.homologRepository.deleteHomologation(tenantId, homologation.id, tx);
+              if (homologation.boxQr) {
+                await this.homologRepository.deleteRegistryByValues(tenantId, [homologation.boxQr], tx);
+              }
+            }
+          });
+          correction.applied = true;
+        } catch (err) {
+          report.problems.push(`Saída da caixa falhou para ${state.code}: ${errMessage(err)}`);
+        }
+      }
+      report.corrections.push(correction);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 4 — mirror upsert + orphan cleanup (always applied, shadow included)
+  // ---------------------------------------------------------------------------
+
+  private async upsertMirror(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const existingRows = await this.repository.allStates(tenantId);
+    const existingByCode = new Map(existingRows.map((r) => [r.code, r]));
+
+    for (const state of effective.values()) {
+      const existing = existingByCode.get(state.code);
+      const changed =
+        !existing ||
+        existing.location !== state.location ||
+        existing.status !== state.status ||
+        existing.technician !== state.technician ||
+        existing.clientName !== state.clientName ||
+        existing.productType !== state.productType;
+      if (changed) report.changed += 1;
+
+      try {
+        await this.repository.upsertState({
+          tenantId,
+          code: state.code,
+          productType: state.productType,
+          location: state.location,
+          status: state.status,
+          technician: state.technician,
+          clientName: state.clientName,
+          qrValue: state.unit?.unit.qrValue ?? state.registry?.qrValue ?? state.code,
+          itemId: state.registry?.itemId ?? state.unit?.homologation.itemId ?? null,
+          homologationUnitId: state.unit?.unit.id ?? null,
+          // last_change_at only bumps when the observable state changed.
+          lastChangeAt: changed ? this.now() : existing?.lastChangeAt ?? null,
+          payload: state.payload,
+        });
+      } catch (err) {
+        report.problems.push(`Upsert do mirror falhou para ${state.code}: ${errMessage(err)}`);
+      }
+    }
+
+    try {
+      report.orphansDeleted = await this.repository.deleteStatesNotIn(tenantId, [...effective.keys()]);
+    } catch (err) {
+      report.problems.push(`Limpeza de órfãos do mirror falhou: ${errMessage(err)}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 5 — ledger reconciliation + technician zeroing (shadow-gated)
+  // ---------------------------------------------------------------------------
+
+  private async reconcileLedger(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const unitStates = [...effective.values()].filter((s) => !s.isBox);
+    if (unitStates.length === 0) return;
+
+    const allCandidates = unitStates.flatMap((s) => s.candidates);
+    const latestByQr = await this.stockRepository.latestQrEventTypes(tenantId, allCandidates);
+    const dispatches = await this.repository.dispatchesByQrValues(tenantId, allCandidates);
+    // Newest-first from the repo — first hit per QR wins.
+    const dispatchByQr = new Map<string, (typeof dispatches)[number]>();
+    for (const d of dispatches) {
+      if (!dispatchByQr.has(d.qrValue)) dispatchByQr.set(d.qrValue, d);
+    }
+
+    for (const state of unitStates) {
+      const latest = state.candidates.map((c) => latestByQr.get(c)).find((t) => t !== undefined);
+      if (latest === undefined) continue; // QR never touched the ledger — nothing to reconcile
+      const inStock = !EXIT_TYPES.has(latest);
+      const itemId = state.registry?.itemId ?? state.unit?.homologation.itemId ?? null;
+      const qrValue = state.unit?.unit.qrValue ?? state.registry?.qrValue ?? state.code;
+
+      if (state.location !== null && state.location !== 'estoque' && inStock) {
+        // In the field per the platform, still in stock per the ledger ⇒ SAIDA.
+        await this.applyLedgerExit(tenantId, state, itemId, qrValue, live, report);
+      } else if (state.location === 'estoque' && !inStock) {
+        // Back in stock per the platform, exited per the ledger ⇒ ENTRADA.
+        await this.applyLedgerReturn(tenantId, state, itemId, qrValue, live, report);
+      }
+
+      // Technician zeroing: the QR left the technician's custody.
+      await this.zeroTechnicianCustody(tenantId, state, dispatchByQr, live, report);
+    }
+  }
+
+  private async zeroTechnicianCustody(
+    tenantId: string,
+    state: EffectiveState,
+    dispatchByQr: Map<string, DispatchByQrRow>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    if (state.location === null || state.location === 'tecnico') return;
+    const dispatch = state.candidates.map((c) => dispatchByQr.get(c)).find((d) => d);
+    const destination = LOCATION_TO_TECH_DESTINATION[state.location];
+    if (!dispatch || !destination || Number(dispatch.quantity) - dispatch.movedQuantity <= 0) return;
+
+    const correction: SyncCorrection = {
+      kind: 'TECHNICIAN_MOVE',
+      code: state.code,
+      detail: `Zera custódia do técnico ${dispatch.technician} → ${destination} (1un)`,
+      applied: false,
+    };
+    if (live) {
+      try {
+        await this.fieldRepository.insertTechnicianMove({
+          tenantId,
+          movementId: dispatch.movementId,
+          itemId: dispatch.itemId,
+          technician: dispatch.technician,
+          destination,
+          quantity: 1,
+          notes: `Sincronização externa — ${state.code} em ${state.location}`,
+        });
+        correction.applied = true;
+      } catch (err) {
+        report.problems.push(`Baixa de custódia do técnico falhou para ${state.code}: ${errMessage(err)}`);
+      }
+    }
+    report.corrections.push(correction);
+  }
+
+  private async applyLedgerExit(
+    tenantId: string,
+    state: EffectiveState,
+    itemId: string | null,
+    qrValue: string,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    if (!itemId) {
+      report.problems.push(`Correção SAIDA impossível para ${state.code}: item desconhecido`);
+      return;
+    }
+    const correction: SyncCorrection = {
+      kind: 'LEDGER_SAIDA',
+      code: state.code,
+      detail: `SAIDA 1un de ${SYNC_STOCK_LOCATION} (plataforma reporta ${state.location})`,
+      applied: false,
+    };
+    if (live) {
+      try {
+        await this.stockRepository.withTransaction(async (tx) => {
+          await this.stockRepository.lockItem(tenantId, itemId, tx);
+          const balance = await this.stockRepository.getBalance(tenantId, itemId, SYNC_STOCK_LOCATION, tx);
+          if (Number(balance.balance) < 1) {
+            // App-level negative guard: never drive the ledger negative.
+            throw new Error(`saldo insuficiente (${balance.balance}) em ${SYNC_STOCK_LOCATION}`);
+          }
+          const movement = await this.stockRepository.insertMovement(
+            {
+              tenantId,
+              itemId,
+              location: SYNC_STOCK_LOCATION,
+              quantity: '1',
+              type: 'SAIDA',
+              reason: `Sincronização externa — ${state.code} em ${state.location}`,
+              responsible: state.location === 'tecnico' ? state.technician ?? null : null,
+            },
+            tx,
+          );
+          await this.stockRepository.insertMovementQrs(
+            tenantId,
+            movement.id,
+            [{ qrValue, homologationUnitId: state.unit?.unit.id }],
+            tx,
+          );
+        });
+        correction.applied = true;
+      } catch (err) {
+        report.problems.push(`Correção SAIDA falhou para ${state.code}: ${errMessage(err)}`);
+      }
+    }
+    report.corrections.push(correction);
+  }
+
+  private async applyLedgerReturn(
+    tenantId: string,
+    state: EffectiveState,
+    itemId: string | null,
+    qrValue: string,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    if (!itemId) {
+      report.problems.push(`Correção ENTRADA impossível para ${state.code}: item desconhecido`);
+      return;
+    }
+    const correction: SyncCorrection = {
+      kind: 'LEDGER_ENTRADA',
+      code: state.code,
+      detail: `ENTRADA de estorno 1un em ${SYNC_STOCK_LOCATION} (plataforma reporta estoque)`,
+      applied: false,
+    };
+    if (live) {
+      try {
+        await this.stockRepository.withTransaction(async (tx) => {
+          await this.stockRepository.lockItem(tenantId, itemId, tx);
+          const movement = await this.stockRepository.insertMovement(
+            {
+              tenantId,
+              itemId,
+              location: SYNC_STOCK_LOCATION,
+              quantity: '1',
+              type: 'ENTRADA',
+              reason: `Sincronização externa — retorno ao estoque (${state.code})`,
+            },
+            tx,
+          );
+          // Re-link the QR so the NEXT run sees it "in stock" (anti-loop).
+          await this.stockRepository.insertMovementQrs(
+            tenantId,
+            movement.id,
+            [{ qrValue, homologationUnitId: state.unit?.unit.id }],
+            tx,
+          );
+        });
+        correction.applied = true;
+      } catch (err) {
+        report.problems.push(`Correção ENTRADA falhou para ${state.code}: ${errMessage(err)}`);
+      }
+    }
+    report.corrections.push(correction);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 6 — EM_TRANSITO orders fully at the client ⇒ ENTREGUE_CLIENTE
+  // ---------------------------------------------------------------------------
+
+  private async autoDeliverOrders(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    let orders;
+    try {
+      orders = await this.repository.ordersInTransit(tenantId);
+    } catch (err) {
+      report.problems.push(`Consulta de pedidos em trânsito falhou: ${errMessage(err)}`);
+      return;
+    }
+
+    for (const order of orders) {
+      try {
+        const allQrs = await this.expeditionRepository.deliveredQrsByOrder(tenantId, order.id);
+        const qrs = allQrs
+          .filter((q) => q.qrValue !== null)
+          .map((q) => ({ qrValue: q.qrValue as string, itemId: q.itemId }));
+        if (qrs.length === 0) continue;
+        const allAtClient = qrs.every((q) => {
+          const state = effective.get(normalizeQrInput(q.qrValue).code);
+          return state?.location === 'cliente';
+        });
+        if (!allAtClient) continue;
+
+        const correction: SyncCorrection = {
+          kind: 'ORDER_DELIVERED',
+          code: order.id,
+          detail: `Pedido ${order.title ?? order.id}: todos os ${qrs.length} QRs em cliente ⇒ ENTREGUE_CLIENTE`,
+          applied: false,
+        };
+        if (live) {
+          await this.expeditionRepository.withTransaction(async (tx) => {
+            await this.expeditionRepository.updateOrder(tenantId, order.id, { status: 'ENTREGUE_CLIENTE' }, tx);
+            // Vínculo: one unit product per delivered QR (idempotent by label).
+            const project = order.projectId
+              ? await this.expeditionRepository.getProject(tenantId, order.projectId, tx)
+              : null;
+            const labels = [...new Set(qrs.map((q) => q.qrValue))];
+            const existing = await this.expeditionRepository.existingUnitProductLabels(tenantId, labels, tx);
+            const byLabel = new Map(qrs.map((q) => [q.qrValue, q]));
+            await this.expeditionRepository.insertUnitProducts(
+              labels
+                .filter((l) => !existing.has(l))
+                .map((label) => ({
+                  tenantId,
+                  itemId: byLabel.get(label)?.itemId ?? null,
+                  label,
+                  projectId: order.projectId,
+                  customerId: project?.customerId ?? order.customerId ?? null,
+                  clientNameSnapshot: project?.name ?? null,
+                  expeditionOrderId: order.id,
+                  createdBy: null,
+                })),
+              tx,
+            );
+          });
+          correction.applied = true;
+        }
+        report.corrections.push(correction);
+      } catch (err) {
+        report.problems.push(`Auto-entrega do pedido ${order.id} falhou: ${errMessage(err)}`);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 7 — client unit products (upsert + moved-out), shadow-gated
+  // ---------------------------------------------------------------------------
+
+  private async reconcileClientUnits(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const unitStates = [...effective.values()].filter((s) => !s.isBox);
+    if (unitStates.length === 0) return;
+
+    const allCandidates = unitStates.flatMap((s) => s.candidates);
+    const unitProducts = await this.repository.unitProductsByLabels(tenantId, allCandidates);
+    const unitByLabel = new Map(unitProducts.filter((u) => u.label).map((u) => [u.label as string, u]));
+
+    const clientNames = [
+      ...new Set(
+        unitStates
+          .filter((s) => s.location === 'cliente' && s.clientName)
+          .map((s) => (s.clientName as string).toLowerCase()),
+      ),
+    ];
+    const projects = await this.repository.projectsByNamesInsensitive(
+      tenantId,
+      clientNames,
+    );
+    const projectByName = new Map(projects.map((p) => [p.name.toLowerCase(), p]));
+
+    for (const state of unitStates) {
+      const existing = state.candidates.map((c) => unitByLabel.get(c)).find((u) => u) ?? null;
+      if (state.location === 'cliente') {
+        await this.upsertClientUnit(tenantId, state, existing, projectByName, live, report);
+      } else if (existing && existing.movedTo === null && state.location !== null) {
+        await this.markUnitLeftClient(tenantId, state, existing, live, report);
+      }
+    }
+  }
+
+  /** Platform says `cliente`: create the unit product or fix its status. */
+  private async upsertClientUnit(
+    tenantId: string,
+    state: EffectiveState,
+    existing: InvUnitProductRow | null,
+    projectByName: Map<string, InvProjectRow>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const targetStatus = state.status === 'instalado' ? 'INSTALADO' : 'PARADO';
+    const project = state.clientName ? projectByName.get(state.clientName.toLowerCase()) ?? null : null;
+    if (state.clientName && !project) {
+      report.problems.push(
+        `Projeto não encontrado para o cliente "${state.clientName}" (${state.code}) — unidade sem vínculo de projeto`,
+      );
+    }
+
+    if (!existing) {
+      await this.recordCorrection(
+        report,
+        {
+          kind: 'UNIT_CREATED',
+          code: state.code,
+          detail: `Cria unit product ${targetStatus} no cliente ${state.clientName ?? '?'} (projeto ${project?.name ?? '—'})`,
+          applied: false,
+        },
+        live,
+        () =>
+          this.fieldRepository
+            .insertUnitProducts([
+              {
+                tenantId,
+                itemId: state.registry?.itemId ?? state.unit?.homologation.itemId ?? null,
+                label: state.unit?.unit.qrValue ?? state.registry?.qrValue ?? state.code,
+                status: targetStatus,
+                projectId: project?.id ?? null,
+                customerId: project?.customerId ?? null,
+                clientNameSnapshot: state.clientName ?? project?.name ?? null,
+                notes: 'Criado pela sincronização externa',
+              },
+            ])
+            .then(() => undefined),
+        `Criação de unit product falhou para ${state.code}`,
+      );
+      return;
+    }
+
+    if (existing.movedTo === null && existing.status !== targetStatus) {
+      await this.recordCorrection(
+        report,
+        {
+          kind: 'UNIT_STATUS',
+          code: state.code,
+          detail: `Status ${existing.status} → ${targetStatus}`,
+          applied: false,
+        },
+        live,
+        () =>
+          this.fieldRepository
+            .updateUnitStatus(tenantId, existing.id, targetStatus, targetStatus === 'INSTALADO' ? this.now() : null)
+            .then(() => undefined),
+        `Atualização de status falhou para ${state.code}`,
+      );
+    }
+  }
+
+  /** Log the correction; apply it only in live mode (J4 shadow gate). */
+  private async recordCorrection(
+    report: SyncRunReport,
+    correction: SyncCorrection,
+    live: boolean,
+    apply: () => Promise<void>,
+    failurePrefix: string,
+  ): Promise<void> {
+    if (live) {
+      try {
+        await apply();
+        correction.applied = true;
+      } catch (err) {
+        report.problems.push(`${failurePrefix}: ${errMessage(err)}`);
+      }
+    }
+    report.corrections.push(correction);
+  }
+
+  /** Left the client per the platform ⇒ moved_to (tracking-only, §M7). */
+  private async markUnitLeftClient(
+    tenantId: string,
+    state: EffectiveState,
+    existing: InvUnitProductRow,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const movedTo = LOCATION_TO_MOVED_TO[state.location as string];
+    if (!movedTo) return; // expedicao/transporte: in-flight logistics, not a field move
+    const technicianSuffix = state.technician ? ` (técnico ${state.technician})` : '';
+    const correction: SyncCorrection = {
+      kind: 'UNIT_MOVED_OUT',
+      code: state.code,
+      detail: `Saiu do cliente ⇒ moved_to ${movedTo}${technicianSuffix}`,
+      applied: false,
+    };
+    if (live) {
+      try {
+        await this.fieldRepository.markUnitMoved(tenantId, existing.id, {
+          movedTo,
+          movedTechnician: state.technician ?? null,
+          movedAt: this.now(),
+          moveNotes: `Sincronização externa — ${state.code} em ${state.location}`,
+        });
+        correction.applied = true;
+      } catch (err) {
+        report.problems.push(`Baixa do cliente falhou para ${state.code}: ${errMessage(err)}`);
+      }
+    }
+    report.corrections.push(correction);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 8 — damaged auto-report (one open row per code), shadow-gated
+  // ---------------------------------------------------------------------------
+
+  private async reportDamaged(
+    tenantId: string,
+    effective: Map<string, EffectiveState>,
+    live: boolean,
+    report: SyncRunReport,
+  ): Promise<void> {
+    const damaged = [...effective.values()].filter((s) => !s.isBox && s.location === 'avariado');
+    if (damaged.length === 0) return;
+
+    let openCodes: Set<string>;
+    try {
+      const openRows = await this.repository.listOpenDamaged(tenantId);
+      openCodes = new Set(
+        openRows
+          .map((r) => EMBEDDED_QR_REGEX.exec(r.sourceDetail ?? '')?.[0])
+          .filter((c): c is string => !!c),
+      );
+    } catch (err) {
+      report.problems.push(`Consulta de avarias abertas falhou: ${errMessage(err)}`);
+      return;
+    }
+
+    for (const state of damaged) {
+      if (openCodes.has(state.code)) continue; // one open report per code
+      const correction: SyncCorrection = {
+        kind: 'DAMAGED_REPORT',
+        code: state.code,
+        detail: `Abre avaria (1un) reportada pela plataforma externa`,
+        applied: false,
+      };
+      if (live) {
+        try {
+          await this.fieldRepository.insertDamagedItem({
+            tenantId,
+            itemId: state.registry?.itemId ?? state.unit?.homologation.itemId ?? null,
+            productNameSnapshot: state.productType,
+            quantity: 1,
+            source: 'SYNC_EXTERNO',
+            sourceDetail: `QR ${state.code}`,
+            reason: 'Reportado avariado pela plataforma externa',
+          });
+          correction.applied = true;
+        } catch (err) {
+          report.problems.push(`Abertura de avaria falhou para ${state.code}: ${errMessage(err)}`);
+        }
+      }
+      report.corrections.push(correction);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Step 9 — persist the run report + release the lease
+  // ---------------------------------------------------------------------------
+
+  private async persistReport(tenantId: string, report: SyncRunReport): Promise<void> {
+    const status: 'OK' | 'PARCIAL' | 'ERRO' = !report.ok ? 'ERRO' : report.problems.length > 0 ? 'PARCIAL' : 'OK';
+    const persisted = {
+      ...report,
+      corrections: report.corrections.slice(0, REPORT_CORRECTIONS_CAP),
+      correctionsTotal: report.corrections.length,
+    };
+    // Shadow log: every would-be correction also goes to stdout for diffing.
+    if (!report.live && report.corrections.length > 0) {
+      // eslint-disable-next-line no-console -- J4 shadow-mode diff trail
+      console.info(`[inv-external-sync] SHADOW ${tenantId}: ${report.corrections.length} correção(ões) NÃO aplicadas`, {
+        corrections: persisted.corrections,
+      });
+    }
+    try {
+      await this.repository.releaseLease(tenantId, {
+        status,
+        message: JSON.stringify(persisted),
+        totalItems: report.total,
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console -- last resort: never swallow silently
+      console.error(`[inv-external-sync] falha ao liberar lease/persistir relatório: ${errMessage(err)}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Response mapping
+  // ---------------------------------------------------------------------------
+
+  private toStateResponse(row: InvExternalStateRow): InvExternalStateResponse {
+    return {
+      id: row.id,
+      code: row.code,
+      productType: row.productType,
+      location: row.location,
+      status: row.status,
+      technician: row.technician,
+      clientName: row.clientName,
+      qrValue: row.qrValue,
+      itemId: row.itemId,
+      homologationUnitId: row.homologationUnitId,
+      lastChangeAt: toIso(row.lastChangeAt),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  private toSyncStateResponse(row: InvExternalSyncStateRow): NonNullable<ExternalSyncStatusResponse['syncState']> {
+    const leaseUntil = row.leaseUntil ? new Date(row.leaseUntil) : null;
+    return {
+      tenantId: row.tenantId,
+      leaseUntil: toIso(leaseUntil),
+      leaseActive: !!leaseUntil && leaseUntil.getTime() > this.now().getTime(),
+      lastRunAt: toIso(row.lastRunAt),
+      lastStatus: row.lastStatus,
+      lastMessage: row.lastMessage,
+      totalItems: row.totalItems,
+    };
+  }
+}
+
+export const inventoryExternalSyncService = new InventoryExternalSyncService();

--- a/src/services/inventory/InventoryExternalWorkers.ts
+++ b/src/services/inventory/InventoryExternalWorkers.ts
@@ -1,0 +1,108 @@
+// =============================================================================
+// RFC-0061 M8 — background workers bootstrap (pull sync + outbox drain).
+//
+// NOT wired yet: app.ts is frozen for this module PR. The wave-3 integration
+// adds, next to the other subsystem starts in app.ts (`startRestoreSweep()`):
+//
+//   import { startInventoryExternalWorkers } from './services/inventory/InventoryExternalWorkers';
+//   ...
+//   try {
+//     startInventoryExternalWorkers();
+//   } catch (error) {
+//     console.error('Failed to start the inventory external-sync workers:', error);
+//   }
+//
+// Scheduling follows the codebase's standing pattern (setInterval + unref —
+// CentralRestoreSweep): node-cron is NOT a dependency of this repo, so the RFC's
+// "node-cron every 5 min" lands as an equivalent 5-min interval; swapping to
+// node-cron later is a one-liner once the dependency is approved.
+//
+// v1 tenant scope (DEC-7 follow-up = per-tenant config via secretEnvelope):
+// the workers only start when the env-based client is configured
+// (MYIO_PRODUCTS_API_KEY) and pull for the single default tenant
+// (INV_SYNC_TENANT_ID || DEFAULT_TENANT_ID || the seed default). The outbox
+// drain is tenant-agnostic — it claims rows for every tenant, all dispatched
+// through the same env-based client in v1.
+//
+// Shadow mode (J4): the pull runs with the env-resolved mode — writes only
+// when INV_SYNC_LIVE=true; otherwise corrections are computed and logged.
+// =============================================================================
+
+import { inventoryExternalSyncService } from './InventoryExternalSyncService';
+import { inventoryOutboxWorker } from './InventoryOutboxWorker';
+import { isExternalPlatformConfigured } from './ExternalPlatformClient';
+import { ConflictError } from '../../shared/errors/AppError';
+
+const PULL_INTERVAL_MS = Number(process.env.INV_SYNC_PULL_INTERVAL_MS ?? String(5 * 60_000)); // 5 min (§M8)
+const DRAIN_INTERVAL_MS = Number(process.env.INV_OUTBOX_DRAIN_INTERVAL_MS ?? String(30_000)); // 30 s
+
+function syncTenantId(): string {
+  return (
+    process.env.INV_SYNC_TENANT_ID ||
+    process.env.DEFAULT_TENANT_ID ||
+    '11111111-1111-1111-1111-111111111111'
+  );
+}
+
+let pullTimer: NodeJS.Timeout | null = null;
+let drainTimer: NodeJS.Timeout | null = null;
+
+async function pullTick(): Promise<void> {
+  try {
+    const report = await inventoryExternalSyncService.runPull(syncTenantId());
+    // eslint-disable-next-line no-console -- worker heartbeat
+    console.info(
+      `[inv-external-sync] pull ${report.live ? 'LIVE' : 'SHADOW'}: total=${report.total} ignored=${report.ignored} changed=${report.changed} corrections=${report.corrections.length} problems=${report.problems.length}`,
+    );
+  } catch (err) {
+    if (err instanceof ConflictError) return; // lease held elsewhere — single-flight working as designed
+    // eslint-disable-next-line no-console -- worker diagnostics
+    console.error('[inv-external-sync] pull tick failed:', err);
+  }
+}
+
+async function drainTick(): Promise<void> {
+  try {
+    const result = await inventoryOutboxWorker.drainOnce();
+    if (result.claimed > 0) {
+      // eslint-disable-next-line no-console -- worker heartbeat
+      console.info(
+        `[inv-outbox] drain: claimed=${result.claimed} dispatched=${result.dispatched} failed=${result.failed} dead=${result.dead}`,
+      );
+    }
+  } catch (err) {
+    // eslint-disable-next-line no-console -- worker diagnostics
+    console.error('[inv-outbox] drain tick failed:', err);
+  }
+}
+
+/**
+ * Start both M8 workers on the long-running server. Idempotent; no-op when the
+ * external platform client is not configured (MYIO_PRODUCTS_API_KEY unset).
+ */
+export function startInventoryExternalWorkers(): void {
+  if (!isExternalPlatformConfigured()) {
+    // eslint-disable-next-line no-console -- startup diagnostics
+    console.info('[inv-external-sync] MYIO_PRODUCTS_API_KEY não configurada — workers M8 desativados');
+    return;
+  }
+  if (!pullTimer) {
+    pullTimer = setInterval(() => void pullTick(), PULL_INTERVAL_MS);
+    pullTimer.unref?.(); // never keep the process alive for the worker alone
+  }
+  if (!drainTimer) {
+    drainTimer = setInterval(() => void drainTick(), DRAIN_INTERVAL_MS);
+    drainTimer.unref?.();
+  }
+}
+
+export function stopInventoryExternalWorkers(): void {
+  if (pullTimer) {
+    clearInterval(pullTimer);
+    pullTimer = null;
+  }
+  if (drainTimer) {
+    clearInterval(drainTimer);
+    drainTimer = null;
+  }
+}

--- a/src/services/inventory/InventoryOutboxWorker.ts
+++ b/src/services/inventory/InventoryOutboxWorker.ts
@@ -1,0 +1,179 @@
+// =============================================================================
+// RFC-0061 M8 — Push-outbox drain worker (DEC-6/W3).
+//
+// The domain services (M6 today; M7 install toggles are a standing wave-3
+// follow-up — no enqueue points landed with M7) enqueue
+// inv_external_push_outbox rows in the SAME transaction as the domain write.
+// This worker drains them:
+//
+//   - CLAIM: `SELECT … FOR UPDATE SKIP LOCKED` (InventoryExternalRepository.
+//     claimOutboxBatchQuery) — safe under side-by-side instances during
+//     Dokploy deploys — with per-QR FIFO: a row is only eligible when NO older
+//     live row shares any of its qr_codes, so a backoff on "tecnico" can never
+//     let a later "cliente" push overtake it.
+//   - DISPATCH: one PATCH /api/public/products/:code per code. Enqueue points
+//     already expand boxes into unit QRs (M6 resolves box scans to unit values
+//     before enqueueing), but the worker defensively re-expands any code that
+//     is a registered BOX QR via the M5 repos. The PATCH body always carries
+//     location/technician/client_name (nulls included, clearing stale values);
+//     the row's `status` column is the OUTBOX lifecycle (PENDING/FAILED/DONE),
+//     not the product status.
+//   - RESULT: full success → DONE + dispatched_at. Any failure → FAILED,
+//     attempts+1, exponential backoff (30s · 2^(attempts−1), capped 15 min).
+//     After OUTBOX_MAX_ATTEMPTS (6) the row is DEAD-LETTERED: next_attempt_at
+//     NULL, keeps last_error, stops draining AND stops blocking its QRs (the
+//     pull-sync reconciliation is the safety net; a younger push for the same
+//     QR carries newer state anyway).
+//
+// Rows stay locked while the PATCHes run (claim tx = drain tx) — accepted
+// trade-off: batches are small, the platform timeout is bounded, and SKIP
+// LOCKED means a concurrent drainer simply claims other rows.
+// =============================================================================
+
+import {
+  InventoryExternalRepository,
+  inventoryExternalRepository,
+  InvExternalPushOutboxRow,
+  OUTBOX_MAX_ATTEMPTS,
+} from '../../repositories/inventory/InventoryExternalRepository';
+import {
+  InventoryHomologationRepository,
+  inventoryHomologationRepository,
+} from '../../repositories/inventory/InventoryHomologationRepository';
+import { ExternalPlatformClient, externalPlatformClientFromEnv } from './ExternalPlatformClient';
+import { normalizeQrInput } from './InventoryQrService';
+
+export const OUTBOX_BATCH_SIZE = 20;
+const BACKOFF_BASE_MS = 30_000;
+const BACKOFF_MAX_MS = 15 * 60_000;
+
+/** Exponential backoff for the Nth failed attempt (1-based). */
+export function outboxBackoffMs(attempt: number): number {
+  return Math.min(BACKOFF_BASE_MS * 2 ** Math.max(0, attempt - 1), BACKOFF_MAX_MS);
+}
+
+export interface DrainResult {
+  claimed: number;
+  dispatched: number;
+  failed: number;
+  dead: number;
+}
+
+export type IOutboxRepository = Pick<
+  InventoryExternalRepository,
+  'withTransaction' | 'claimOutboxBatch' | 'markOutboxDispatched' | 'markOutboxFailed'
+>;
+
+export type IOutboxHomologRepository = Pick<
+  InventoryHomologationRepository,
+  'findRegistryByValues' | 'findBoxesByQrValues' | 'unitsByHomologationIds'
+>;
+
+export interface InventoryOutboxWorkerDeps {
+  repository?: IOutboxRepository;
+  homologRepository?: IOutboxHomologRepository;
+  clientProvider?: () => ExternalPlatformClient | null;
+  now?: () => Date;
+}
+
+/** Unwrap DrizzleQueryError — real SQLSTATE/message live in err.cause. */
+function errMessage(err: unknown): string {
+  const cause = (err as { cause?: unknown })?.cause;
+  if (cause instanceof Error && cause.message) return cause.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class InventoryOutboxWorker {
+  private repository: IOutboxRepository;
+  private homologRepository: IOutboxHomologRepository;
+  private clientProvider: () => ExternalPlatformClient | null;
+  private now: () => Date;
+
+  constructor(deps: InventoryOutboxWorkerDeps = {}) {
+    this.repository = deps.repository ?? inventoryExternalRepository;
+    this.homologRepository = deps.homologRepository ?? inventoryHomologationRepository;
+    this.clientProvider = deps.clientProvider ?? externalPlatformClientFromEnv;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  /**
+   * One drain pass: claim a batch (SKIP LOCKED + per-QR FIFO) and dispatch it.
+   * No-op when the external client is not configured.
+   */
+  async drainOnce(batchSize: number = OUTBOX_BATCH_SIZE): Promise<DrainResult> {
+    const result: DrainResult = { claimed: 0, dispatched: 0, failed: 0, dead: 0 };
+    const client = this.clientProvider();
+    if (!client) return result;
+
+    await this.repository.withTransaction(async (tx) => {
+      const rows = await this.repository.claimOutboxBatch(batchSize, tx);
+      result.claimed = rows.length;
+
+      for (const row of rows) {
+        try {
+          const codes = await this.expandCodes(row);
+          for (const code of codes) {
+            await client.patchProduct(code, {
+              location: row.location ?? undefined,
+              technician: row.technician,
+              client_name: row.clientName,
+            });
+          }
+          await this.repository.markOutboxDispatched([row.id], tx);
+          result.dispatched += 1;
+        } catch (err) {
+          const attempts = row.attempts + 1;
+          const dead = attempts >= OUTBOX_MAX_ATTEMPTS;
+          const nextAttemptAt = dead ? null : new Date(this.now().getTime() + outboxBackoffMs(attempts));
+          await this.repository.markOutboxFailed(row.id, attempts, nextAttemptAt, errMessage(err), tx);
+          if (dead) {
+            result.dead += 1;
+            // eslint-disable-next-line no-console -- operators need the dead letter
+            console.error(
+              `[inv-outbox] linha ${row.id} morta após ${attempts} tentativas: ${errMessage(err)}`,
+            );
+          } else {
+            result.failed += 1;
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * Bare PATCH codes for one outbox row. Enqueued values are unit QR
+   * spellings (bare or full URL); a value registered as a BOX QR is expanded
+   * to its units' codes (defensive — M6 already expands at enqueue time).
+   */
+  private async expandCodes(row: InvExternalPushOutboxRow): Promise<string[]> {
+    const normalized = row.qrCodes.map((qr) => normalizeQrInput(qr));
+    const allCandidates = [...new Set(normalized.flatMap((n) => n.candidates))];
+    const registry = await this.homologRepository.findRegistryByValues(row.tenantId, allCandidates);
+    const boxValues = new Set(registry.filter((r) => r.kind === 'BOX').map((r) => r.qrValue));
+
+    const codes = new Set<string>();
+    const boxCandidates: string[] = [];
+    for (const n of normalized) {
+      if (n.candidates.some((c) => boxValues.has(c))) {
+        boxCandidates.push(...n.candidates);
+      } else {
+        codes.add(n.code);
+      }
+    }
+
+    if (boxCandidates.length > 0) {
+      const boxes = await this.homologRepository.findBoxesByQrValues(row.tenantId, boxCandidates);
+      const units = await this.homologRepository.unitsByHomologationIds(
+        row.tenantId,
+        boxes.map((b) => b.id),
+      );
+      for (const u of units) codes.add(normalizeQrInput(u.qrValue).code);
+    }
+
+    return [...codes];
+  }
+}
+
+export const inventoryOutboxWorker = new InventoryOutboxWorker();

--- a/tests/unit/inventory/m5-contract.test.ts
+++ b/tests/unit/inventory/m5-contract.test.ts
@@ -305,7 +305,9 @@ describe('M5 QR routes — real contract', () => {
     }
   });
 
-  it('POST /qr/generate stays deferred → 501 INV_NOT_IMPLEMENTED (external platform client is M8)', async () => {
+  it('POST /qr/generate is real since M8 (was 501): DTO gate → 400 on an empty body', async () => {
+    // Full route coverage (201/503) lives in m8-contract.test.ts — here only
+    // the M5-visible contract: the route validates before touching anything.
     const srv = await listen(buildApp());
     try {
       const res = await fetch(U(srv.url, '/qr/generate'), {
@@ -313,9 +315,9 @@ describe('M5 QR routes — real contract', () => {
         headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
         body: JSON.stringify({}),
       });
-      expect(res.status).toBe(501);
+      expect(res.status).toBe(400);
       const body = (await res.json()) as ErrBody;
-      expect(body.error.code).toBe('INV_NOT_IMPLEMENTED');
+      expect(body.error.code).toBe('VALIDATION_ERROR');
     } finally {
       await srv.close();
     }

--- a/tests/unit/inventory/m8-contract.test.ts
+++ b/tests/unit/inventory/m8-contract.test.ts
@@ -1,0 +1,319 @@
+/**
+ * RFC-0061 M8 — wired-contract test for the REAL external routes + the now-real
+ * POST /qr/generate.
+ *
+ * Same harness as m1..m7-contract: real router + real auth middleware, auth
+ * leaves mocked, the M8 sync service mocked (no DB, NO network).
+ *
+ * SUPERSEDES the frozen case in tests/unit/controllers/inventory.contract.test.ts
+ * ("POST /external/sync/run → 501 INV_NOT_IMPLEMENTED") — that file is frozen
+ * for module PRs; remove that single case at wave-3 integration time.
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+
+jest.mock('../../../src/services/CustomerApiKeyService', () => ({
+  customerApiKeyService: {
+    validateApiKey: jest.fn(),
+    validateApiKeyWithTenant: jest.fn(),
+  },
+}));
+
+jest.mock('../../../src/middleware/context', () => {
+  const actual = jest.requireActual('../../../src/middleware/context');
+  return { ...actual, decodeJWT: jest.fn() };
+});
+
+jest.mock('../../../src/services/inventory/InventoryExternalSyncService', () => {
+  const actual = jest.requireActual('../../../src/services/inventory/InventoryExternalSyncService');
+  return {
+    ...actual,
+    inventoryExternalSyncService: {
+      listStates: jest.fn(),
+      getStatus: jest.fn(),
+      runPull: jest.fn(),
+      generateQr: jest.fn(),
+    },
+  };
+});
+
+import { customerApiKeyService } from '../../../src/services/CustomerApiKeyService';
+import { inventoryExternalSyncService } from '../../../src/services/inventory/InventoryExternalSyncService';
+import { externalNotConfigured } from '../../../src/services/inventory/ExternalPlatformClient';
+import { ConflictError, ForbiddenError, ValidationError } from '../../../src/shared/errors/AppError';
+import { contextMiddleware } from '../../../src/middleware/context';
+import { hybridAuthByMethod } from '../../../src/middleware/auth';
+import inventoryController from '../../../src/controllers/inventory.controller';
+import { errorHandler } from '../../../src/middleware/errorHandler';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+
+const limiter = rateLimit({ windowMs: 60_000, limit: 10_000, validate: false });
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(contextMiddleware);
+  app.use('/api/v1/inventory', limiter, hybridAuthByMethod('inventory:read', 'inventory:write'), inventoryController);
+  app.use(errorHandler);
+  return app;
+}
+
+async function listen(app: express.Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+function apiKeyCtx(scopes: string[]) {
+  return { keyId: 'key-1', tenantId: TENANT, customerId: TENANT, scopes, name: 'inv-key', hierarchyAccess: 'SELF' };
+}
+
+const U = (base: string, path: string) => `${base}/api/v1/inventory${path}`;
+
+type ErrBody = { success: boolean; error: { code: string } };
+type OkBody<T> = { success: boolean; data: T };
+
+const syncSvc = inventoryExternalSyncService as jest.Mocked<typeof inventoryExternalSyncService>;
+
+const emptyPage = { items: [], page: 1, pageSize: 20, total: 0, totalPages: 0 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  delete process.env.DISABLE_AUTH;
+  delete process.env.GCDR_MASTER_API_KEY;
+  (customerApiKeyService.validateApiKey as jest.Mock).mockResolvedValue(
+    apiKeyCtx(['inventory:read', 'inventory:write']),
+  );
+});
+
+describe('M8 GET /external/states — real contract (was 501)', () => {
+  it('200 with the paginated mirror; filters pass through', async () => {
+    syncSvc.listStates.mockResolvedValue(emptyPage as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/states?page=2&pageSize=50&location=cliente&q=2501'), {
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(syncSvc.listStates).toHaveBeenCalledWith(
+        TENANT,
+        expect.objectContaining({ page: 2, pageSize: 50, location: 'cliente', q: '2501' }),
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('bad pagination → 400 VALIDATION_ERROR', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/states?page=0'), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(400);
+      expect(syncSvc.listStates).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M8 GET /external/sync/status', () => {
+  it('200 with sync state + outbox counters + mode', async () => {
+    syncSvc.getStatus.mockResolvedValue({
+      syncState: null,
+      outbox: { pending: 0, retryable: 0, dead: 0, done: 0 },
+      mode: { live: false, shadow: true },
+    } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/status'), { headers: { 'X-API-Key': 'gcdr_cust_test' } });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as OkBody<{ mode: { shadow: boolean } }>;
+      expect(body.data.mode.shadow).toBe(true);
+      expect(syncSvc.getStatus).toHaveBeenCalledWith(TENANT);
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M8 POST /external/sync/run — real contract (SUPERSEDES the frozen 501 case)', () => {
+  it('200 with the run report (shadow default: live undefined)', async () => {
+    syncSvc.runPull.mockResolvedValue({ ok: true, live: false, corrections: [], problems: [] } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(syncSvc.runPull).toHaveBeenCalledWith(TENANT, { live: undefined });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('?live=true forwards live: true to the service', async () => {
+    syncSvc.runPull.mockResolvedValue({ ok: true, live: true, corrections: [], problems: [] } as never);
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run?live=true'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(200);
+      expect(syncSvc.runPull).toHaveBeenCalledWith(TENANT, { live: true });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('lease held → 409 CONFLICT', async () => {
+    syncSvc.runPull.mockRejectedValue(new ConflictError('Sincronização externa já em execução (lease ativo)'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(409);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('?live=true without INV_SYNC_LIVE → 400 (service gate)', async () => {
+    syncSvc.runPull.mockRejectedValue(new ValidationError('live=true requer INV_SYNC_LIVE=true'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run?live=true'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('?live=banana → 400 at the DTO boundary', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run?live=banana'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(400);
+      expect(syncSvc.runPull).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('client not configured → 503 INV_EXTERNAL_NOT_CONFIGURED', async () => {
+    syncSvc.runPull.mockRejectedValue(externalNotConfigured());
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_EXTERNAL_NOT_CONFIGURED');
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M8 POST /qr/generate — real contract (was 501)', () => {
+  it('201 with {code, qrUrl}', async () => {
+    syncSvc.generateQr.mockResolvedValue({ code: '250101_000123', qrUrl: 'https://produto.myio.com.br/250101_000123' });
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/generate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productType: 'SmartLight v3' }),
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as OkBody<{ code: string; qrUrl: string }>;
+      expect(body.data.code).toBe('250101_000123');
+      expect(body.data.qrUrl).toBe('https://produto.myio.com.br/250101_000123');
+      expect(syncSvc.generateQr).toHaveBeenCalledWith({ productType: 'SmartLight v3' });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('missing productType → 400 at the DTO boundary', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/generate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      expect(syncSvc.generateQr).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('no external client env → 503 with a clear code', async () => {
+    syncSvc.generateQr.mockRejectedValue(externalNotConfigured());
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/qr/generate'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ productType: 'SmartLight v3' }),
+      });
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as ErrBody;
+      expect(body.error.code).toBe('INV_EXTERNAL_NOT_CONFIGURED');
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
+describe('M8 auth boundary', () => {
+  it('write verbs demand inventory:write from the API key (403 from the scope check)', async () => {
+    // The scope gate lives inside customerApiKeyService.validateApiKey — the
+    // route passes 'inventory:write' for POST; a key without it is rejected.
+    (customerApiKeyService.validateApiKey as jest.Mock).mockRejectedValue(new ForbiddenError('Insufficient scope'));
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/sync/run'), {
+        method: 'POST',
+        headers: { 'X-API-Key': 'gcdr_cust_test' },
+      });
+      expect(res.status).toBe(403);
+      expect(customerApiKeyService.validateApiKey).toHaveBeenCalledWith(
+        'gcdr_cust_test',
+        expect.anything(),
+        'inventory:write',
+      );
+      expect(syncSvc.runPull).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('no credentials → 401', async () => {
+    const srv = await listen(buildApp());
+    try {
+      const res = await fetch(U(srv.url, '/external/states'));
+      expect(res.status).toBe(401);
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/tests/unit/inventory/m8-helpers.ts
+++ b/tests/unit/inventory/m8-helpers.ts
@@ -1,0 +1,341 @@
+// Shared fixtures/mocks for the RFC-0061 M8 unit suites (sync service + outbox
+// worker with every repository mocked and the platform client stubbed — no DB,
+// NO network: the real ExternalPlatformClient is never constructed here).
+
+import {
+  InventoryExternalSyncService,
+  IExternalSyncRepository,
+  IExternalHomologRepository,
+  IExternalStockRepository,
+  IExternalFieldRepository,
+  IExternalExpeditionRepository,
+} from '../../../src/services/inventory/InventoryExternalSyncService';
+import {
+  InventoryOutboxWorker,
+  IOutboxRepository,
+  IOutboxHomologRepository,
+} from '../../../src/services/inventory/InventoryOutboxWorker';
+import type { ExternalPlatformClient, ExternalProduct } from '../../../src/services/inventory/ExternalPlatformClient';
+import type {
+  InvExternalStateRow,
+  InvExternalSyncStateRow,
+  InvExternalPushOutboxRow,
+  DispatchByQrRow,
+} from '../../../src/repositories/inventory/InventoryExternalRepository';
+import type {
+  InvQrRegistryRow,
+  InvHomologationRow,
+  InvHomologationUnitRow,
+  UnitWithHomologationRow,
+} from '../../../src/repositories/inventory/InventoryHomologationRepository';
+
+export const TENANT = '11111111-1111-1111-1111-111111111111';
+export const ITEM_ID = '33333333-3333-3333-3333-333333333333';
+export const PROJECT_ID = 'aaaaaaaa-1111-4111-8111-111111111111';
+export const CUSTOMER_ID = 'bbbbbbbb-2222-4222-8222-222222222222';
+export const ORDER_ID = 'cccccccc-9999-4999-8999-999999999999';
+export const HOMOLOGATION_ID = 'eeeeeeee-5555-4555-8555-555555555555';
+export const BOX_HOMOLOGATION_ID = 'eeeeeeee-6666-4666-8666-666666666666';
+export const UNIT_ROW_ID = 'ffffffff-7777-4777-8777-777777777777';
+
+export const CODE = '250101_000123';
+export const CODE_2 = '250101_000124';
+export const QR_URL = `https://produto.myio.com.br/${CODE}`;
+export const BOX_QR = 'https://produto.myio.com.br/caixa-10/2026-01';
+/** The mirror keys box states by the normalized spelling (URL prefix stripped). */
+export const BOX_CODE = 'caixa-10/2026-01';
+
+let seq = 0;
+export function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-0000-4000-8000-${String(seq).padStart(12, '0')}`;
+}
+
+// -----------------------------------------------------------------------------
+// Row factories
+// -----------------------------------------------------------------------------
+
+export function makeProduct(overrides: Partial<ExternalProduct> = {}): ExternalProduct {
+  return {
+    code: CODE,
+    productType: 'SmartLight v3',
+    location: 'estoque',
+    status: 'parado',
+    technician: null,
+    clientName: null,
+    changedAt: null,
+    raw: { code: overrides.code ?? CODE },
+    ...overrides,
+  };
+}
+
+export function makeRegistryRow(overrides: Partial<InvQrRegistryRow> = {}): InvQrRegistryRow {
+  return {
+    id: nextId('11111111'),
+    tenantId: TENANT,
+    qrValue: CODE,
+    kind: 'UNIT',
+    itemId: ITEM_ID,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: null,
+    ...overrides,
+  } as InvQrRegistryRow;
+}
+
+export function makeHomologation(overrides: Partial<InvHomologationRow> = {}): InvHomologationRow {
+  return {
+    id: HOMOLOGATION_ID,
+    tenantId: TENANT,
+    releaseId: null,
+    itemId: ITEM_ID,
+    boxSize: 1,
+    boxQr: null,
+    responsibleId: null,
+    notes: null,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    createdBy: null,
+    ...overrides,
+  } as InvHomologationRow;
+}
+
+export function makeHomologationUnit(overrides: Partial<InvHomologationUnitRow> = {}): InvHomologationUnitRow {
+  return {
+    id: UNIT_ROW_ID,
+    tenantId: TENANT,
+    homologationId: HOMOLOGATION_ID,
+    position: 1,
+    qrValue: CODE,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    ...overrides,
+  } as InvHomologationUnitRow;
+}
+
+export function makeUnitWithHomologation(
+  unit: Partial<InvHomologationUnitRow> = {},
+  homologation: Partial<InvHomologationRow> = {},
+): UnitWithHomologationRow {
+  return { unit: makeHomologationUnit(unit), homologation: makeHomologation(homologation) };
+}
+
+export function makeStateRow(overrides: Partial<InvExternalStateRow> = {}): InvExternalStateRow {
+  return {
+    id: nextId('22222222'),
+    tenantId: TENANT,
+    code: CODE,
+    productType: 'SmartLight v3',
+    location: 'estoque',
+    status: 'parado',
+    technician: null,
+    clientName: null,
+    qrValue: CODE,
+    itemId: ITEM_ID,
+    homologationUnitId: UNIT_ROW_ID,
+    lastChangeAt: new Date('2026-03-01T00:00:00Z'),
+    payload: {},
+    updatedAt: new Date('2026-03-01T00:00:00Z'),
+    ...overrides,
+  } as InvExternalStateRow;
+}
+
+export function makeSyncStateRow(overrides: Partial<InvExternalSyncStateRow> = {}): InvExternalSyncStateRow {
+  return {
+    tenantId: TENANT,
+    leaseUntil: null,
+    lastRunAt: null,
+    lastStatus: null,
+    lastMessage: null,
+    totalItems: null,
+    ...overrides,
+  } as InvExternalSyncStateRow;
+}
+
+export function makeOutboxRow(overrides: Partial<InvExternalPushOutboxRow> = {}): InvExternalPushOutboxRow {
+  return {
+    id: nextId('33333333'),
+    tenantId: TENANT,
+    qrCodes: [CODE],
+    location: 'expedicao',
+    status: 'PENDING',
+    technician: null,
+    clientName: null,
+    attempts: 0,
+    nextAttemptAt: null,
+    lastError: null,
+    dispatchedAt: null,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  } as InvExternalPushOutboxRow;
+}
+
+export function makeDispatchByQr(overrides: Partial<DispatchByQrRow> = {}): DispatchByQrRow {
+  return {
+    movementId: nextId('44444444'),
+    itemId: ITEM_ID,
+    technician: 'João da Silva',
+    quantity: '1',
+    movedQuantity: 0,
+    qrValue: CODE,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Mocked dependencies
+// -----------------------------------------------------------------------------
+
+export type MockSyncRepo = jest.Mocked<IExternalSyncRepository>;
+export type MockHomologRepo = jest.Mocked<IExternalHomologRepository>;
+export type MockStockRepo = jest.Mocked<IExternalStockRepository>;
+export type MockFieldRepo = jest.Mocked<IExternalFieldRepository>;
+export type MockExpeditionRepo = jest.Mocked<IExternalExpeditionRepository>;
+
+export interface MockClient {
+  listProducts: jest.Mock;
+  createProduct: jest.Mock;
+  patchProduct: jest.Mock;
+}
+
+export function makeClient(products: ExternalProduct[] = []): MockClient {
+  return {
+    listProducts: jest.fn(async () => products),
+    createProduct: jest.fn(async () => makeProduct()),
+    patchProduct: jest.fn(async () => undefined),
+  };
+}
+
+export function makeSyncRepo(): MockSyncRepo {
+  return {
+    listStates: jest.fn(async () => ({ rows: [], total: 0 })),
+    allStates: jest.fn(async () => [] as InvExternalStateRow[]),
+    upsertState: jest.fn(async () => makeStateRow()),
+    deleteStatesNotIn: jest.fn(async () => 0),
+    claimLease: jest.fn(async () => makeSyncStateRow({ leaseUntil: new Date(Date.now() + 180_000) })),
+    releaseLease: jest.fn(async () => undefined),
+    getSyncState: jest.fn(async () => makeSyncStateRow()),
+    outboxCounters: jest.fn(async () => ({ pending: 0, retryable: 0, dead: 0, done: 0 })),
+    unitProductsByLabels: jest.fn(async () => []),
+    projectsByNamesInsensitive: jest.fn(async () => []),
+    dispatchesByQrValues: jest.fn(async () => [] as DispatchByQrRow[]),
+    listOpenDamaged: jest.fn(async () => []),
+    ordersInTransit: jest.fn(async () => []),
+  } as unknown as MockSyncRepo;
+}
+
+export function makeHomologRepo(): MockHomologRepo {
+  return {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    findRegistryByValues: jest.fn(async () => [] as InvQrRegistryRow[]),
+    findUnitsByQrValues: jest.fn(async () => [] as UnitWithHomologationRow[]),
+    findBoxesByQrValues: jest.fn(async () => [] as InvHomologationRow[]),
+    unitsByHomologationIds: jest.fn(async () => [] as InvHomologationUnitRow[]),
+    insertHomologation: jest.fn(async () => makeHomologation({ id: nextId('55555555') })),
+    moveUnit: jest.fn(async () => makeHomologationUnit()),
+    countUnits: jest.fn(async () => 0),
+    deleteHomologation: jest.fn(async () => 1),
+    deleteRegistryByValues: jest.fn(async () => 1),
+  } as unknown as MockHomologRepo;
+}
+
+export function makeStockRepo(): MockStockRepo {
+  return {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    lockItem: jest.fn(async () => ({ id: ITEM_ID }) as never),
+    getBalance: jest.fn(async () => ({ balance: '5', totalIn: '5', totalOut: '0', lastMovementAt: null })),
+    insertMovement: jest.fn(async () => ({ id: nextId('66666666') }) as never),
+    insertMovementQrs: jest.fn(async () => []),
+    latestQrEventTypes: jest.fn(async () => new Map<string, string>()),
+  } as unknown as MockStockRepo;
+}
+
+export function makeFieldRepo(): MockFieldRepo {
+  return {
+    insertUnitProducts: jest.fn(async () => []),
+    updateUnitStatus: jest.fn(async () => null),
+    markUnitMoved: jest.fn(async () => null),
+    insertTechnicianMove: jest.fn(async () => ({}) as never),
+    insertDamagedItem: jest.fn(async () => ({}) as never),
+  } as unknown as MockFieldRepo;
+}
+
+export function makeExpeditionRepo(): MockExpeditionRepo {
+  return {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    deliveredQrsByOrder: jest.fn(async () => []),
+    updateOrder: jest.fn(async () => null),
+    existingUnitProductLabels: jest.fn(async () => new Set<string>()),
+    insertUnitProducts: jest.fn(async () => []),
+    getProject: jest.fn(async () => null),
+  } as unknown as MockExpeditionRepo;
+}
+
+export interface SyncHarness {
+  service: InventoryExternalSyncService;
+  repository: MockSyncRepo;
+  homologRepository: MockHomologRepo;
+  stockRepository: MockStockRepo;
+  fieldRepository: MockFieldRepo;
+  expeditionRepository: MockExpeditionRepo;
+  client: MockClient;
+}
+
+export function makeSyncHarness(products: ExternalProduct[] = []): SyncHarness {
+  const repository = makeSyncRepo();
+  const homologRepository = makeHomologRepo();
+  const stockRepository = makeStockRepo();
+  const fieldRepository = makeFieldRepo();
+  const expeditionRepository = makeExpeditionRepo();
+  const client = makeClient(products);
+  const service = new InventoryExternalSyncService({
+    repository,
+    homologRepository,
+    stockRepository,
+    fieldRepository,
+    expeditionRepository,
+    clientProvider: () => client as unknown as ExternalPlatformClient,
+  });
+  return { service, repository, homologRepository, stockRepository, fieldRepository, expeditionRepository, client };
+}
+
+export interface OutboxHarness {
+  worker: InventoryOutboxWorker;
+  repository: jest.Mocked<IOutboxRepository>;
+  homologRepository: jest.Mocked<IOutboxHomologRepository>;
+  client: MockClient;
+  /** Rows the mocked claim returns per call (drained batches). */
+  queue: InvExternalPushOutboxRow[][];
+}
+
+export function makeOutboxHarness(batches: InvExternalPushOutboxRow[][] = []): OutboxHarness {
+  const queue = [...batches];
+  const repository = {
+    withTransaction: jest.fn(async (fn: (tx: never) => Promise<unknown>) => fn({} as never)),
+    claimOutboxBatch: jest.fn(async () => queue.shift() ?? []),
+    markOutboxDispatched: jest.fn(async () => undefined),
+    markOutboxFailed: jest.fn(async () => undefined),
+  } as unknown as jest.Mocked<IOutboxRepository>;
+  const homologRepository = {
+    findRegistryByValues: jest.fn(async () => [] as InvQrRegistryRow[]),
+    findBoxesByQrValues: jest.fn(async () => [] as InvHomologationRow[]),
+    unitsByHomologationIds: jest.fn(async () => [] as InvHomologationUnitRow[]),
+  } as unknown as jest.Mocked<IOutboxHomologRepository>;
+  const client = makeClient();
+  const worker = new InventoryOutboxWorker({
+    repository,
+    homologRepository,
+    clientProvider: () => client as unknown as ExternalPlatformClient,
+  });
+  return { worker, repository, homologRepository, client, queue };
+}
+
+// -----------------------------------------------------------------------------
+// Env helpers (INV_SYNC_LIVE — J4 shadow gate)
+// -----------------------------------------------------------------------------
+
+export function withLiveEnv(): void {
+  process.env.INV_SYNC_LIVE = 'true';
+}
+
+export function clearLiveEnv(): void {
+  delete process.env.INV_SYNC_LIVE;
+}

--- a/tests/unit/inventory/m8-lease.test.ts
+++ b/tests/unit/inventory/m8-lease.test.ts
@@ -1,0 +1,135 @@
+/**
+ * RFC-0061 M8 — single-flight lease + live/shadow gate (J4).
+ *
+ * The pull claims a persisted 3-minute lease atomically; a held lease means
+ * 409 (ConflictError) on the manual trigger. ?live=true is refused without
+ * env INV_SYNC_LIVE=true. The lease is always released with the run report —
+ * success, PARCIAL or ERRO.
+ */
+
+import { ConflictError, ValidationError, AppError } from '../../../src/shared/errors/AppError';
+import {
+  InventoryExternalSyncService,
+  SYNC_LEASE_MS,
+} from '../../../src/services/inventory/InventoryExternalSyncService';
+import {
+  TENANT,
+  CODE,
+  makeProduct,
+  makeSyncHarness,
+  makeSyncStateRow,
+  withLiveEnv,
+  clearLiveEnv,
+} from './m8-helpers';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearLiveEnv();
+});
+
+afterAll(() => clearLiveEnv());
+
+describe('M8 lease (single-flight, §M8)', () => {
+  it('claims a 3-minute lease before pulling', async () => {
+    const h = makeSyncHarness([]);
+    await h.service.runPull(TENANT);
+    expect(h.repository.claimLease).toHaveBeenCalledWith(TENANT, SYNC_LEASE_MS);
+    expect(SYNC_LEASE_MS).toBe(180_000);
+  });
+
+  it('throws ConflictError (→ 409) when the lease is held elsewhere', async () => {
+    const h = makeSyncHarness([]);
+    h.repository.claimLease.mockResolvedValue(null); // claim refused — active lease
+
+    await expect(h.service.runPull(TENANT)).rejects.toBeInstanceOf(ConflictError);
+    expect(h.client.listProducts).not.toHaveBeenCalled();
+    expect(h.repository.releaseLease).not.toHaveBeenCalled(); // never releases a lease it does not hold
+  });
+
+  it('an expired lease is claimable again (repository claim contract)', async () => {
+    // The atomic claim (UPDATE … WHERE lease_until IS NULL OR < now()) is the
+    // repository's; at the service level an expired lease simply claims.
+    const h = makeSyncHarness([]);
+    h.repository.claimLease.mockResolvedValue(
+      makeSyncStateRow({ leaseUntil: new Date(Date.now() + SYNC_LEASE_MS) }),
+    );
+    const report = await h.service.runPull(TENANT);
+    expect(report.ok).toBe(true);
+    expect(h.repository.releaseLease).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lease even when the run blows up mid-flight', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE })]);
+    h.homologRepository.findRegistryByValues.mockRejectedValue(new Error('db down'));
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.ok).toBe(false);
+    expect(h.repository.releaseLease).toHaveBeenCalledWith(TENANT, expect.objectContaining({ status: 'ERRO' }));
+  });
+});
+
+describe('M8 live/shadow gate (J4)', () => {
+  it('refuses ?live=true without INV_SYNC_LIVE=true (400, before the lease)', async () => {
+    const h = makeSyncHarness([]);
+    await expect(h.service.runPull(TENANT, { live: true })).rejects.toBeInstanceOf(ValidationError);
+    expect(h.repository.claimLease).not.toHaveBeenCalled();
+  });
+
+  it('runs shadow by default (report.live=false)', async () => {
+    const h = makeSyncHarness([]);
+    const report = await h.service.runPull(TENANT);
+    expect(report.live).toBe(false);
+  });
+
+  it('accepts live with INV_SYNC_LIVE=true', async () => {
+    withLiveEnv();
+    const h = makeSyncHarness([]);
+    const report = await h.service.runPull(TENANT, { live: true });
+    expect(report.live).toBe(true);
+  });
+
+  it('the cron path (no opts) follows the env', async () => {
+    withLiveEnv();
+    const h = makeSyncHarness([]);
+    const report = await h.service.runPull(TENANT);
+    expect(report.live).toBe(true);
+  });
+});
+
+describe('M8 client configuration', () => {
+  it('throws 503 INV_EXTERNAL_NOT_CONFIGURED when no client is available', async () => {
+    const service = new InventoryExternalSyncService({ clientProvider: () => null });
+    const err = await service.runPull(TENANT).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(AppError);
+    expect((err as AppError).statusCode).toBe(503);
+    expect((err as AppError).code).toBe('INV_EXTERNAL_NOT_CONFIGURED');
+  });
+});
+
+describe('M8 sync status response', () => {
+  it('reports leaseActive from lease_until vs now + outbox counters + mode', async () => {
+    const h = makeSyncHarness([]);
+    h.repository.getSyncState.mockResolvedValue(
+      makeSyncStateRow({ leaseUntil: new Date(Date.now() + 60_000), lastStatus: 'OK', totalItems: 42 }),
+    );
+    h.repository.outboxCounters.mockResolvedValue({ pending: 2, retryable: 1, dead: 0, done: 9 });
+
+    const status = await h.service.getStatus(TENANT);
+
+    expect(status.syncState?.leaseActive).toBe(true);
+    expect(status.syncState?.lastStatus).toBe('OK');
+    expect(status.outbox).toEqual({ pending: 2, retryable: 1, dead: 0, done: 9 });
+    expect(status.mode).toEqual({ live: false, shadow: true });
+  });
+
+  it('an expired lease shows leaseActive=false', async () => {
+    const h = makeSyncHarness([]);
+    h.repository.getSyncState.mockResolvedValue(makeSyncStateRow({ leaseUntil: new Date(Date.now() - 1000) }));
+    const status = await h.service.getStatus(TENANT);
+    expect(status.syncState?.leaseActive).toBe(false);
+  });
+});

--- a/tests/unit/inventory/m8-outbox.test.ts
+++ b/tests/unit/inventory/m8-outbox.test.ts
@@ -1,0 +1,235 @@
+/**
+ * RFC-0061 M8 — push-outbox drain (DEC-6/W3).
+ *
+ * Two layers, no DB and no network:
+ *  - SQL shape of the claim (InventoryExternalRepository.claimOutboxBatchQuery):
+ *    FOR UPDATE SKIP LOCKED, per-QR FIFO via NOT EXISTS + array overlap (&&),
+ *    oldest-first ordering, attempts ceiling.
+ *  - Worker behavior (mocked repo + client): PATCH per code, DONE on success,
+ *    FAILED + exponential backoff on failure, dead letter after
+ *    OUTBOX_MAX_ATTEMPTS, FIFO order preserved when an older row fails.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import {
+  InventoryExternalRepository,
+  OUTBOX_MAX_ATTEMPTS,
+} from '../../../src/repositories/inventory/InventoryExternalRepository';
+import { InventoryOutboxWorker, outboxBackoffMs } from '../../../src/services/inventory/InventoryOutboxWorker';
+import {
+  CODE,
+  CODE_2,
+  BOX_QR,
+  TENANT,
+  makeOutboxRow,
+  makeOutboxHarness,
+  makeRegistryRow,
+  makeHomologation,
+  makeHomologationUnit,
+} from './m8-helpers';
+
+const dialect = new PgDialect();
+
+beforeEach(() => jest.clearAllMocks());
+
+// -----------------------------------------------------------------------------
+// Claim SQL shape (W3)
+// -----------------------------------------------------------------------------
+
+describe('claimOutboxBatchQuery SQL shape (SKIP LOCKED + per-QR FIFO)', () => {
+  const repo = new InventoryExternalRepository();
+  const { sql, params } = dialect.sqlToQuery(repo.claimOutboxBatchQuery(20));
+
+  it('locks with FOR UPDATE SKIP LOCKED (deploy-safe under side-by-side instances)', () => {
+    expect(sql).toMatch(/FOR UPDATE OF o SKIP LOCKED/i);
+  });
+
+  it('claims oldest-first (created_at, id)', () => {
+    expect(sql).toMatch(/ORDER BY o\.created_at ASC, o\.id ASC/i);
+  });
+
+  it('enforces per-QR FIFO: NOT EXISTS older live row sharing qr_codes (&& overlap)', () => {
+    expect(sql).toMatch(/NOT EXISTS/i);
+    expect(sql).toMatch(/older\.qr_codes && o\.qr_codes/);
+    expect(sql).toMatch(/older\.created_at < o\.created_at/);
+    expect(sql).toMatch(/older\.id < o\.id/); // stable tiebreak on equal timestamps
+    expect(sql).toMatch(/older\.tenant_id = o\.tenant_id/);
+  });
+
+  it('only claims live rows due now (status, attempts ceiling, next_attempt_at)', () => {
+    expect(sql).toMatch(/o\.status IN \('PENDING','FAILED'\)/);
+    expect(sql).toMatch(/o\.attempts </);
+    expect(sql).toMatch(/o\.next_attempt_at IS NULL OR o\.next_attempt_at <= now\(\)/);
+    expect(params).toEqual(expect.arrayContaining([OUTBOX_MAX_ATTEMPTS, 20]));
+  });
+
+  it('the blocking predicate ALSO honors the attempts ceiling — a dead letter stops blocking', () => {
+    // Both the claim filter and the NOT EXISTS use attempts < max: an
+    // exhausted row neither drains nor wedges younger pushes for its QRs
+    // (the pull-sync reconciliation is the safety net for those).
+    const matches = sql.match(/attempts </g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Backoff
+// -----------------------------------------------------------------------------
+
+describe('outboxBackoffMs (exponential, capped)', () => {
+  it('doubles from 30s and caps at 15 minutes', () => {
+    expect(outboxBackoffMs(1)).toBe(30_000);
+    expect(outboxBackoffMs(2)).toBe(60_000);
+    expect(outboxBackoffMs(3)).toBe(120_000);
+    expect(outboxBackoffMs(5)).toBe(480_000);
+    expect(outboxBackoffMs(10)).toBe(900_000); // cap
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Worker behavior
+// -----------------------------------------------------------------------------
+
+describe('InventoryOutboxWorker.drainOnce', () => {
+  it('is a no-op when the client is not configured', async () => {
+    const h = makeOutboxHarness([[makeOutboxRow()]]);
+    const worker = new InventoryOutboxWorker({
+      repository: h.repository,
+      homologRepository: h.homologRepository,
+      clientProvider: () => null,
+    });
+    const result = await worker.drainOnce();
+    expect(result).toEqual({ claimed: 0, dispatched: 0, failed: 0, dead: 0 });
+    expect(h.repository.claimOutboxBatch).not.toHaveBeenCalled();
+  });
+
+  it('PATCHes each bare code and marks the row DONE', async () => {
+    const row = makeOutboxRow({
+      qrCodes: [`https://produto.myio.com.br/${CODE}`, CODE_2],
+      location: 'transporte',
+      technician: 'Transportadora',
+      clientName: null,
+    });
+    const h = makeOutboxHarness([[row]]);
+
+    const result = await h.worker.drainOnce();
+
+    expect(result).toEqual({ claimed: 1, dispatched: 1, failed: 0, dead: 0 });
+    expect(h.client.patchProduct).toHaveBeenCalledTimes(2);
+    expect(h.client.patchProduct).toHaveBeenCalledWith(CODE, {
+      location: 'transporte',
+      technician: 'Transportadora',
+      client_name: null,
+    });
+    expect(h.client.patchProduct).toHaveBeenCalledWith(CODE_2, expect.objectContaining({ location: 'transporte' }));
+    expect(h.repository.markOutboxDispatched).toHaveBeenCalledWith([row.id], expect.anything());
+  });
+
+  it('expands a BOX QR into its unit codes before PATCHing (defensive)', async () => {
+    const row = makeOutboxRow({ qrCodes: [BOX_QR], location: 'expedicao' });
+    const h = makeOutboxHarness([[row]]);
+    const box = makeHomologation({ boxSize: 10, boxQr: BOX_QR });
+    h.homologRepository.findRegistryByValues.mockResolvedValue([
+      makeRegistryRow({ qrValue: BOX_QR, kind: 'BOX' }),
+    ]);
+    h.homologRepository.findBoxesByQrValues.mockResolvedValue([box]);
+    h.homologRepository.unitsByHomologationIds.mockResolvedValue([
+      makeHomologationUnit({ qrValue: CODE, homologationId: box.id }),
+      makeHomologationUnit({ id: 'ffffffff-7777-4777-8777-777777777772', qrValue: CODE_2, homologationId: box.id }),
+    ]);
+
+    await h.worker.drainOnce();
+
+    expect(h.client.patchProduct).toHaveBeenCalledTimes(2);
+    expect(h.client.patchProduct).toHaveBeenCalledWith(CODE, expect.anything());
+    expect(h.client.patchProduct).toHaveBeenCalledWith(CODE_2, expect.anything());
+  });
+
+  it('failure → FAILED with attempts+1 and the exponential backoff', async () => {
+    const row = makeOutboxRow({ attempts: 1 });
+    const h = makeOutboxHarness([[row]]);
+    h.client.patchProduct.mockRejectedValue(new Error('HTTP 500'));
+
+    const result = await h.worker.drainOnce();
+
+    expect(result).toEqual({ claimed: 1, dispatched: 0, failed: 1, dead: 0 });
+    expect(h.repository.markOutboxDispatched).not.toHaveBeenCalled();
+    const [id, attempts, nextAttemptAt, lastError] = h.repository.markOutboxFailed.mock.calls[0];
+    expect(id).toBe(row.id);
+    expect(attempts).toBe(2);
+    expect(nextAttemptAt).toBeInstanceOf(Date);
+    expect(lastError).toContain('HTTP 500');
+  });
+
+  it('dead-letters after OUTBOX_MAX_ATTEMPTS: next_attempt_at NULL, keeps last_error', async () => {
+    const row = makeOutboxRow({ attempts: OUTBOX_MAX_ATTEMPTS - 1, status: 'FAILED' });
+    const h = makeOutboxHarness([[row]]);
+    h.client.patchProduct.mockRejectedValue(new Error('still down'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const result = await h.worker.drainOnce();
+
+      expect(result).toEqual({ claimed: 1, dispatched: 0, failed: 0, dead: 1 });
+      const [, attempts, nextAttemptAt, lastError] = h.repository.markOutboxFailed.mock.calls[0];
+      expect(attempts).toBe(OUTBOX_MAX_ATTEMPTS);
+      expect(nextAttemptAt).toBeNull();
+      expect(lastError).toContain('still down');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('FIFO preserved on failure: the failing older row is marked FAILED, later same-QR rows are NOT in the batch (claim contract) and the rest of the batch still drains', async () => {
+    // The claim already excluded the younger same-QR row (NOT EXISTS) — the
+    // batch carries the older failing row plus an unrelated row.
+    const older = makeOutboxRow({ qrCodes: [CODE], location: 'tecnico' });
+    const unrelated = makeOutboxRow({ qrCodes: ['777777_777777'], location: 'cliente' });
+    const h = makeOutboxHarness([[older, unrelated]]);
+    h.client.patchProduct.mockImplementation(async (code: string) => {
+      if (code === CODE) throw new Error('tecnico push down');
+    });
+
+    const result = await h.worker.drainOnce();
+
+    expect(result).toEqual({ claimed: 2, dispatched: 1, failed: 1, dead: 0 });
+    expect(h.repository.markOutboxFailed).toHaveBeenCalledWith(
+      older.id,
+      1,
+      expect.any(Date),
+      expect.stringContaining('tecnico push down'),
+      expect.anything(),
+    );
+    expect(h.repository.markOutboxDispatched).toHaveBeenCalledWith([unrelated.id], expect.anything());
+  });
+
+  it('a partially-PATCHed multi-code row is retried whole (fails as one unit)', async () => {
+    const row = makeOutboxRow({ qrCodes: [CODE, CODE_2] });
+    const h = makeOutboxHarness([[row]]);
+    h.client.patchProduct.mockImplementation(async (code: string) => {
+      if (code === CODE_2) throw new Error('second code failed');
+    });
+
+    const result = await h.worker.drainOnce();
+
+    expect(result.failed).toBe(1);
+    expect(h.repository.markOutboxDispatched).not.toHaveBeenCalled();
+  });
+
+  it('claims within the drain transaction (claim tx = dispatch tx)', async () => {
+    const h = makeOutboxHarness([[makeOutboxRow()]]);
+    await h.worker.drainOnce();
+    expect(h.repository.withTransaction).toHaveBeenCalledTimes(1);
+    expect(h.repository.claimOutboxBatch).toHaveBeenCalledWith(20, expect.anything());
+  });
+
+  it('rows for any tenant drain through the single env client (v1)', async () => {
+    const row = makeOutboxRow({ tenantId: TENANT });
+    const other = makeOutboxRow({ tenantId: '22222222-2222-4222-8222-222222222222', qrCodes: ['888888_888888'] });
+    const h = makeOutboxHarness([[row, other]]);
+
+    const result = await h.worker.drainOnce();
+
+    expect(result.dispatched).toBe(2);
+  });
+});

--- a/tests/unit/inventory/m8-sync-box-master.test.ts
+++ b/tests/unit/inventory/m8-sync-box-master.test.ts
@@ -1,0 +1,171 @@
+/**
+ * RFC-0061 M8 — box-is-master (2 passes, §M8).
+ *
+ * Pass 1: a state reported for a BOX QR propagates to every unit in the box
+ * (the box overwrites unit-level state). Pass 2: a unit reported at the
+ * client (location `cliente` or status `instalado`) "leaves the box" — a solo
+ * box_size=1 homologation via the M5 repos; an emptied box is deleted and its
+ * box-QR identity released. Pass 2 is shadow-gated (J4).
+ */
+
+import {
+  TENANT,
+  ITEM_ID,
+  CODE,
+  CODE_2,
+  BOX_QR,
+  BOX_CODE,
+  BOX_HOMOLOGATION_ID,
+  makeProduct,
+  makeRegistryRow,
+  makeHomologation,
+  makeHomologationUnit,
+  makeSyncHarness,
+  withLiveEnv,
+  clearLiveEnv,
+} from './m8-helpers';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearLiveEnv();
+});
+
+afterAll(() => clearLiveEnv());
+
+function boxSetup() {
+  const box = makeHomologation({ id: BOX_HOMOLOGATION_ID, boxSize: 10, boxQr: BOX_QR });
+  const unit1 = makeHomologationUnit({ id: 'ffffffff-7777-4777-8777-777777777771', homologationId: box.id, qrValue: CODE });
+  const unit2 = makeHomologationUnit({ id: 'ffffffff-7777-4777-8777-777777777772', homologationId: box.id, qrValue: CODE_2, position: 2 });
+  return { box, unit1, unit2 };
+}
+
+describe('M8 box-is-master — pass 1 (box state propagates to units)', () => {
+  it('propagates the box location/status/technician to every unit in the box', async () => {
+    const { box, unit1, unit2 } = boxSetup();
+    const h = makeSyncHarness([
+      makeProduct({ code: BOX_QR, location: 'transporte', technician: 'Transportadora' }),
+      // Platform ALSO lists unit1 individually with a stale location:
+      makeProduct({ code: CODE, location: 'estoque' }),
+    ]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([
+      makeRegistryRow({ qrValue: BOX_QR, kind: 'BOX' }),
+      makeRegistryRow({ qrValue: CODE }),
+    ]);
+    h.homologRepository.findUnitsByQrValues.mockResolvedValue([{ unit: unit1, homologation: box }]);
+    h.homologRepository.findBoxesByQrValues.mockResolvedValue([box]);
+    h.homologRepository.unitsByHomologationIds.mockResolvedValue([unit1, unit2]);
+
+    await h.service.runPull(TENANT);
+
+    // Both units mirrored with the BOX's state — the box is master.
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: CODE, location: 'transporte', technician: 'Transportadora' }),
+    );
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: CODE_2, location: 'transporte' }),
+    );
+    // The box's own mirror row is kept too (keyed by the normalized code).
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: BOX_CODE, location: 'transporte' }),
+    );
+  });
+
+  it('adds units the platform did not list individually (synthetic states)', async () => {
+    const { box, unit1, unit2 } = boxSetup();
+    const h = makeSyncHarness([makeProduct({ code: BOX_QR, location: 'expedicao' })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: BOX_QR, kind: 'BOX' })]);
+    h.homologRepository.findBoxesByQrValues.mockResolvedValue([box]);
+    h.homologRepository.unitsByHomologationIds.mockResolvedValue([unit1, unit2]);
+
+    await h.service.runPull(TENANT);
+
+    // 1 box row + 2 propagated unit rows.
+    expect(h.repository.upsertState).toHaveBeenCalledTimes(3);
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: CODE_2, location: 'expedicao', homologationUnitId: unit2.id }),
+    );
+  });
+});
+
+describe('M8 box-is-master — pass 2 (unit at the client leaves the box)', () => {
+  function clientUnitInBox() {
+    const { box, unit1 } = boxSetup();
+    const h = makeSyncHarness([
+      makeProduct({ code: CODE, location: 'cliente', status: 'instalado', clientName: 'Moxuara' }),
+    ]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.homologRepository.findUnitsByQrValues.mockResolvedValue([{ unit: unit1, homologation: box }]);
+    return { h, box, unit1 };
+  }
+
+  it('SHADOW: records the box exit as an unapplied correction', async () => {
+    const { h } = clientUnitInBox();
+
+    const report = await h.service.runPull(TENANT);
+
+    const exit = report.corrections.find((c) => c.kind === 'BOX_UNIT_LEFT_BOX');
+    expect(exit).toBeDefined();
+    expect(exit?.applied).toBe(false);
+    expect(h.homologRepository.insertHomologation).not.toHaveBeenCalled();
+    expect(h.homologRepository.moveUnit).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: creates the solo box_size=1 homologation and moves the unit', async () => {
+    withLiveEnv();
+    const { h, box, unit1 } = clientUnitInBox();
+    h.homologRepository.countUnits.mockResolvedValue(4); // box not emptied
+
+    const report = await h.service.runPull(TENANT);
+
+    const exit = report.corrections.find((c) => c.kind === 'BOX_UNIT_LEFT_BOX');
+    expect(exit?.applied).toBe(true);
+    expect(h.homologRepository.insertHomologation).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: TENANT, itemId: ITEM_ID, boxSize: 1, boxQr: null }),
+      expect.anything(),
+    );
+    expect(h.homologRepository.moveUnit).toHaveBeenCalledWith(
+      TENANT,
+      unit1.id,
+      expect.any(String),
+      1,
+      expect.anything(),
+    );
+    // Box still holds units — NOT deleted.
+    expect(h.homologRepository.deleteHomologation).not.toHaveBeenCalled();
+    expect(box.boxQr).toBe(BOX_QR);
+  });
+
+  it('LIVE: an emptied box is deleted and its box-QR identity released', async () => {
+    withLiveEnv();
+    const { h, box } = clientUnitInBox();
+    h.homologRepository.countUnits.mockResolvedValue(0); // last unit left
+
+    await h.service.runPull(TENANT);
+
+    expect(h.homologRepository.deleteHomologation).toHaveBeenCalledWith(TENANT, box.id, expect.anything());
+    expect(h.homologRepository.deleteRegistryByValues).toHaveBeenCalledWith(TENANT, [BOX_QR], expect.anything());
+  });
+
+  it('does NOT leave the box for a unit still in transit', async () => {
+    const { box, unit1 } = boxSetup();
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'transporte' })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.homologRepository.findUnitsByQrValues.mockResolvedValue([{ unit: unit1, homologation: box }]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'BOX_UNIT_LEFT_BOX')).toBeUndefined();
+  });
+
+  it('does NOT leave the box for a solo (box_size=1) homologation', async () => {
+    const solo = makeHomologation({ boxSize: 1 });
+    const unit = makeHomologationUnit({ homologationId: solo.id });
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'cliente' })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.homologRepository.findUnitsByQrValues.mockResolvedValue([{ unit, homologation: solo }]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'BOX_UNIT_LEFT_BOX')).toBeUndefined();
+  });
+});

--- a/tests/unit/inventory/m8-sync-golden-rule.test.ts
+++ b/tests/unit/inventory/m8-sync-golden-rule.test.ts
@@ -1,0 +1,167 @@
+/**
+ * RFC-0061 M8 — golden rule + mirror upsert + run report.
+ *
+ * Only codes whose QR exists in the M5 registry/homologation_units are
+ * considered; everything else is ignored (counted, never mirrored). Orphan
+ * mirror rows (codes no longer eligible) are deleted. The mirror upsert only
+ * bumps last_change_at when the observable state changed, and the run report
+ * {ok,total,ignored,changed,corrections,problems} is persisted on release.
+ */
+
+import {
+  TENANT,
+  CODE,
+  CODE_2,
+  QR_URL,
+  makeProduct,
+  makeRegistryRow,
+  makeStateRow,
+  makeSyncHarness,
+  clearLiveEnv,
+} from './m8-helpers';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearLiveEnv();
+});
+
+describe('M8 golden rule (§M8)', () => {
+  it('ignores codes not present in the registry and never mirrors them', async () => {
+    const h = makeSyncHarness([
+      makeProduct({ code: CODE }),
+      makeProduct({ code: '999999_999999' }), // not homologated in GCDR
+    ]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.total).toBe(2);
+    expect(report.ignored).toBe(1);
+    expect(h.repository.upsertState).toHaveBeenCalledTimes(1);
+    expect(h.repository.upsertState).toHaveBeenCalledWith(expect.objectContaining({ code: CODE }));
+  });
+
+  it('matches the registry by any QR spelling (bare code or full URL)', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE })]);
+    // Registry stored the FULL URL spelling (camera-scan homologation).
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: QR_URL })]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.ignored).toBe(0);
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: CODE, qrValue: QR_URL }),
+    );
+  });
+
+  it('deletes orphan mirror rows — codes no longer eligible', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.repository.deleteStatesNotIn.mockResolvedValue(3);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(h.repository.deleteStatesNotIn).toHaveBeenCalledWith(TENANT, [CODE]);
+    expect(report.orphansDeleted).toBe(3);
+  });
+
+  it('caps a run at 1000 items and flags the cap as a problem (PARCIAL)', async () => {
+    const products = Array.from({ length: 1001 }, (_, i) => makeProduct({ code: `1_${i}` }));
+    const h = makeSyncHarness(products);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.total).toBe(1001);
+    expect(report.ignored).toBe(1000); // only the capped slice was considered
+    expect(report.problems.some((p) => p.includes('cap'))).toBe(true);
+    expect(h.repository.releaseLease).toHaveBeenCalledWith(
+      TENANT,
+      expect.objectContaining({ status: 'PARCIAL', totalItems: 1001 }),
+    );
+  });
+});
+
+describe('M8 mirror upsert + last_change_at', () => {
+  it('keeps last_change_at when the observable state did not change', async () => {
+    const prior = makeStateRow({ code: CODE, location: 'estoque', status: 'parado' });
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'estoque', status: 'parado' })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.repository.allStates.mockResolvedValue([prior]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.changed).toBe(0);
+    expect(h.repository.upsertState).toHaveBeenCalledWith(
+      expect.objectContaining({ code: CODE, lastChangeAt: prior.lastChangeAt }),
+    );
+  });
+
+  it('bumps last_change_at and counts the change when the state moved', async () => {
+    const prior = makeStateRow({ code: CODE, location: 'estoque', status: 'parado' });
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'transporte', status: 'parado' })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+    h.repository.allStates.mockResolvedValue([prior]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.changed).toBe(1);
+    const arg = h.repository.upsertState.mock.calls[0][0];
+    expect(arg.lastChangeAt).not.toEqual(prior.lastChangeAt);
+  });
+
+  it('stores the raw platform payload on the mirror row', async () => {
+    const raw = { code: CODE, extra: 'anything the platform sends' };
+    const h = makeSyncHarness([makeProduct({ code: CODE, raw })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+
+    await h.service.runPull(TENANT);
+
+    expect(h.repository.upsertState).toHaveBeenCalledWith(expect.objectContaining({ payload: raw }));
+  });
+});
+
+describe('M8 run report persistence (§M8 step 9)', () => {
+  it('persists OK with the JSON report and total on a clean run', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.ok).toBe(true);
+    expect(h.repository.releaseLease).toHaveBeenCalledTimes(1);
+    const [, persisted] = h.repository.releaseLease.mock.calls[0];
+    expect(persisted.status).toBe('OK');
+    expect(persisted.totalItems).toBe(1);
+    const parsed = JSON.parse(persisted.message) as { ok: boolean; corrections: unknown[] };
+    expect(parsed.ok).toBe(true);
+    expect(Array.isArray(parsed.corrections)).toBe(true);
+  });
+
+  it('persists ERRO and releases the lease when the platform fetch fails', async () => {
+    const h = makeSyncHarness();
+    h.client.listProducts.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.ok).toBe(false);
+    expect(report.problems[0]).toContain('ECONNREFUSED');
+    expect(h.repository.releaseLease).toHaveBeenCalledWith(TENANT, expect.objectContaining({ status: 'ERRO' }));
+  });
+
+  it('unwraps err.cause (Drizzle gotcha) into the problems list', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE }), makeProduct({ code: CODE_2 })]);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([
+      makeRegistryRow({ qrValue: CODE }),
+      makeRegistryRow({ qrValue: CODE_2 }),
+    ]);
+    const wrapped = new Error('DrizzleQueryError: query failed');
+    (wrapped as { cause?: Error }).cause = new Error('duplicate key value violates unique constraint (23505)');
+    h.repository.upsertState.mockRejectedValueOnce(wrapped);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.problems.some((p) => p.includes('23505'))).toBe(true);
+    expect(h.repository.releaseLease).toHaveBeenCalledWith(TENANT, expect.objectContaining({ status: 'PARCIAL' }));
+  });
+});

--- a/tests/unit/inventory/m8-sync-reconciliation.test.ts
+++ b/tests/unit/inventory/m8-sync-reconciliation.test.ts
@@ -1,0 +1,486 @@
+/**
+ * RFC-0061 M8 — ledger reconciliation, client upsert, damaged auto-report and
+ * order auto-transition — each rule asserted in SHADOW (computed + logged,
+ * never applied) and LIVE (INV_SYNC_LIVE=true — applied) modes (J4).
+ */
+
+import { SYNC_STOCK_LOCATION } from '../../../src/services/inventory/InventoryExternalSyncService';
+import {
+  TENANT,
+  ITEM_ID,
+  PROJECT_ID,
+  CUSTOMER_ID,
+  ORDER_ID,
+  CODE,
+  CODE_2,
+  makeProduct,
+  makeRegistryRow,
+  makeUnitWithHomologation,
+  makeSyncHarness,
+  makeDispatchByQr,
+  withLiveEnv,
+  clearLiveEnv,
+} from './m8-helpers';
+import type { SyncHarness } from './m8-helpers';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearLiveEnv();
+});
+
+afterAll(() => clearLiveEnv());
+
+function eligible(h: SyncHarness): void {
+  h.homologRepository.findRegistryByValues.mockResolvedValue([makeRegistryRow({ qrValue: CODE })]);
+  h.homologRepository.findUnitsByQrValues.mockResolvedValue([makeUnitWithHomologation()]);
+}
+
+// -----------------------------------------------------------------------------
+// Rule 1 — in the field per the platform, in stock per the ledger ⇒ SAIDA
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — field vs stock ⇒ SAIDA', () => {
+  function fieldButInStock(location = 'cliente') {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location, technician: location === 'tecnico' ? 'Zé' : null })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'ENTRADA']]));
+    return h;
+  }
+
+  it('SHADOW: logs the SAIDA correction without writing the ledger', async () => {
+    const h = fieldButInStock();
+    const report = await h.service.runPull(TENANT);
+
+    const saida = report.corrections.find((c) => c.kind === 'LEDGER_SAIDA');
+    expect(saida).toBeDefined();
+    expect(saida?.applied).toBe(false);
+    expect(h.stockRepository.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: writes SAIDA 1un with the QR linked to the new movement', async () => {
+    withLiveEnv();
+    const h = fieldButInStock();
+    const report = await h.service.runPull(TENANT);
+
+    const saida = report.corrections.find((c) => c.kind === 'LEDGER_SAIDA');
+    expect(saida?.applied).toBe(true);
+    expect(h.stockRepository.lockItem).toHaveBeenCalledWith(TENANT, ITEM_ID, expect.anything());
+    expect(h.stockRepository.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SAIDA', quantity: '1', itemId: ITEM_ID, location: SYNC_STOCK_LOCATION }),
+      expect.anything(),
+    );
+    expect(h.stockRepository.insertMovementQrs).toHaveBeenCalledWith(
+      TENANT,
+      expect.any(String),
+      [expect.objectContaining({ qrValue: CODE })],
+      expect.anything(),
+    );
+  });
+
+  it('LIVE: sets responsible = technician when the platform says tecnico (conserta responsible)', async () => {
+    withLiveEnv();
+    const h = fieldButInStock('tecnico');
+    await h.service.runPull(TENANT);
+
+    expect(h.stockRepository.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SAIDA', responsible: 'Zé' }),
+      expect.anything(),
+    );
+  });
+
+  it('LIVE: negative guard — balance < 1 skips the write and records a problem', async () => {
+    withLiveEnv();
+    const h = fieldButInStock();
+    h.stockRepository.getBalance.mockResolvedValue({ balance: '0', totalIn: '1', totalOut: '1', lastMovementAt: null });
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(h.stockRepository.insertMovement).not.toHaveBeenCalled();
+    expect(report.problems.some((p) => p.includes('saldo insuficiente'))).toBe(true);
+    const saida = report.corrections.find((c) => c.kind === 'LEDGER_SAIDA');
+    expect(saida?.applied).toBe(false);
+  });
+
+  it('no correction when the ledger already agrees (QR exited)', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'cliente' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'LEDGER_SAIDA')).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Rule 2 — back to estoque per the platform, exited per the ledger ⇒ ENTRADA
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — estoque vs exited ⇒ ENTRADA estorno', () => {
+  function backInStock() {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'estoque' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    return h;
+  }
+
+  it('SHADOW: logs the ENTRADA without writing', async () => {
+    const h = backInStock();
+    const report = await h.service.runPull(TENANT);
+
+    const entrada = report.corrections.find((c) => c.kind === 'LEDGER_ENTRADA');
+    expect(entrada).toBeDefined();
+    expect(entrada?.applied).toBe(false);
+    expect(h.stockRepository.insertMovement).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: writes the compensating ENTRADA and RE-LINKS the QR (anti-loop)', async () => {
+    withLiveEnv();
+    const h = backInStock();
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'LEDGER_ENTRADA')?.applied).toBe(true);
+    expect(h.stockRepository.insertMovement).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'ENTRADA', quantity: '1', location: SYNC_STOCK_LOCATION }),
+      expect.anything(),
+    );
+    // Without this re-link the next run would see the old SAIDA and undo it.
+    expect(h.stockRepository.insertMovementQrs).toHaveBeenCalledWith(
+      TENANT,
+      expect.any(String),
+      [expect.objectContaining({ qrValue: CODE })],
+      expect.anything(),
+    );
+  });
+
+  it('no correction when the QR never touched the ledger', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'estoque' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map());
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections).toHaveLength(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Rule 3 — QR left the technician ⇒ consume the dispatch (zera a lista)
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — technician custody zeroing', () => {
+  function leftTechnician(location = 'cliente') {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location, clientName: 'Moxuara' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    h.repository.dispatchesByQrValues.mockResolvedValue([
+      makeDispatchByQr({ movementId: 'dddddddd-0000-4000-8000-000000000001', quantity: '1', movedQuantity: 0 }),
+    ]);
+    return h;
+  }
+
+  it('SHADOW: logs the technician move without writing', async () => {
+    const h = leftTechnician();
+    const report = await h.service.runPull(TENANT);
+
+    const move = report.corrections.find((c) => c.kind === 'TECHNICIAN_MOVE');
+    expect(move).toBeDefined();
+    expect(move?.applied).toBe(false);
+    expect(h.fieldRepository.insertTechnicianMove).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: consumes the open dispatch with the mapped destination (cliente → UNIDADE)', async () => {
+    withLiveEnv();
+    const h = leftTechnician('cliente');
+    await h.service.runPull(TENANT);
+
+    expect(h.fieldRepository.insertTechnicianMove).toHaveBeenCalledWith(
+      expect.objectContaining({
+        movementId: 'dddddddd-0000-4000-8000-000000000001',
+        destination: 'UNIDADE',
+        quantity: 1,
+        technician: 'João da Silva',
+      }),
+    );
+  });
+
+  it('LIVE: estoque maps to ALMOXARIFADO', async () => {
+    withLiveEnv();
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'estoque' })]);
+    eligible(h);
+    // Ledger already back in stock (no ENTRADA correction) — dispatch open.
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'ENTRADA']]));
+    h.repository.dispatchesByQrValues.mockResolvedValue([makeDispatchByQr()]);
+
+    await h.service.runPull(TENANT);
+
+    expect(h.fieldRepository.insertTechnicianMove).toHaveBeenCalledWith(
+      expect.objectContaining({ destination: 'ALMOXARIFADO' }),
+    );
+  });
+
+  it('does nothing while the platform still says tecnico', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'tecnico', technician: 'Zé' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    h.repository.dispatchesByQrValues.mockResolvedValue([makeDispatchByQr()]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'TECHNICIAN_MOVE')).toBeUndefined();
+  });
+
+  it('does nothing when the dispatch has no remaining quantity', async () => {
+    const h = leftTechnician();
+    h.repository.dispatchesByQrValues.mockResolvedValue([makeDispatchByQr({ quantity: '1', movedQuantity: 1 })]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'TECHNICIAN_MOVE')).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Rule 4 — cliente ⇒ unit products (upsert, status, moved-out) + projeto match
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — client unit products', () => {
+  function atClient(status = 'instalado') {
+    const h = makeSyncHarness([
+      makeProduct({ code: CODE, location: 'cliente', status, clientName: 'MOXUARA' }),
+    ]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    return h;
+  }
+
+  it('SHADOW: logs the unit creation without writing', async () => {
+    const h = atClient();
+    const report = await h.service.runPull(TENANT);
+
+    const created = report.corrections.find((c) => c.kind === 'UNIT_CREATED');
+    expect(created).toBeDefined();
+    expect(created?.applied).toBe(false);
+    expect(h.fieldRepository.insertUnitProducts).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: creates the unit product matching projeto→cliente case-insensitively', async () => {
+    withLiveEnv();
+    const h = atClient('instalado');
+    h.repository.projectsByNamesInsensitive.mockResolvedValue([
+      {
+        id: PROJECT_ID,
+        tenantId: TENANT,
+        name: 'Moxuara', // platform said "MOXUARA" — matched case-insensitively
+        customerId: CUSTOMER_ID,
+      } as never,
+    ]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(h.repository.projectsByNamesInsensitive).toHaveBeenCalledWith(TENANT, ['moxuara']);
+    expect(h.fieldRepository.insertUnitProducts).toHaveBeenCalledWith([
+      expect.objectContaining({
+        label: CODE,
+        status: 'INSTALADO',
+        projectId: PROJECT_ID,
+        customerId: CUSTOMER_ID,
+        clientNameSnapshot: 'MOXUARA',
+      }),
+    ]);
+    expect(report.problems).toHaveLength(0);
+  });
+
+  it('LIVE: unmatched client name still creates the unit and records a problem', async () => {
+    withLiveEnv();
+    const h = atClient();
+    h.repository.projectsByNamesInsensitive.mockResolvedValue([]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(h.fieldRepository.insertUnitProducts).toHaveBeenCalledWith([
+      expect.objectContaining({ projectId: null, customerId: null, clientNameSnapshot: 'MOXUARA' }),
+    ]);
+    expect(report.problems.some((p) => p.includes('Projeto não encontrado'))).toBe(true);
+  });
+
+  it('LIVE: fixes the install status of an existing active unit', async () => {
+    withLiveEnv();
+    const h = atClient('instalado');
+    h.repository.unitProductsByLabels.mockResolvedValue([
+      { id: 'ab000000-0000-4000-8000-000000000001', label: CODE, status: 'PARADO', movedTo: null } as never,
+    ]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'UNIT_STATUS')?.applied).toBe(true);
+    expect(h.fieldRepository.updateUnitStatus).toHaveBeenCalledWith(
+      TENANT,
+      'ab000000-0000-4000-8000-000000000001',
+      'INSTALADO',
+      expect.any(Date),
+    );
+    expect(h.fieldRepository.insertUnitProducts).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: a unit that left the client is marked moved_to (tecnico → TECNICO)', async () => {
+    withLiveEnv();
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'tecnico', technician: 'Zé' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    h.repository.unitProductsByLabels.mockResolvedValue([
+      { id: 'ab000000-0000-4000-8000-000000000002', label: CODE, status: 'INSTALADO', movedTo: null } as never,
+    ]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'UNIT_MOVED_OUT')?.applied).toBe(true);
+    expect(h.fieldRepository.markUnitMoved).toHaveBeenCalledWith(
+      TENANT,
+      'ab000000-0000-4000-8000-000000000002',
+      expect.objectContaining({ movedTo: 'TECNICO', movedTechnician: 'Zé' }),
+    );
+  });
+
+  it('transporte does NOT move a unit out (in-flight logistics)', async () => {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'transporte' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    h.repository.unitProductsByLabels.mockResolvedValue([
+      { id: 'ab000000-0000-4000-8000-000000000003', label: CODE, status: 'PARADO', movedTo: null } as never,
+    ]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'UNIT_MOVED_OUT')).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Rule 5 — avariado ⇒ inv_damaged_items (one open report per code)
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — damaged auto-report', () => {
+  function damaged() {
+    const h = makeSyncHarness([makeProduct({ code: CODE, location: 'avariado', productType: 'SmartLight v3' })]);
+    eligible(h);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(new Map([[CODE, 'SAIDA']]));
+    return h;
+  }
+
+  it('SHADOW: logs the damage report without writing', async () => {
+    const h = damaged();
+    const report = await h.service.runPull(TENANT);
+
+    const dmg = report.corrections.find((c) => c.kind === 'DAMAGED_REPORT');
+    expect(dmg).toBeDefined();
+    expect(dmg?.applied).toBe(false);
+    expect(h.fieldRepository.insertDamagedItem).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: opens the damage report with the code in source_detail', async () => {
+    withLiveEnv();
+    const h = damaged();
+    await h.service.runPull(TENANT);
+
+    expect(h.fieldRepository.insertDamagedItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: ITEM_ID,
+        quantity: 1,
+        source: 'SYNC_EXTERNO',
+        sourceDetail: `QR ${CODE}`,
+        productNameSnapshot: 'SmartLight v3',
+      }),
+    );
+  });
+
+  it('LIVE: never opens a second report while one is still AVARIADO for the code', async () => {
+    withLiveEnv();
+    const h = damaged();
+    h.repository.listOpenDamaged.mockResolvedValue([
+      { id: 'dc000000-0000-4000-8000-000000000001', sourceDetail: `Projeto X / ${CODE}`, status: 'AVARIADO' } as never,
+    ]);
+
+    const report = await h.service.runPull(TENANT);
+
+    expect(h.fieldRepository.insertDamagedItem).not.toHaveBeenCalled();
+    expect(report.corrections.find((c) => c.kind === 'DAMAGED_REPORT')).toBeUndefined();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Rule 6 — EM_TRANSITO order fully at the client ⇒ ENTREGUE_CLIENTE + vínculo
+// -----------------------------------------------------------------------------
+
+describe('M8 reconciliation — order auto-transition', () => {
+  function orderInTransit(locations: Record<string, string>) {
+    const products = Object.entries(locations).map(([code, location]) => makeProduct({ code, location }));
+    const h = makeSyncHarness(products);
+    h.homologRepository.findRegistryByValues.mockResolvedValue([
+      makeRegistryRow({ qrValue: CODE }),
+      makeRegistryRow({ qrValue: CODE_2 }),
+    ]);
+    h.stockRepository.latestQrEventTypes.mockResolvedValue(
+      new Map([
+        [CODE, 'SAIDA'],
+        [CODE_2, 'SAIDA'],
+      ]),
+    );
+    h.repository.ordersInTransit.mockResolvedValue([
+      { id: ORDER_ID, title: 'Pedido Moxuara', status: 'EM_TRANSITO', projectId: PROJECT_ID, customerId: null } as never,
+    ]);
+    h.expeditionRepository.deliveredQrsByOrder.mockResolvedValue([
+      { orderItemId: 'x', itemId: ITEM_ID, qrValue: CODE, boxQr: null, homologationUnitId: null },
+      { orderItemId: 'x', itemId: ITEM_ID, qrValue: CODE_2, boxQr: null, homologationUnitId: null },
+    ] as never);
+    return h;
+  }
+
+  it('SHADOW: logs ORDER_DELIVERED without touching the order', async () => {
+    const h = orderInTransit({ [CODE]: 'cliente', [CODE_2]: 'cliente' });
+    const report = await h.service.runPull(TENANT);
+
+    const delivered = report.corrections.find((c) => c.kind === 'ORDER_DELIVERED');
+    expect(delivered).toBeDefined();
+    expect(delivered?.applied).toBe(false);
+    expect(h.expeditionRepository.updateOrder).not.toHaveBeenCalled();
+  });
+
+  it('LIVE: transitions to ENTREGUE_CLIENTE and creates the unit-product vínculo', async () => {
+    withLiveEnv();
+    const h = orderInTransit({ [CODE]: 'cliente', [CODE_2]: 'cliente' });
+    h.expeditionRepository.getProject.mockResolvedValue(
+      { id: PROJECT_ID, name: 'Moxuara', customerId: CUSTOMER_ID } as never,
+    );
+    h.expeditionRepository.existingUnitProductLabels.mockResolvedValue(new Set([CODE])); // idempotent
+
+    await h.service.runPull(TENANT);
+
+    expect(h.expeditionRepository.updateOrder).toHaveBeenCalledWith(
+      TENANT,
+      ORDER_ID,
+      { status: 'ENTREGUE_CLIENTE' },
+      expect.anything(),
+    );
+    // Only the missing label is created, with the expedition vínculo.
+    expect(h.expeditionRepository.insertUnitProducts).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          label: CODE_2,
+          expeditionOrderId: ORDER_ID,
+          projectId: PROJECT_ID,
+          customerId: CUSTOMER_ID,
+          clientNameSnapshot: 'Moxuara',
+        }),
+      ],
+      expect.anything(),
+    );
+  });
+
+  it('does nothing while ANY delivered QR is not yet at the client', async () => {
+    const h = orderInTransit({ [CODE]: 'cliente', [CODE_2]: 'transporte' });
+    const report = await h.service.runPull(TENANT);
+
+    expect(report.corrections.find((c) => c.kind === 'ORDER_DELIVERED')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## RFC-0061 §M8 — Sync externo (P2 shadow / P4 live)

Last functional module of the inventory backend. Implements the pull worker (shadow mode by default — J4), the push-outbox drain (DEC-6/W3), the 3 `/external/*` routes and the now-real `POST /qr/generate`.

### New files
| File | What |
|---|---|
| `src/services/inventory/ExternalPlatformClient.ts` | HTTP client for the platform's 3 endpoints (`GET/POST /api/public/products`, `PATCH /api/public/products/:code`, `x-api-key`). Env config `MYIO_PRODUCTS_API_BASE` (defaults to the Lovable URL) / `MYIO_PRODUCTS_API_KEY` / `MYIO_PRODUCTS_API_TIMEOUT_MS`; AbortController timeout; errors mapped to `INV_EXTERNAL_PLATFORM_ERROR` (502) / `INV_EXTERNAL_NOT_CONFIGURED` (503). DEC-7 per-tenant `secretEnvelope` config annotated as follow-up. |
| `src/repositories/inventory/InventoryExternalRepository.ts` | Mirror upsert (`onConflict (tenant_id, code)`, `last_change_at` only bumped on observable change, raw payload kept); atomic lease claim (upsert with `setWhere lease_until IS NULL OR < now()` returning the row) + release-with-report; outbox claim `SELECT … FOR UPDATE SKIP LOCKED` with **per-QR FIFO** (`NOT EXISTS` older live row with `qr_codes && qr_codes`); dispatched/failed/dead-letter marks; M8 batch reads (unit products by label, projects by lower(name), dispatches by QR, open damaged, EM_TRANSITO orders). |
| `src/services/inventory/InventoryExternalSyncService.ts` | The pull run, exactly §M8: 3-min persisted single-flight lease (held → 409), 1000-item cap, **golden rule** (registry/homologation_units only; orphan mirror rows deleted), **box-is-master** 2 passes (box state propagates to units; unit at cliente/instalado leaves the box via M5 repos — solo box_size=1, emptied box deleted + box-QR identity released), mirror upsert, **ledger reconciliation** (field-but-in-stock ⇒ SAIDA 1un with app-level negative guard and `responsible` fix; back-to-estoque ⇒ ENTRADA estorno **with QR re-link** (anti-loop); technician custody zeroing via `inv_technician_moves` with destination map), order auto-transition EM_TRANSITO → ENTREGUE_CLIENTE + unit-product vínculo (runs **before** the generic client upsert so the vínculo wins), client unit upsert (projeto→cliente **case-insensitive**), damaged auto-report (one open row per code, code embedded in `source_detail`), report `{ok,total,ignored,changed,corrections,problems}`. |
| `src/services/inventory/InventoryOutboxWorker.ts` | Drain: claim batch inside one tx (SKIP LOCKED — rows stay locked during PATCH; concurrent drainers skip), PATCH per bare code (defensive box→units expansion; M6 already expands at enqueue), success → DONE + `dispatched_at`; failure → FAILED, attempts+1, backoff `30s·2^(n−1)` capped 15 min; **6 attempts → dead letter** (`next_attempt_at NULL`, keeps `last_error`, stops draining AND stops blocking its QRs — the pull reconciliation is the safety net, and a younger push carries newer state). |
| `src/services/inventory/InventoryExternalWorkers.ts` | `startInventoryExternalWorkers()` / `stopInventoryExternalWorkers()` — pull every 5 min (default tenant), drain every 30 s; `setInterval`+`unref` per the codebase pattern (`CentralRestoreSweep`) since **node-cron is not a dependency of this repo** (swap is a one-liner if the dep is approved). No-op without `MYIO_PRODUCTS_API_KEY`. **NOT wired** — see integration note below. |

### Edited (authorized boundary)
- `src/controllers/inventory/external.controller.ts` — the 3 real routes.
- `src/controllers/inventory/homologation.controller.ts` — **only** `POST /qr/generate`: POST `{product_type, location:'estoque', status:'parado'}` on the platform → `{code, qrUrl}` (201); 503 `INV_EXTERNAL_NOT_CONFIGURED` without the client env.
- `tests/unit/inventory/m5-contract.test.ts` — the single `/qr/generate stays deferred → 501` case updated to the now-real route (DTO gate → 400); full route coverage lives in `m8-contract`.

### Shadow mode (J4) — the simple choice, documented
Mirror writes + orphan cleanup + the run report always run for real. Steps 5–8 (ledger corrections, client units, damaged, order transitions) are **computed and logged only**: each would-be correction lands in the report persisted as JSON in `inv_external_sync_state.last_message` (capped at 200 verbatim entries + `correctionsTotal`) and on stdout — no extra log table. Real writes require env `INV_SYNC_LIVE=true`; `POST /external/sync/run?live=true` is refused (400) without that env.

### Routes
- `GET /inventory/external/states` — paginated mirror; filters `location`, `status`, `q` (code substring).
- `GET /inventory/external/sync/status` — sync state (lease active?, last run/status/report) + outbox counters `{pending, retryable, dead, done}` + `{live, shadow}` mode.
- `POST /inventory/external/sync/run` — one pull respecting the lease (**409** when held); `?live=true` gated on `INV_SYNC_LIVE`.
- Auth: the standing `inventory:read`/`inventory:write` hybrid gate (DEC-7 — no anon endpoint); finer admin/M2M role gating arrives with M10 like the sibling modules.

### Tests — status REAL
- `tsc --noEmit` clean; `eslint --max-warnings 0` clean on every touched file.
- `jest tests/unit/inventory`: **40 suites / 577 tests, all green** (82 new M8 cases: golden rule, box-master 2 passes + box exit, every reconciliation rule in shadow AND live, lease claim/expiry/409, outbox SQL shape (SKIP LOCKED, FIFO `&&` predicate, tiebreak), backoff/dead-letter/partial-batch behavior, projeto→cliente matching, report persistence incl. the `err.cause` Drizzle unwrap).
- Full `jest tests/unit`: 1270/1271 — the only failure is the **frozen** case below.
- The platform client is mocked in every test — zero network.

### Superseded — remove at wave-3 integration
- `tests/unit/controllers/inventory.contract.test.ts` → case `POST /external/sync/run → 501 INV_NOT_IMPLEMENTED` (file is frozen for module PRs; the behavior is now covered by `m8-contract.test.ts`).

### Integration wiring (app.ts — one line, wave-3)
Next to the other subsystem starts (`startRestoreSweep()`):
```ts
import { startInventoryExternalWorkers } from './services/inventory/InventoryExternalWorkers';
// inside the startup block:
try {
  startInventoryExternalWorkers();
} catch (error) {
  console.error('Failed to start the inventory external-sync workers:', error);
}
```

### To go LIVE (P4 checklist)
1. Set `MYIO_PRODUCTS_API_KEY` (+ optionally `MYIO_PRODUCTS_API_BASE`) — enables the workers, `POST /qr/generate` and the outbox drain (drain PATCHes are real once the key exists; the shadow gate covers only the pull's ledger writes).
2. Weeks of shadow-diff sign-off reading `GET /external/sync/status` reports (J4).
3. Set `INV_SYNC_LIVE=true` → pull corrections start applying; `?live=true` accepted.
4. Follow-ups: per-tenant client config via `secretEnvelope` (DEC-7); M7 install-toggle outbox enqueue points (M7 landed without them — noted in the worker header); optional node-cron swap; M10 admin-role gating for `sync/run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvWKPT4KpwdZYVNVAis2qK
